### PR TITLE
Fix CI fixture coverage checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 coverage/
+!tests/fixtures/**/coverage/
+!tests/fixtures/**/coverage/lcov.info
 *.tsbuildinfo
 *.tgz
 .temp/

--- a/tests/fixtures/workspace-project/packages/package-a/coverage/lcov.info
+++ b/tests/fixtures/workspace-project/packages/package-a/coverage/lcov.info
@@ -1,0 +1,10 @@
+TN:
+SF:src/math.ts
+DA:1,1
+DA:2,1
+DA:5,0
+DA:6,0
+DA:7,0
+DA:9,0
+end_of_record
+

--- a/tests/fixtures/workspace-project/packages/package-b/coverage/lcov.info
+++ b/tests/fixtures/workspace-project/packages/package-b/coverage/lcov.info
@@ -1,0 +1,5 @@
+TN:
+SF:src/text.ts
+DA:1,1
+DA:2,1
+end_of_record


### PR DESCRIPTION
## Summary
- unignore fixture LCOV reports under 	ests/fixtures/**/coverage/
- commit the workspace fixture coverage files used by nalysis.test.ts
- restore the Build workflow from a clean checkout

Closes #1