### PR TITLE
#19 make structural N/A detection conservative

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It combines cyclomatic complexity with function-level coverage derived from Ista
 
 - `CC` is cyclomatic complexity.
 - `coverage` is defined separately as the minimum of the function's statement coverage and branch coverage.
-- Structural non-applicability is treated as `100%` for the affected component metric only.
+- Structural non-applicability is treated as `100%` for the affected component metric only when the analyzer can prove it.
 - Unknown coverage remains `N/A`, and CRAP remains `N/A` for that function.
 
 ## Coverage Pipeline

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -217,7 +217,7 @@ function toSourceSpan(node: ts.Node, sourceFile: ts.SourceFile): SourceSpan {
 
 function hasAttributableStatements(body: ts.ConciseBody): boolean {
   return ts.isBlock(body)
-    ? body.statements.some((statement) => !isNonExecutableDeclarationStatement(statement))
+    ? body.statements.some((statement) => !isProvablyNonExecutableDeclarationStatement(statement))
     : true;
 }
 
@@ -267,11 +267,7 @@ function isNestedBoundary(node: ts.Node): boolean {
     ts.isClassExpression(node);
 }
 
-function isNonExecutableDeclarationStatement(statement: ts.Statement): boolean {
-  return ts.isFunctionDeclaration(statement) ||
-    ts.isClassDeclaration(statement) ||
-    ts.isInterfaceDeclaration(statement) ||
-    ts.isTypeAliasDeclaration(statement) ||
-    ts.isEnumDeclaration(statement) ||
-    ts.isModuleDeclaration(statement);
+function isProvablyNonExecutableDeclarationStatement(statement: ts.Statement): boolean {
+  return ts.isInterfaceDeclaration(statement) ||
+    ts.isTypeAliasDeclaration(statement);
 }

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -182,4 +182,98 @@ export const trim = (value: string) => value.trim();
       null
     ]);
   });
+
+  it("keeps coverage unknown when a body is not provably structural N/A even if no statements were attributed", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function empty(): void {}
+
+export function typeOnly(): void {
+  type Local = { value: string };
+  interface Shape { value: string }
+}
+
+export function functionDeclOnly(): void {
+  function inner() {}
+}
+
+export function classDeclOnly(): void {
+  class Local {}
+}
+
+export function enumDeclOnly(): void {
+  enum LocalEnum { A }
+}
+`
+    });
+
+    const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
+    const methodCoverage = coverageForMethods(methods, {
+      statements: [],
+      branches: []
+    });
+    const byName = new Map(methods.map((method, index) => [method.displayName, methodCoverage[index]]));
+
+    expect(byName.get("empty")).toEqual({
+      coveragePercent: 100,
+      statementCoveragePercent: null,
+      branchCoveragePercent: null
+    });
+    expect(byName.get("typeOnly")).toEqual({
+      coveragePercent: 100,
+      statementCoveragePercent: null,
+      branchCoveragePercent: null
+    });
+    expect(byName.get("functionDeclOnly")).toBeNull();
+    expect(byName.get("classDeclOnly")).toBeNull();
+    expect(byName.get("enumDeclOnly")).toBeNull();
+  });
+
+  it("keeps coverage unknown when branch syntax exists but no branch counters can be attributed", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function branchy(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 3, column: 4 },
+              end: { line: 3, column: 13 }
+            },
+            "1": {
+              start: { line: 5, column: 2 },
+              end: { line: 5, column: 11 }
+            }
+          },
+          fnMap: {},
+          branchMap: {},
+          s: {
+            "0": 1,
+            "1": 1
+          },
+          f: {},
+          b: {}
+        }
+      })
+    });
+
+    const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
+    const coverageReport = await parseCoverageReport(
+      path.join(projectRoot, "coverage", "coverage-final.json"),
+      projectRoot
+    );
+
+    expect(coverageForMethods(methods, [...coverageReport.values()][0])).toEqual([null]);
+  });
 });

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -206,4 +206,42 @@ export function declarationsOnly(): void {
       }
     ]);
   });
+
+  it("keeps statement coverage expected for runtime declarations and only treats empty or type-only bodies as structural N/A", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "declarations.ts");
+    await writeFile(
+      filePath,
+      `export function empty(): void {}
+
+export function typeOnly(): void {
+  type Local = { value: string };
+  interface Shape { value: string }
+}
+
+export function functionDeclOnly(): void {
+  function inner() {}
+}
+
+export function classDeclOnly(): void {
+  class Local {}
+}
+
+export function enumDeclOnly(): void {
+  enum LocalEnum { A }
+}
+`,
+      "utf8"
+    );
+
+    const methods = await parseFileMethods(filePath);
+    const byName = new Map(methods.map((method) => [method.displayName, method]));
+
+    expect(byName.get("empty")?.expectsStatementCoverage).toBe(false);
+    expect(byName.get("typeOnly")?.expectsStatementCoverage).toBe(false);
+    expect(byName.get("functionDeclOnly")?.expectsStatementCoverage).toBe(true);
+    expect(byName.get("classDeclOnly")?.expectsStatementCoverage).toBe(true);
+    expect(byName.get("enumDeclOnly")?.expectsStatementCoverage).toBe(true);
+  });
 });

--- a/spec.md
+++ b/spec.md
@@ -168,8 +168,8 @@ Where:
 
 Structural non-applicability means the metric has no meaningful denominator for the function, for example:
 
-- no attributable statements inside the function for statement coverage
-- no measurable branches inside the function for branch coverage
+- statement coverage is structurally not applicable only for empty bodies or bodies proven to contain only non-executable type-only declarations local to that function
+- branch coverage is structurally not applicable only when no attributable branch syntax exists in the function's own body after excluding nested function and class bodies
 
 Unknown coverage is distinct from structural non-applicability.
 
@@ -178,6 +178,7 @@ Unknown coverage includes cases such as:
 - missing coverage report
 - analyzed file not present in the report
 - missing or unusable statement or branch attribution for a function that should have such coverage data
+- any zero-unit attribution where the analyzer cannot prove structural non-applicability
 
 If coverage is unknown for non-structural reasons:
 


### PR DESCRIPTION
Closes #19

## Summary
- tighten statement structural-N/A detection so only provably non-executable type-only bodies are neutralized
- keep ambiguous zero-unit statement and branch attribution as unknown coverage instead of treating it as structural N/A
- add parser and coverage regressions plus docs/spec updates for the conservative policy

## Verification
- `npm test`