### PR TITLE
#16 cross-check AST methods against fnMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ For each resolved module today:
 3. Otherwise auto-detect the package manager and test runner unless the CLI forces them.
 4. Run the module tests with JSON coverage enabled.
 5. Read `coverage/coverage-final.json` from the module root, falling back to the project root for workspace coverage.
-6. Derive function statement and branch coverage from the Istanbul coverage counters and use their minimum as CRAP coverage.
+6. Use Istanbul `fnMap` as a validation and secondary matching aid when it is present.
+7. Derive function statement and branch coverage from the Istanbul coverage counters and use their minimum as CRAP coverage.
 
 ## Compatibility Matrix
 

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -89,6 +89,11 @@ export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promi
       for (const [index, descriptor] of descriptors.entries()) {
         const coverage = methodCoverage[index];
         const coveragePercent = coverage.coverage.percent;
+        if (coverage.coverage.unknownReason === "fnmap_conflict") {
+          const warning = `Warning: Function coverage metadata in ${relativePath} could not be matched unambiguously for ${descriptor.displayName}. Coverage will be N/A.`;
+          warnings.push(warning);
+          writeLine(options.stderr, warning);
+        }
         metrics.push({
           ...descriptor,
           filePath,

--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -144,10 +144,11 @@ function matchFunctionCoverage(
   }
 
   const lineAlignedMatches = functions.filter((entry) => spansShareBoundaryLines(entry.span, methodSpan));
-  if (lineAlignedMatches.length === 1) {
-    return lineAlignedMatches[0];
+  const overlappingLineAlignedMatches = lineAlignedMatches.filter((entry) => spansOverlap(entry.span, methodSpan));
+  if (overlappingLineAlignedMatches.length === 1) {
+    return overlappingLineAlignedMatches[0];
   }
-  if (lineAlignedMatches.length > 1) {
+  if (overlappingLineAlignedMatches.length > 1) {
     return null;
   }
 
@@ -293,6 +294,9 @@ function findOwningMethodIndex(methods: AttributableMethod[], span: SourceSpan):
 
   for (let index = 0; index < methods.length; index += 1) {
     const method = methods[index];
+    if (method.fnMapConflict) {
+      continue;
+    }
     if (!spanContains(method.span, span) && !spanContainsPosition(method.span, span.startLine, span.startColumn)) {
       continue;
     }
@@ -340,6 +344,11 @@ function spansEqual(left: SourceSpan, right: SourceSpan): boolean {
 function spansShareBoundaryLines(left: SourceSpan, right: SourceSpan): boolean {
   return left.startLine === right.startLine &&
     left.endLine === right.endLine;
+}
+
+function spansOverlap(left: SourceSpan, right: SourceSpan): boolean {
+  return comparePosition(left.startLine, left.startColumn, right.endLine, right.endColumn) < 0 &&
+    comparePosition(right.startLine, right.startColumn, left.endLine, left.endColumn) < 0;
 }
 
 function parseStatements(statementMapValue: unknown, hitsValue: unknown): StatementCoverageUnit[] {

--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -16,9 +16,14 @@ interface BranchCoverageUnit {
   hits: number[];
 }
 
+interface FunctionCoverageUnit {
+  span: SourceSpan;
+}
+
 export interface FileCoverage {
   statements: StatementCoverageUnit[];
   branches: BranchCoverageUnit[];
+  functions: FunctionCoverageUnit[];
 }
 
 export interface MethodCoverage {
@@ -51,12 +56,14 @@ export async function parseCoverageReport(
       ? sourcePath
       : path.resolve(sourceRoot, sourcePath);
     const normalized = normalizePathForMatch(resolved);
-    const merged = records.get(normalized) ?? { statements: [], branches: [] };
+    const merged = records.get(normalized) ?? { statements: [], branches: [], functions: [] };
     merged.statements.push(...parseStatements(entryValue.statementMap, entryValue.s));
     merged.branches.push(...parseBranches(entryValue.branchMap, entryValue.b));
+    merged.functions.push(...parseFunctions(entryValue.fnMap));
     records.set(normalized, {
       statements: deduplicateStatements(merged.statements),
-      branches: deduplicateBranches(merged.branches)
+      branches: deduplicateBranches(merged.branches),
+      functions: deduplicateFunctions(merged.functions)
     });
   }
 
@@ -72,28 +79,86 @@ export function coverageForMethods(
     return methods.map((method) => unavailableMethodCoverage(method, fileUnknownReason));
   }
 
+  const attributableMethods = buildAttributableMethods(methods, fileCoverage.functions);
   const attributed = methods.map(() => ({
     statements: [] as StatementCoverageUnit[],
     branches: [] as BranchCoverageUnit[]
   }));
 
   for (const statement of fileCoverage.statements) {
-    const owner = findOwningMethodIndex(methods, statement.span);
+    const owner = findOwningMethodIndex(attributableMethods, statement.span);
     if (owner !== null) {
       attributed[owner].statements.push(statement);
     }
   }
 
   for (const branch of fileCoverage.branches) {
-    const owner = findOwningMethodIndex(methods, branch.span);
+    const owner = findOwningMethodIndex(attributableMethods, branch.span);
     if (owner !== null) {
       attributed[owner].branches.push(branch);
     }
   }
 
   return methods.map((method, index) =>
-    computeMethodCoverage(method, attributed[index].statements, attributed[index].branches)
+    attributableMethods[index].fnMapConflict
+      ? unavailableMethodCoverage(method, "fnmap_conflict")
+      : computeMethodCoverage(method, attributed[index].statements, attributed[index].branches)
   );
+}
+
+interface AttributableMethod {
+  span: SourceSpan;
+  fnMapConflict: boolean;
+}
+
+function buildAttributableMethods(
+  methods: MethodDescriptor[],
+  functions: FunctionCoverageUnit[]
+): AttributableMethod[] {
+  if (functions.length === 0) {
+    return methods.map((method) => ({
+      span: method.bodySpan,
+      fnMapConflict: false
+    }));
+  }
+
+  return methods.map((method) => {
+    const matchedFunction = matchFunctionCoverage(method.bodySpan, functions);
+    return {
+      span: matchedFunction?.span ?? method.bodySpan,
+      fnMapConflict: matchedFunction === null
+    };
+  });
+}
+
+function matchFunctionCoverage(
+  methodSpan: SourceSpan,
+  functions: FunctionCoverageUnit[]
+): FunctionCoverageUnit | null {
+  const exactMatches = functions.filter((entry) => spansEqual(entry.span, methodSpan));
+  if (exactMatches.length === 1) {
+    return exactMatches[0];
+  }
+  if (exactMatches.length > 1) {
+    return null;
+  }
+
+  const lineAlignedMatches = functions.filter((entry) => spansShareBoundaryLines(entry.span, methodSpan));
+  if (lineAlignedMatches.length === 1) {
+    return lineAlignedMatches[0];
+  }
+  if (lineAlignedMatches.length > 1) {
+    return null;
+  }
+
+  const containingMatches = functions.filter((entry) =>
+    spanContains(entry.span, methodSpan) || spanContains(methodSpan, entry.span)
+  );
+  if (containingMatches.length === 1) {
+    return containingMatches[0];
+  }
+
+  return null;
 }
 
 function computeMethodCoverage(
@@ -223,15 +288,15 @@ function percentageOfCoveredBranches(branches: BranchCoverageUnit[]): number | n
   return (coveredBranches / totalBranches) * 100;
 }
 
-function findOwningMethodIndex(methods: MethodDescriptor[], span: SourceSpan): number | null {
+function findOwningMethodIndex(methods: AttributableMethod[], span: SourceSpan): number | null {
   let bestMatch: number | null = null;
 
   for (let index = 0; index < methods.length; index += 1) {
     const method = methods[index];
-    if (!spanContains(method.bodySpan, span) && !spanContainsPosition(method.bodySpan, span.startLine, span.startColumn)) {
+    if (!spanContains(method.span, span) && !spanContainsPosition(method.span, span.startLine, span.startColumn)) {
       continue;
     }
-    if (bestMatch === null || spanContains(methods[bestMatch].bodySpan, method.bodySpan)) {
+    if (bestMatch === null || spanContains(methods[bestMatch].span, method.span)) {
       bestMatch = index;
     }
   }
@@ -263,6 +328,18 @@ function comparePosition(
     return leftLine - rightLine;
   }
   return leftColumn - rightColumn;
+}
+
+function spansEqual(left: SourceSpan, right: SourceSpan): boolean {
+  return left.startLine === right.startLine &&
+    left.startColumn === right.startColumn &&
+    left.endLine === right.endLine &&
+    left.endColumn === right.endColumn;
+}
+
+function spansShareBoundaryLines(left: SourceSpan, right: SourceSpan): boolean {
+  return left.startLine === right.startLine &&
+    left.endLine === right.endLine;
 }
 
 function parseStatements(statementMapValue: unknown, hitsValue: unknown): StatementCoverageUnit[] {
@@ -306,6 +383,28 @@ function parseBranches(branchMapValue: unknown, hitsValue: unknown): BranchCover
   }
 
   return deduplicateBranches(branches);
+}
+
+function parseFunctions(fnMapValue: unknown): FunctionCoverageUnit[] {
+  if (!isRecord(fnMapValue)) {
+    return [];
+  }
+
+  const functions: FunctionCoverageUnit[] = [];
+  for (const entryValue of Object.values(fnMapValue)) {
+    if (!isRecord(entryValue)) {
+      continue;
+    }
+
+    const span = parseSpan(entryValue.loc) ??
+      parseSpan(entryValue.decl) ??
+      parseLineSpan(entryValue.line);
+    if (span) {
+      functions.push({ span });
+    }
+  }
+
+  return deduplicateFunctions(functions);
 }
 
 function parseFirstLocation(value: unknown): SourceSpan | null {
@@ -422,6 +521,15 @@ function deduplicateBranches(branches: BranchCoverageUnit[]): BranchCoverageUnit
       span: branch.span,
       hits: mergedHits
     });
+  }
+  return [...deduplicated.values()];
+}
+
+function deduplicateFunctions(functions: FunctionCoverageUnit[]): FunctionCoverageUnit[] {
+  const deduplicated = new Map<string, FunctionCoverageUnit>();
+  for (const entry of functions) {
+    const key = stringifySpan(entry.span);
+    deduplicated.set(key, entry);
   }
   return [...deduplicated.values()];
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,6 +9,7 @@ export type CoverageUnknownReason =
   | "missing_report"
   | "unparseable_report"
   | "file_unmatched"
+  | "fnmap_conflict"
   | "statement_unattributed"
   | "branch_unattributed";
 

--- a/packages/core/test/analysis.test.ts
+++ b/packages/core/test/analysis.test.ts
@@ -148,4 +148,94 @@ describe("analyzeProject", () => {
     expect(result.metrics[0]?.statementCoverage.unknownReason).toBe("file_unmatched");
     expect(result.metrics[0]?.branchCoverage.unknownReason).toBe("file_unmatched");
   });
+
+  it("warns and reports fnMap conflicts as unknown coverage", async () => {
+    const projectRoot = await createTempDir("crap-analysis-");
+    tempDirs.push(projectRoot);
+    const warnings: string[] = [];
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function risky(flagA: boolean, flagB: boolean): number {
+  if (flagA && flagB) {
+    return 1;
+  }
+  return 0;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 3, column: 4 },
+              end: { line: 3, column: 13 }
+            },
+            "1": {
+              start: { line: 5, column: 2 },
+              end: { line: 5, column: 11 }
+            }
+          },
+          fnMap: {
+            "0": {
+              name: "risky",
+              line: 1,
+              loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 6, column: 1 }
+              }
+            },
+            "1": {
+              name: "risky_alt",
+              line: 1,
+              loc: {
+                start: { line: 1, column: 1 },
+                end: { line: 6, column: 2 }
+              }
+            }
+          },
+          branchMap: {
+            "0": {
+              line: 2,
+              type: "if",
+              loc: {
+                start: { line: 2, column: 2 },
+                end: { line: 4, column: 3 }
+              },
+              locations: [
+                {
+                  start: { line: 2, column: 2 },
+                  end: { line: 4, column: 3 }
+                },
+                {}
+              ]
+            }
+          },
+          s: {
+            "0": 1,
+            "1": 1
+          },
+          f: {},
+          b: {
+            "0": [1, 1]
+          }
+        }
+      })
+    });
+
+    const result = await analyzeProject({
+      projectRoot,
+      coverageMode: "existing-only",
+      stderr: {
+        write(chunk: string) {
+          warnings.push(chunk);
+        }
+      }
+    });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(warnings.join("")).toContain("could not be matched unambiguously");
+    expect(result.metrics[0]?.coveragePercent).toBeNull();
+    expect(result.metrics[0]?.crapScore).toBeNull();
+    expect(result.metrics[0]?.coverage.unknownReason).toBe("fnmap_conflict");
+  });
 });

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -181,7 +181,8 @@ export const trim = (value: string) => value.trim();
     const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
     const methodCoverage = coverageForMethods(methods, {
       statements: [],
-      branches: []
+      branches: [],
+      functions: []
     });
 
     expect(methodCoverage.map(summarizeMethodCoverage)).toEqual([
@@ -273,7 +274,8 @@ export function enumDeclOnly(): void {
     const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
     const methodCoverage = coverageForMethods(methods, {
       statements: [],
-      branches: []
+      branches: [],
+      functions: []
     });
     const byName = new Map(methods.map((method, index) => [method.displayName, methodCoverage[index]]));
 
@@ -352,6 +354,87 @@ export function enumDeclOnly(): void {
         coverage: { percent: null, status: "unknown", reason: "branch_unattributed" },
         statement: { percent: 100.0, status: "measured", reason: null },
         branch: { percent: null, status: "unknown", reason: "branch_unattributed" }
+      }
+    ]);
+  });
+
+  it("accepts exact fnMap matches during attribution", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function exact(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}
+`
+    });
+
+    const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
+    const [method] = methods;
+    expect(
+      coverageForMethods(methods, {
+        statements: [
+          { span: { startLine: 3, startColumn: 4, endLine: 3, endColumn: 13 }, hits: 1 },
+          { span: { startLine: 5, startColumn: 2, endLine: 5, endColumn: 11 }, hits: 1 }
+        ],
+        branches: [
+          {
+            span: { startLine: 2, startColumn: 2, endLine: 4, endColumn: 3 },
+            hits: [1, 1]
+          }
+        ],
+        functions: [
+          { span: method.bodySpan }
+        ]
+      }).map(summarizeMethodCoverage)
+    ).toEqual([
+      {
+        coverage: { percent: 100.0, status: "measured", reason: null },
+        statement: { percent: 100.0, status: "measured", reason: null },
+        branch: { percent: 100.0, status: "measured", reason: null }
+      }
+    ]);
+  });
+
+  it("uses fnMap as a secondary matching aid when function columns drift", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function drift(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}
+`
+    });
+
+    const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
+    expect(
+      coverageForMethods(methods, {
+        statements: [
+          { span: { startLine: 3, startColumn: 4, endLine: 3, endColumn: 13 }, hits: 1 },
+          { span: { startLine: 5, startColumn: 2, endLine: 5, endColumn: 11 }, hits: 1 }
+        ],
+        branches: [
+          {
+            span: { startLine: 1, startColumn: 0, endLine: 4, endColumn: 3 },
+            hits: [1, 1]
+          }
+        ],
+        functions: [
+          { span: { startLine: 1, startColumn: 0, endLine: 6, endColumn: 1 } }
+        ]
+      }).map(summarizeMethodCoverage)
+    ).toEqual([
+      {
+        coverage: { percent: 100.0, status: "measured", reason: null },
+        statement: { percent: 100.0, status: "measured", reason: null },
+        branch: { percent: 100.0, status: "measured", reason: null }
       }
     ]);
   });

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -438,6 +438,35 @@ export function enumDeclOnly(): void {
       }
     ]);
   });
