### PR TITLE
#21 add compatibility matrix fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ For each resolved module today:
 5. Read `coverage/coverage-final.json` from the module root, falling back to the project root for workspace coverage.
 6. Derive function statement and branch coverage from the Istanbul coverage counters and use their minimum as CRAP coverage.
 
+## Compatibility Matrix
+
+Verified and unverified coverage-attribution shapes are tracked in [docs/compatibility-matrix.md](docs/compatibility-matrix.md). The matrix is backed by golden fixtures under `tests/fixtures/compatibility-matrix/`.
+
 ## Build and Test
 
 ```bash

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,0 +1,34 @@
+# Compatibility Matrix
+
+This matrix records which coverage-attribution shapes are verified by golden fixtures today, which shapes are explicitly unsupported, and which shapes remain unverified.
+
+## Verified
+
+| Shape | Fixture | Notes |
+| --- | --- | --- |
+| Vitest-style Istanbul JSON with relative source paths | `tests/fixtures/compatibility-matrix/vitest-style-report` | Verifies normalized Istanbul JSON coverage with relative `path` values. |
+| Jest-style Istanbul JSON with absolute source paths | `tests/fixtures/compatibility-matrix/jest-style-report` | Verifies normalized Istanbul JSON coverage when the report record resolves to an absolute source path. |
+| Workspace coverage lookup across multiple packages | `tests/fixtures/workspace-project` | Verifies per-package coverage lookup and analysis across a workspace layout. |
+| TSX parsing and attribution | `tests/fixtures/compatibility-matrix/tsx-component` | Verifies `.tsx` parsing and attribution to an expression-bodied component function. |
+| Nested functions | `tests/fixtures/compatibility-matrix/nested-functions` | Verifies that inner coverage is not attributed to the enclosing function. |
+| Anonymous default-exported function declarations | `tests/fixtures/compatibility-matrix/default-export` | Verifies `default` naming and attribution for anonymous default exports. |
+| Class methods and object literal methods | `tests/fixtures/compatibility-matrix/object-and-class-methods` | Verifies both class and object-container naming and attribution. |
+| Expression-bodied arrows and declaration-only bodies | `tests/fixtures/compatibility-matrix/expression-and-declarations` | Verifies executable expression bodies and structural `N/A` for declaration-only bodies. |
+| Source-location drift within function bounds | `tests/fixtures/compatibility-matrix/source-location-drift` | Verifies attribution when line/column data is imprecise but still unambiguously inside the function body. |
+
+## Unsupported
+
+| Shape | Notes |
+| --- | --- |
+| Coverage inputs outside Istanbul JSON | The canonical input is `coverage/coverage-final.json`; non-Istanbul ecosystems are out of scope. |
+| Coverage data that cannot be mapped to any analyzed file or function | The analyzer reports `N/A` instead of inventing attribution. |
+
+## Unverified
+
+| Shape | Notes |
+| --- | --- |
+| Accessors | Planned follow-up work in `[P6]`. |
+| Computed property names | Planned follow-up work in `[P6]`. |
+| Decorated methods | Planned follow-up work in `[P6]`. |
+| Additional property-assigned function forms | Planned follow-up work in `[P6]`. |
+| Ambient and namespace-only constructs beyond the current declaration-only tests | Planned follow-up work in `[P6]`. |

--- a/packages/core/test/compatibilityMatrix.test.ts
+++ b/packages/core/test/compatibilityMatrix.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { analyzeProject } from "../src/analyzeProject";
+import { copyFixture, disposeTempDir, repoPath } from "./testUtils";
+
+interface ExpectedMetric {
+  name: string;
+  coverage: number | null;
+}
+
+interface CompatibilityCase {
+  name: string;
+  fixture: string;
+  pathMode?: "relative" | "absolute";
+  expectedSelectedFiles?: string[];
+  expectedMetrics: ExpectedMetric[];
+}
+
+interface CompatibilityMatrix {
+  cases: CompatibilityCase[];
+}
+
+const tempDirs: string[] = [];
+const matrix = JSON.parse(
+  readFileSync(repoPath("tests", "fixtures", "compatibility-matrix", "matrix.json"), "utf8")
+) as CompatibilityMatrix;
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(disposeTempDir));
+});
+
+describe("compatibility matrix", () => {
+  for (const testCase of matrix.cases) {
+    it(`verifies ${testCase.name}`, async () => {
+      const projectRoot = await copyFixture(testCase.fixture);
+      tempDirs.push(projectRoot);
+      await applyCoveragePathMode(projectRoot, testCase);
+
+      const result = await analyzeProject({
+        projectRoot,
+        coverageMode: "existing-only"
+      });
+
+      expect(result.warnings).toEqual([]);
+
+      if (testCase.expectedSelectedFiles) {
+        expect(result.selectedFiles.map((file) => path.relative(projectRoot, file).replace(/\\/g, "/"))).toEqual(
+          testCase.expectedSelectedFiles
+        );
+      }
+
+      expect(result.metrics.map((metric) => ({
+        name: metric.displayName,
+        coverage: metric.coveragePercent === null ? null : Number(metric.coveragePercent.toFixed(1))
+      }))).toEqual(testCase.expectedMetrics);
+    });
+  }
+});
+
+async function applyCoveragePathMode(projectRoot: string, testCase: CompatibilityCase): Promise<void> {
+  if (testCase.pathMode !== "absolute") {
+    return;
+  }
+
+  const reportPath = path.join(projectRoot, "coverage", "coverage-final.json");
+  const raw = JSON.parse(await readFile(reportPath, "utf8")) as Record<string, Record<string, unknown>>;
+  const rewritten = Object.fromEntries(
+    Object.entries(raw).map(([entryKey, entryValue]) => {
+      const sourcePath = typeof entryValue.path === "string" ? entryValue.path : entryKey;
+      return [
+        entryKey,
+        {
+          ...entryValue,
+          path: path.join(projectRoot, sourcePath)
+        }
+      ];
+    })
+  );
+
+  await writeFile(reportPath, JSON.stringify(rewritten, null, 2));
+}

--- a/packages/core/test/testUtils.ts
+++ b/packages/core/test/testUtils.ts
@@ -24,7 +24,8 @@ export async function disposeTempDir(tempDir: string): Promise<void> {
 }
 
 export async function copyFixture(name: string): Promise<string> {
-  const tempDir = await createTempDir(`crap-typescript-${name}-`);
+  const safeName = name.replace(/[\\/]/g, "-");
+  const tempDir = await createTempDir(`crap-typescript-${safeName}-`);
   const sourceDir = path.join(process.cwd(), "tests", "fixtures", name);
   await cp(sourceDir, tempDir, { recursive: true });
   return tempDir;
@@ -84,4 +85,3 @@ export function repoPath(...parts: string[]): string {
 export async function readText(filePath: string): Promise<string> {
   return readFile(filePath, "utf8");
 }
-

--- a/tests/fixtures/compatibility-matrix/default-export/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/default-export/coverage/coverage-final.json
@@ -1,0 +1,18 @@
+{
+  "src/defaultExport.ts": {
+    "path": "src/defaultExport.ts",
+    "statementMap": {
+      "0": {
+        "start": { "line": 2, "column": 2 },
+        "end": { "line": 2, "column": 11 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {},
+    "s": {
+      "0": 1
+    },
+    "f": {},
+    "b": {}
+  }
+}

--- a/tests/fixtures/compatibility-matrix/default-export/src/defaultExport.ts
+++ b/tests/fixtures/compatibility-matrix/default-export/src/defaultExport.ts
@@ -1,0 +1,3 @@
+export default function () {
+  return 1;
+}

--- a/tests/fixtures/compatibility-matrix/expression-and-declarations/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/expression-and-declarations/coverage/coverage-final.json
@@ -1,0 +1,18 @@
+{
+  "src/sample.ts": {
+    "path": "src/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": { "line": 1, "column": 39 },
+        "end": { "line": 1, "column": 51 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {},
+    "s": {
+      "0": 1
+    },
+    "f": {},
+    "b": {}
+  }
+}

--- a/tests/fixtures/compatibility-matrix/expression-and-declarations/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/expression-and-declarations/src/sample.ts
@@ -1,0 +1,6 @@
+export const trim = (value: string) => value.trim();
+
+export function declarationsOnly(): void {
+  type Local = { value: string };
+  interface Shape { value: string }
+}

--- a/tests/fixtures/compatibility-matrix/jest-style-report/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/jest-style-report/coverage/coverage-final.json
@@ -1,0 +1,18 @@
+{
+  "src/sample.ts": {
+    "path": "src/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": { "line": 2, "column": 2 },
+        "end": { "line": 2, "column": 22 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {},
+    "s": {
+      "0": 1
+    },
+    "f": {},
+    "b": {}
+  }
+}

--- a/tests/fixtures/compatibility-matrix/jest-style-report/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/jest-style-report/src/sample.ts
@@ -1,0 +1,3 @@
+export function jestStyle(value: string): string {
+  return value.trim();
+}

--- a/tests/fixtures/compatibility-matrix/matrix.json
+++ b/tests/fixtures/compatibility-matrix/matrix.json
@@ -1,0 +1,119 @@
+{
+  "cases": [
+    {
+      "name": "Vitest-style Istanbul JSON",
+      "fixture": "compatibility-matrix/vitest-style-report",
+      "expectedMetrics": [
+        {
+          "name": "vitestStyle",
+          "coverage": 50
+        }
+      ]
+    },
+    {
+      "name": "Jest-style Istanbul JSON",
+      "fixture": "compatibility-matrix/jest-style-report",
+      "pathMode": "absolute",
+      "expectedMetrics": [
+        {
+          "name": "jestStyle",
+          "coverage": 100
+        }
+      ]
+    },
+    {
+      "name": "workspace layout",
+      "fixture": "workspace-project",
+      "expectedSelectedFiles": [
+        "packages/package-a/src/math.ts",
+        "packages/package-b/src/text.ts"
+      ],
+      "expectedMetrics": [
+        {
+          "name": "add",
+          "coverage": 100
+        },
+        {
+          "name": "risky",
+          "coverage": 0
+        },
+        {
+          "name": "upper",
+          "coverage": 100
+        }
+      ]
+    },
+    {
+      "name": "TSX parsing",
+      "fixture": "compatibility-matrix/tsx-component",
+      "expectedMetrics": [
+        {
+          "name": "Widget",
+          "coverage": 100
+        }
+      ]
+    },
+    {
+      "name": "nested functions",
+      "fixture": "compatibility-matrix/nested-functions",
+      "expectedMetrics": [
+        {
+          "name": "outer",
+          "coverage": 100
+        },
+        {
+          "name": "inner",
+          "coverage": 50
+        }
+      ]
+    },
+    {
+      "name": "anonymous default exports",
+      "fixture": "compatibility-matrix/default-export",
+      "expectedMetrics": [
+        {
+          "name": "default",
+          "coverage": 100
+        }
+      ]
+    },
+    {
+      "name": "class and object methods",
+      "fixture": "compatibility-matrix/object-and-class-methods",
+      "expectedMetrics": [
+        {
+          "name": "Example.value",
+          "coverage": 50
+        },
+        {
+          "name": "helper.score",
+          "coverage": 100
+        }
+      ]
+    },
+    {
+      "name": "expression-bodied arrows and declaration-only bodies",
+      "fixture": "compatibility-matrix/expression-and-declarations",
+      "expectedMetrics": [
+        {
+          "name": "trim",
+          "coverage": 100
+        },
+        {
+          "name": "declarationsOnly",
+          "coverage": 100
+        }
+      ]
+    },
+    {
+      "name": "source-location drift",
+      "fixture": "compatibility-matrix/source-location-drift",
+      "expectedMetrics": [
+        {
+          "name": "drift",
+          "coverage": 100
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/compatibility-matrix/nested-functions/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/nested-functions/coverage/coverage-final.json
@@ -1,0 +1,46 @@
+{
+  "src/sample.ts": {
+    "path": "src/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": { "line": 4, "column": 6 },
+        "end": { "line": 4, "column": 15 }
+      },
+      "1": {
+        "start": { "line": 6, "column": 4 },
+        "end": { "line": 6, "column": 13 }
+      },
+      "2": {
+        "start": { "line": 9, "column": 2 },
+        "end": { "line": 9, "column": 17 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {
+      "0": {
+        "line": 3,
+        "type": "if",
+        "loc": {
+          "start": { "line": 3, "column": 4 },
+          "end": { "line": 5, "column": 5 }
+        },
+        "locations": [
+          {
+            "start": { "line": 3, "column": 4 },
+            "end": { "line": 5, "column": 5 }
+          },
+          {}
+        ]
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 0,
+      "2": 1
+    },
+    "f": {},
+    "b": {
+      "0": [1, 0]
+    }
+  }
+}

--- a/tests/fixtures/compatibility-matrix/nested-functions/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/nested-functions/src/sample.ts
@@ -1,0 +1,10 @@
+export function outer(value: number): number {
+  const inner = () => {
+    if (value > 0) {
+      return 1;
+    }
+    return 0;
+  };
+
+  return inner();
+}

--- a/tests/fixtures/compatibility-matrix/object-and-class-methods/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/object-and-class-methods/coverage/coverage-final.json
@@ -1,0 +1,70 @@
+{
+  "src/sample.ts": {
+    "path": "src/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": { "line": 4, "column": 6 },
+        "end": { "line": 4, "column": 15 }
+      },
+      "1": {
+        "start": { "line": 6, "column": 4 },
+        "end": { "line": 6, "column": 13 }
+      },
+      "2": {
+        "start": { "line": 13, "column": 8 },
+        "end": { "line": 13, "column": 17 }
+      },
+      "3": {
+        "start": { "line": 15, "column": 8 },
+        "end": { "line": 15, "column": 17 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {
+      "0": {
+        "line": 3,
+        "type": "if",
+        "loc": {
+          "start": { "line": 3, "column": 4 },
+          "end": { "line": 5, "column": 5 }
+        },
+        "locations": [
+          {
+            "start": { "line": 3, "column": 4 },
+            "end": { "line": 5, "column": 5 }
+          },
+          {}
+        ]
+      },
+      "1": {
+        "line": 12,
+        "type": "switch",
+        "loc": {
+          "start": { "line": 12, "column": 4 },
+          "end": { "line": 17, "column": 5 }
+        },
+        "locations": [
+          {
+            "start": { "line": 13, "column": 6 },
+            "end": { "line": 13, "column": 17 }
+          },
+          {
+            "start": { "line": 15, "column": 6 },
+            "end": { "line": 15, "column": 17 }
+          }
+        ]
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 0,
+      "2": 1,
+      "3": 1
+    },
+    "f": {},
+    "b": {
+      "0": [1, 0],
+      "1": [1, 1]
+    }
+  }
+}

--- a/tests/fixtures/compatibility-matrix/object-and-class-methods/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/object-and-class-methods/src/sample.ts
@@ -1,0 +1,19 @@
+export class Example {
+  value(flag: boolean): number {
+    if (flag) {
+      return 1;
+    }
+    return 0;
+  }
+}
+
+export const helper = {
+  score(value: number): number {
+    switch (value) {
+      case 1:
+        return 1;
+      default:
+        return 0;
+    }
+  }
+};

--- a/tests/fixtures/compatibility-matrix/source-location-drift/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/source-location-drift/coverage/coverage-final.json
@@ -1,0 +1,35 @@
+{
+  "src/sample.ts": {
+    "path": "src/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": { "line": 3, "column": 0 },
+        "end": { "line": 3, "column": 40 }
+      },
+      "1": {
+        "start": { "line": 5, "column": 0 },
+        "end": { "line": 5, "column": 40 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {
+      "0": {
+        "line": 2,
+        "type": "if",
+        "loc": {},
+        "locations": [
+          {},
+          {}
+        ]
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 1
+    },
+    "f": {},
+    "b": {
+      "0": [1, 1]
+    }
+  }
+}

--- a/tests/fixtures/compatibility-matrix/source-location-drift/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/source-location-drift/src/sample.ts
@@ -1,0 +1,6 @@
+export function drift(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/fixtures/compatibility-matrix/tsx-component/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/tsx-component/coverage/coverage-final.json
@@ -1,0 +1,18 @@
+{
+  "src/Widget.tsx": {
+    "path": "src/Widget.tsx",
+    "statementMap": {
+      "0": {
+        "start": { "line": 2, "column": 2 },
+        "end": { "line": 2, "column": 42 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {},
+    "s": {
+      "0": 1
+    },
+    "f": {},
+    "b": {}
+  }
+}

--- a/tests/fixtures/compatibility-matrix/tsx-component/src/Widget.tsx
+++ b/tests/fixtures/compatibility-matrix/tsx-component/src/Widget.tsx
@@ -1,0 +1,3 @@
+export const Widget = ({ label }: { label: string }) => {
+  return <section>{label.trim()}</section>;
+};

--- a/tests/fixtures/compatibility-matrix/vitest-style-report/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/vitest-style-report/coverage/coverage-final.json
@@ -1,0 +1,41 @@
+{
+  "src/sample.ts": {
+    "path": "src/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": { "line": 3, "column": 4 },
+        "end": { "line": 3, "column": 13 }
+      },
+      "1": {
+        "start": { "line": 5, "column": 2 },
+        "end": { "line": 5, "column": 11 }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {
+      "0": {
+        "line": 2,
+        "type": "if",
+        "loc": {
+          "start": { "line": 2, "column": 2 },
+          "end": { "line": 4, "column": 3 }
+        },
+        "locations": [
+          {
+            "start": { "line": 2, "column": 2 },
+            "end": { "line": 4, "column": 3 }
+          },
+          {}
+        ]
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 0
+    },
+    "f": {},
+    "b": {
+      "0": [1, 0]
+    }
+  }
+}

--- a/tests/fixtures/compatibility-matrix/vitest-style-report/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/vitest-style-report/src/sample.ts
@@ -1,0 +1,6 @@
+export function vitestStyle(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Closes #21

## Summary
- add a documented compatibility matrix for verified, unsupported, and unverified coverage-attribution shapes
- add manifest-driven golden fixtures covering runner styles, workspace layout, TSX, nested functions, default exports, object/class methods, declaration-only bodies, expression-bodied arrows, and source-location drift
- fix the shared fixture-copy helper so nested fixture paths work on Windows

## Verification
- `npm test`