+
+  it("rejects line-aligned fnMap matches when the columns do not overlap", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export const trim = (value: string) => value.trim();
+`
+    });
+
+    const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
+    expect(
+      coverageForMethods(methods, {
+        statements: [
+          { span: { startLine: 1, startColumn: 39, endLine: 1, endColumn: 51 }, hits: 1 }
+        ],
+        branches: [],
+        functions: [
+          { span: { startLine: 1, startColumn: 0, endLine: 1, endColumn: 10 } }
+        ]
+      }).map(summarizeMethodCoverage)
+    ).toEqual([
+      {
+        coverage: { percent: null, status: "unknown", reason: "fnmap_conflict" },
+        statement: { percent: null, status: "unknown", reason: "fnmap_conflict" },
+        branch: { percent: null, status: "structural_na", reason: null }
+      }
+    ]);
+  });
 });
 
 function summarizeMethodCoverage(coverage: {

--- a/spec.md
+++ b/spec.md
@@ -147,6 +147,12 @@ Nested functions and class bodies shall not contribute to the enclosing function
 
 Coverage shall be attributed by matching the analyzed source file to an Istanbul coverage record and assigning statement and branch counters to function bodies.
 
+When Istanbul `fnMap` data is present for a file:
+
+- the analyzer shall first prefer exact body-span agreement between the TypeScript AST method body and the Istanbul function span
+- if exact agreement is absent, the analyzer shall accept a single unambiguous overlapping match when the spans share the same boundary lines but differ in columns, or when one span fully contains the other
+- if no unambiguous match exists, coverage for that function shall be reported as `N/A` and the analyzer shall emit a warning instead of forcing attribution
+
 Statement attribution:
 
 - a statement counter belongs to the innermost analyzed function body that contains the counter location


### PR DESCRIPTION
Closes #16

## Summary
- parse Istanbul `fnMap` data and use it to validate AST-discovered function spans before attributing statement and branch coverage
- accept exact matches first, then unambiguous overlap when columns drift, and mark ambiguous/conflicting matches as unknown with a warning
- add regression tests for exact matches, column drift recovery, and fnMap conflicts plus doc/spec updates

## Verification
- `npm test`