### PR TITLE
#33 add crap-typescript gate to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,26 @@ jobs:
 
       - name: Verify workspace packages
         run: npm pack --workspaces
+
+  crap-typescript-gate:
+    name: crap-typescript Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run crap-typescript gate
+        run: npm run crap-typescript-check

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ Verified and unverified coverage-attribution shapes are tracked in [docs/compati
 npm ci
 npm run build
 npm test
+npm run crap-typescript-check
 npm pack --workspaces
 ```
+
+`npm run crap-typescript-check` runs the repository through its own CRAP threshold gate for the published package sources under `packages/`.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "build": "tsc -b packages/core packages/cli packages/vitest packages/jest",
+    "crap-typescript-check": "npm run build && vitest run --config vitest.crap.config.ts",
     "test": "npm run build && vitest run",
     "pack": "npm pack --workspaces",
     "verify-release-version": "node ./scripts/verify-release-version.mjs"

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -15,103 +15,24 @@ import type {
   AnalyzeProjectOptions,
   CoverageCommand,
   CoverageUnknownReason,
+  MethodDescriptor,
   MethodMetrics
 } from "./types";
 
 export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promise<AnalysisResult> {
-  const projectRoot = path.resolve(options.projectRoot ?? process.cwd());
-  const coverageMode = options.coverageMode ?? "auto";
-  const packageManager = options.packageManager ?? "auto";
-  const testRunner = options.testRunner ?? "auto";
-  const coverageReportPath = options.coverageReportPath;
-  const executor = options.executor ?? new DefaultCommandExecutor();
-
-  const selectedFiles = await selectFiles(projectRoot, options.explicitPaths ?? [], options.changedOnly ?? false);
+  const context = createAnalyzeContext(options);
+  const selectedFiles = await selectFiles(context.projectRoot, options.explicitPaths ?? [], options.changedOnly ?? false);
   if (selectedFiles.length === 0) {
-    return {
-      metrics: [],
-      maxCrap: 0,
-      thresholdExceeded: false,
-      selectedFiles: [],
-      coverageCommands: [],
-      warnings: []
-    };
+    return emptyAnalysisResult();
   }
 
-  const groupedByModule = new Map<string, string[]>();
-  for (const filePath of selectedFiles) {
-    const moduleRoot = await resolveModuleRoot(projectRoot, filePath);
-    const files = groupedByModule.get(moduleRoot) ?? [];
-    files.push(filePath);
-    groupedByModule.set(moduleRoot, files);
-  }
-
-  const metrics: MethodMetrics[] = [];
-  const coverageCommands: CoverageCommand[] = [];
-  const warnings: string[] = [];
-
-  for (const [moduleRoot, moduleFiles] of groupedByModule.entries()) {
-    const coverageResult = await ensureCoverageReport(
-      projectRoot,
-      moduleRoot,
-      packageManager,
-      testRunner,
-      coverageMode,
-      coverageReportPath,
-      executor
-    );
-    if (coverageResult.command) {
-      coverageCommands.push(coverageResult.command);
-    }
-
-    let coverageByFile = new Map<string, FileCoverage>();
-    let coverageUnavailableReason: CoverageUnknownReason | null = null;
-    if (coverageResult.coverageSourcePath && coverageResult.coverageSourceRoot) {
-      try {
-        coverageByFile = await parseCoverageReport(coverageResult.coverageSourcePath, coverageResult.coverageSourceRoot);
-      } catch (error) {
-        coverageUnavailableReason = "unparseable_report";
-        const warning = `Warning: Coverage report at ${coverageResult.coverageSourcePath} could not be parsed: ${(error as Error).message}. Coverage will be N/A.`;
-        warnings.push(warning);
-        writeLine(options.stderr, warning);
-      }
-    } else {
-      coverageUnavailableReason = "missing_report";
-      const warning = `Warning: Coverage report not found at ${expectedCoveragePath(moduleRoot, coverageReportPath)}. Coverage will be N/A.`;
-      warnings.push(warning);
-      writeLine(options.stderr, warning);
-    }
-
-    for (const filePath of moduleFiles) {
-      const descriptors = await parseFileMethods(filePath);
-      const relativePath = toRelativePath(projectRoot, filePath);
-      const fileCoverage = resolveFileCoverage(coverageByFile, filePath, relativePath, coverageUnavailableReason);
-      const methodCoverage = coverageForMethods(descriptors, fileCoverage.coverage, fileCoverage.unknownReason ?? undefined);
-      for (const [index, descriptor] of descriptors.entries()) {
-        const coverage = methodCoverage[index];
-        const coveragePercent = coverage.coverage.percent;
-        if (coverage.coverage.unknownReason === "fnmap_conflict") {
-          const warning = `Warning: Function coverage metadata in ${relativePath} could not be matched unambiguously for ${descriptor.displayName}. Coverage will be N/A.`;
-          warnings.push(warning);
-          writeLine(options.stderr, warning);
-        }
-        metrics.push({
-          ...descriptor,
-          filePath,
-          relativePath,
-          location: `${relativePath}:${descriptor.startLine}-${descriptor.endLine}`,
-          moduleRoot,
-          coverage: coverage.coverage,
-          statementCoverage: coverage.statementCoverage,
-          branchCoverage: coverage.branchCoverage,
-          coveragePercent,
-          crapScore: calculateCrapScore(descriptor.complexity, coveragePercent)
-        });
-      }
-    }
-  }
-
+  const groupedByModule = await groupFilesByModule(context.projectRoot, selectedFiles);
+  const moduleResults = await analyzeModules(groupedByModule, context);
+  const metrics = moduleResults.flatMap((result) => result.metrics);
+  const coverageCommands = moduleResults.flatMap((result) => result.coverageCommands);
+  const warnings = moduleResults.flatMap((result) => result.warnings);
   const max = maxCrap(metrics);
+
   return {
     metrics,
     maxCrap: max,
@@ -119,6 +40,195 @@ export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promi
     selectedFiles,
     coverageCommands,
     warnings
+  };
+}
+
+interface AnalyzeContext {
+  projectRoot: string;
+  coverageMode: NonNullable<AnalyzeProjectOptions["coverageMode"]>;
+  packageManager: NonNullable<AnalyzeProjectOptions["packageManager"]>;
+  testRunner: NonNullable<AnalyzeProjectOptions["testRunner"]>;
+  coverageReportPath: AnalyzeProjectOptions["coverageReportPath"];
+  executor: NonNullable<AnalyzeProjectOptions["executor"]>;
+  stderr: AnalyzeProjectOptions["stderr"];
+}
+
+interface ModuleAnalysisResult {
+  metrics: MethodMetrics[];
+  coverageCommands: CoverageCommand[];
+  warnings: string[];
+}
+
+interface FileAnalysisResult {
+  metrics: MethodMetrics[];
+  warnings: string[];
+}
+
+interface LoadedCoverage {
+  coverageByFile: Map<string, FileCoverage>;
+  unknownReason: CoverageUnknownReason | null;
+  warnings: string[];
+}
+
+function createAnalyzeContext(options: AnalyzeProjectOptions): AnalyzeContext {
+  return {
+    projectRoot: path.resolve(options.projectRoot ?? process.cwd()),
+    coverageMode: options.coverageMode ?? "auto",
+    packageManager: options.packageManager ?? "auto",
+    testRunner: options.testRunner ?? "auto",
+    coverageReportPath: options.coverageReportPath,
+    executor: options.executor ?? new DefaultCommandExecutor(),
+    stderr: options.stderr
+  };
+}
+
+function emptyAnalysisResult(): AnalysisResult {
+  return {
+    metrics: [],
+    maxCrap: 0,
+    thresholdExceeded: false,
+    selectedFiles: [],
+    coverageCommands: [],
+    warnings: []
+  };
+}
+
+async function groupFilesByModule(projectRoot: string, selectedFiles: string[]): Promise<Map<string, string[]>> {
+  const groupedByModule = new Map<string, string[]>();
+  for (const filePath of selectedFiles) {
+    const moduleRoot = await resolveModuleRoot(projectRoot, filePath);
+    const files = groupedByModule.get(moduleRoot) ?? [];
+    files.push(filePath);
+    groupedByModule.set(moduleRoot, files);
+  }
+  return groupedByModule;
+}
+
+async function analyzeModules(groupedByModule: Map<string, string[]>, context: AnalyzeContext): Promise<ModuleAnalysisResult[]> {
+  const results: ModuleAnalysisResult[] = [];
+  for (const [moduleRoot, moduleFiles] of groupedByModule.entries()) {
+    results.push(await analyzeModule(moduleRoot, moduleFiles, context));
+  }
+  return results;
+}
+
+async function analyzeModule(
+  moduleRoot: string,
+  moduleFiles: string[],
+  context: AnalyzeContext
+): Promise<ModuleAnalysisResult> {
+  const coverageResult = await ensureCoverageReport(
+    context.projectRoot,
+    moduleRoot,
+    context.packageManager,
+    context.testRunner,
+    context.coverageMode,
+    context.coverageReportPath,
+    context.executor
+  );
+  const loadedCoverage = await loadModuleCoverage(moduleRoot, coverageResult, context);
+  const fileResults = await analyzeFiles(moduleRoot, moduleFiles, loadedCoverage, context);
+
+  return {
+    metrics: fileResults.flatMap((result) => result.metrics),
+    coverageCommands: coverageResult.command ? [coverageResult.command] : [],
+    warnings: [...loadedCoverage.warnings, ...fileResults.flatMap((result) => result.warnings)]
+  };
+}
+
+async function loadModuleCoverage(
+  moduleRoot: string,
+  coverageResult: Awaited<ReturnType<typeof ensureCoverageReport>>,
+  context: AnalyzeContext
+): Promise<LoadedCoverage> {
+  if (!coverageResult.coverageSourcePath || !coverageResult.coverageSourceRoot) {
+    return {
+      coverageByFile: new Map<string, FileCoverage>(),
+      unknownReason: "missing_report",
+      warnings: [emitWarning(
+        context.stderr,
+        `Warning: Coverage report not found at ${expectedCoveragePath(moduleRoot, context.coverageReportPath)}. Coverage will be N/A.`
+      )]
+    };
+  }
+
+  try {
+    return {
+      coverageByFile: await parseCoverageReport(coverageResult.coverageSourcePath, coverageResult.coverageSourceRoot),
+      unknownReason: null,
+      warnings: []
+    };
+  } catch (error) {
+    return {
+      coverageByFile: new Map<string, FileCoverage>(),
+      unknownReason: "unparseable_report",
+      warnings: [emitWarning(
+        context.stderr,
+        `Warning: Coverage report at ${coverageResult.coverageSourcePath} could not be parsed: ${(error as Error).message}. Coverage will be N/A.`
+      )]
+    };
+  }
+}
+
+async function analyzeFiles(
+  moduleRoot: string,
+  moduleFiles: string[],
+  loadedCoverage: LoadedCoverage,
+  context: AnalyzeContext
+): Promise<FileAnalysisResult[]> {
+  const results: FileAnalysisResult[] = [];
+  for (const filePath of moduleFiles) {
+    results.push(await analyzeFile(filePath, moduleRoot, loadedCoverage, context));
+  }
+  return results;
+}
+
+async function analyzeFile(
+  filePath: string,
+  moduleRoot: string,
+  loadedCoverage: LoadedCoverage,
+  context: AnalyzeContext
+): Promise<FileAnalysisResult> {
+  const descriptors = await parseFileMethods(filePath);
+  const relativePath = toRelativePath(context.projectRoot, filePath);
+  const fileCoverage = resolveFileCoverage(loadedCoverage.coverageByFile, filePath, relativePath, loadedCoverage.unknownReason);
+  const methodCoverage = coverageForMethods(descriptors, fileCoverage.coverage, fileCoverage.unknownReason ?? undefined);
+  const warnings: string[] = [];
+  const metrics = descriptors.map((descriptor, index) =>
+    toMetric(descriptor, methodCoverage[index], filePath, relativePath, moduleRoot, context.stderr, warnings)
+  );
+
+  return { metrics, warnings };
+}
+
+function toMetric(
+  descriptor: MethodDescriptor,
+  coverage: ReturnType<typeof coverageForMethods>[number],
+  filePath: string,
+  relativePath: string,
+  moduleRoot: string,
+  stderr: AnalyzeProjectOptions["stderr"],
+  warnings: string[]
+): MethodMetrics {
+  const coveragePercent = coverage.coverage.percent;
+  if (coverage.coverage.unknownReason === "fnmap_conflict") {
+    warnings.push(emitWarning(
+      stderr,
+      `Warning: Function coverage metadata in ${relativePath} could not be matched unambiguously for ${descriptor.displayName}. Coverage will be N/A.`
+    ));
+  }
+
+  return {
+    ...descriptor,
+    filePath,
+    relativePath,
+    location: `${relativePath}:${descriptor.startLine}-${descriptor.endLine}`,
+    moduleRoot,
+    coverage: coverage.coverage,
+    statementCoverage: coverage.statementCoverage,
+    branchCoverage: coverage.branchCoverage,
+    coveragePercent,
+    crapScore: calculateCrapScore(descriptor.complexity, coveragePercent)
   };
 }
 
@@ -157,4 +267,9 @@ function resolveFileCoverage(
     coverage: undefined,
     unknownReason: coverageUnavailableReason ?? "file_unmatched"
   };
+}
+
+function emitWarning(stderr: AnalyzeProjectOptions["stderr"], warning: string): string {
+  writeLine(stderr, warning);
+  return warning;
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -39,62 +39,98 @@ export function parseCliArguments(args: string[]): CliArguments {
     };
   }
 
-  let help = false;
-  let changed = false;
-  let packageManager: PackageManagerSelection = "auto";
-  let testRunner: TestRunnerSelection = "auto";
-  let packageManagerSeen = false;
-  let testRunnerSeen = false;
-  const fileArgs: string[] = [];
+  const state = createParseState();
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    switch (arg) {
-      case "--help":
-        help = true;
-        break;
-      case "--changed":
-        changed = true;
-        break;
-      case "--package-manager":
-        if (packageManagerSeen) {
-          throw new Error("--package-manager can only be provided once");
-        }
-        packageManager = parsePackageManagerSelection(args[++index]);
-        packageManagerSeen = true;
-        break;
-      case "--test-runner":
-        if (testRunnerSeen) {
-          throw new Error("--test-runner can only be provided once");
-        }
-        testRunner = parseTestRunnerSelection(args[++index]);
-        testRunnerSeen = true;
-        break;
-      default:
-        if (arg.startsWith("--")) {
-          throw new Error(`Unknown option: ${arg}`);
-        }
-        fileArgs.push(arg);
-        break;
+    if (!arg.startsWith("--")) {
+      state.fileArgs.push(arg);
+      continue;
     }
+    index = consumeOption(state, args, index);
   }
 
-  if (help) {
+  return finalizeCliArguments(state);
+}
+
+interface ParseState {
+  help: boolean;
+  changed: boolean;
+  packageManager: PackageManagerSelection;
+  testRunner: TestRunnerSelection;
+  packageManagerSeen: boolean;
+  testRunnerSeen: boolean;
+  fileArgs: string[];
+}
+
+type OptionHandler = (state: ParseState, args: string[], index: number) => number;
+
+const OPTION_HANDLERS: Record<string, OptionHandler> = {
+  "--help": (state, _args, index) => {
+    state.help = true;
+    return index;
+  },
+  "--changed": (state, _args, index) => {
+    state.changed = true;
+    return index;
+  },
+  "--package-manager": (state, args, index) => {
+    ensureOptionIsUnique(state.packageManagerSeen, "--package-manager");
+    state.packageManager = parsePackageManagerSelection(args[index + 1]);
+    state.packageManagerSeen = true;
+    return index + 1;
+  },
+  "--test-runner": (state, args, index) => {
+    ensureOptionIsUnique(state.testRunnerSeen, "--test-runner");
+    state.testRunner = parseTestRunnerSelection(args[index + 1]);
+    state.testRunnerSeen = true;
+    return index + 1;
+  }
+};
+
+function createParseState(): ParseState {
+  return {
+    help: false,
+    changed: false,
+    packageManager: "auto",
+    testRunner: "auto",
+    packageManagerSeen: false,
+    testRunnerSeen: false,
+    fileArgs: []
+  };
+}
+
+function consumeOption(state: ParseState, args: string[], index: number): number {
+  const handler = OPTION_HANDLERS[args[index]];
+  if (!handler) {
+    throw new Error(`Unknown option: ${args[index]}`);
+  }
+  return handler(state, args, index);
+}
+
+function ensureOptionIsUnique(seen: boolean, option: string): void {
+  if (seen) {
+    throw new Error(`${option} can only be provided once`);
+  }
+}
+
+function finalizeCliArguments(state: ParseState): CliArguments {
+  if (state.help) {
     return {
       mode: "help",
       fileArgs: [],
-      packageManager,
-      testRunner
+      packageManager: state.packageManager,
+      testRunner: state.testRunner
     };
   }
-  if (changed && fileArgs.length > 0) {
+  if (state.changed && state.fileArgs.length > 0) {
     throw new Error("--changed cannot be combined with file arguments");
   }
   return {
-    mode: changed ? "changed" : fileArgs.length > 0 ? "explicit" : "all",
-    fileArgs,
-    packageManager,
-    testRunner
+    mode: state.changed ? "changed" : state.fileArgs.length > 0 ? "explicit" : "all",
+    fileArgs: state.fileArgs,
+    packageManager: state.packageManager,
+    testRunner: state.testRunner
   };
 }
 

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { IGNORED_DIRECTORIES } from "./constants";
 import { runCommand, toRelativePath } from "./utils";
 
+const ANALYZABLE_EXTENSIONS = [".ts", ".tsx"];
+const TEST_FILE_MARKERS = [".test.", ".spec."];
+const EXCLUDED_PATH_SEGMENTS = ["/__tests__/", "/dist/", "/coverage/", "/node_modules/"];
+
 export async function findAllTypeScriptFilesUnderSourceRoots(projectRoot: string): Promise<string[]> {
   const files = new Set<string>();
   await walkForSourceRoots(projectRoot, async (sourceRoot) => {
@@ -38,52 +42,65 @@ export async function changedTypeScriptFilesUnderSourceRoots(projectRoot: string
   if (result.exitCode !== 0) {
     throw new Error(result.stderr.trim() || "git status --porcelain failed");
   }
-
-  const files = new Set<string>();
-  const entries = result.stdout.split("\0");
-  for (let index = 0; index < entries.length; index += 1) {
-    const entry = entries[index];
-    if (!entry) {
-      continue;
-    }
-    const status = entry.slice(0, 2);
-    const pathValue = entry.slice(3);
-    if (!isIncludedGitStatus(status)) {
-      if (isRenameOrCopyStatus(status)) {
-        index += 1;
-      }
-      continue;
-    }
-    const resolvedPath = path.resolve(projectRoot, pathValue);
-    if (isAnalyzableFile(resolvedPath) && isUnderSourceTree(projectRoot, resolvedPath)) {
-      files.add(resolvedPath);
-    }
-    if (isRenameOrCopyStatus(status)) {
-      index += 1;
-    }
-  }
-  return Array.from(files).sort();
+  return Array.from(collectChangedFilesFromStatus(projectRoot, result.stdout.split("\0"))).sort();
 }
 
 export function isAnalyzableFile(filePath: string): boolean {
   const normalized = toRelativePath(path.parse(filePath).root, filePath).toLowerCase();
   const baseName = path.basename(normalized);
-  if (!(normalized.endsWith(".ts") || normalized.endsWith(".tsx"))) {
+  if (!hasAnySuffix(normalized, ANALYZABLE_EXTENSIONS)) {
     return false;
   }
   if (normalized.endsWith(".d.ts")) {
     return false;
   }
-  if (baseName.includes(".test.") || baseName.includes(".spec.")) {
+  if (containsAny(baseName, TEST_FILE_MARKERS)) {
     return false;
   }
-  if (normalized.includes("/__tests__/")) {
-    return false;
-  }
-  if (normalized.includes("/dist/") || normalized.includes("/coverage/") || normalized.includes("/node_modules/")) {
+  if (containsAny(normalized, EXCLUDED_PATH_SEGMENTS)) {
     return false;
   }
   return true;
+}
+
+interface GitStatusEntry {
+  status: string;
+  pathValue: string;
+}
+
+function parseGitStatusEntry(entry: string): GitStatusEntry | null {
+  if (!entry) {
+    return null;
+  }
+  return {
+    status: entry.slice(0, 2),
+    pathValue: entry.slice(3)
+  };
+}
+
+function collectChangedFile(projectRoot: string, entry: GitStatusEntry, files: Set<string>): void {
+  if (!isIncludedGitStatus(entry.status)) {
+    return;
+  }
+  const resolvedPath = path.resolve(projectRoot, entry.pathValue);
+  if (isAnalyzableFile(resolvedPath) && isUnderSourceTree(projectRoot, resolvedPath)) {
+    files.add(resolvedPath);
+  }
+}
+
+function collectChangedFilesFromStatus(projectRoot: string, entries: string[]): Set<string> {
+  const files = new Set<string>();
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = parseGitStatusEntry(entries[index]);
+    if (!entry) {
+      continue;
+    }
+    collectChangedFile(projectRoot, entry, files);
+    if (isRenameOrCopyStatus(entry.status)) {
+      index += 1;
+    }
+  }
+  return files;
 }
 
 function isUnderSourceTree(projectRoot: string, filePath: string): boolean {
@@ -100,6 +117,14 @@ function isIncludedGitStatus(status: string): boolean {
 
 function isRenameOrCopyStatus(status: string): boolean {
   return status.includes("R") || status.includes("C");
+}
+
+function containsAny(value: string, fragments: string[]): boolean {
+  return fragments.some((fragment) => value.includes(fragment));
+}
+
+function hasAnySuffix(value: string, suffixes: string[]): boolean {
+  return suffixes.some((suffix) => value.endsWith(suffix));
 }
 
 async function walkForSourceRoots(

--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -75,19 +75,10 @@ function parseBranches(branchMapValue: unknown, hitsValue: unknown): BranchCover
 
   const branches: BranchCoverageUnit[] = [];
   for (const [key, branchValue] of Object.entries(branchMapValue)) {
-    if (!isRecord(branchValue)) {
-      continue;
+    const branch = toBranchCoverageUnit(branchValue, hitsValue[key]);
+    if (branch) {
+      branches.push(branch);
     }
-
-    const hits = parseHitArray(hitsValue[key]);
-    const span = parseSpan(branchValue.loc) ??
-      parseFirstLocation(branchValue.locations) ??
-      parseLineSpan(branchValue.line);
-    if (hits.length === 0 || span === null) {
-      continue;
-    }
-
-    branches.push({ span, hits });
   }
 
   return deduplicateBranches(branches);
@@ -100,13 +91,7 @@ function parseFunctions(fnMapValue: unknown): FunctionCoverageUnit[] {
 
   const functions: FunctionCoverageUnit[] = [];
   for (const entryValue of Object.values(fnMapValue)) {
-    if (!isRecord(entryValue)) {
-      continue;
-    }
-
-    const span = parseSpan(entryValue.loc) ??
-      parseSpan(entryValue.decl) ??
-      parseLineSpan(entryValue.line);
+    const span = resolveFunctionSpan(entryValue);
     if (span) {
       functions.push({ span });
     }
@@ -218,16 +203,9 @@ function deduplicateBranches(branches: BranchCoverageUnit[]): BranchCoverageUnit
       deduplicated.set(key, branch);
       continue;
     }
-
-    const mergedHits = branch.hits.map((hits, index) => Math.max(hits, existing.hits[index] ?? 0));
-    if (existing.hits.length > mergedHits.length) {
-      for (let index = mergedHits.length; index < existing.hits.length; index += 1) {
-        mergedHits.push(existing.hits[index]);
-      }
-    }
     deduplicated.set(key, {
       span: branch.span,
-      hits: mergedHits
+      hits: mergeBranchHits(existing.hits, branch.hits)
     });
   }
   return [...deduplicated.values()];
@@ -253,4 +231,40 @@ function stringifySpan(span: SourceSpan): string {
 
 function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toBranchCoverageUnit(branchValue: unknown, hitsValue: unknown): BranchCoverageUnit | null {
+  if (!isRecord(branchValue)) {
+    return null;
+  }
+
+  const hits = parseHitArray(hitsValue);
+  const span = resolveBranchSpan(branchValue);
+  if (hits.length === 0 || span === null) {
+    return null;
+  }
+  return { span, hits };
+}
+
+function resolveBranchSpan(branchValue: JsonRecord): SourceSpan | null {
+  return parseSpan(branchValue.loc) ??
+    parseFirstLocation(branchValue.locations) ??
+    parseLineSpan(branchValue.line);
+}
+
+function resolveFunctionSpan(entryValue: unknown): SourceSpan | null {
+  if (!isRecord(entryValue)) {
+    return null;
+  }
+  return parseSpan(entryValue.loc) ??
+    parseSpan(entryValue.decl) ??
+    parseLineSpan(entryValue.line);
+}
+
+function mergeBranchHits(existingHits: number[], nextHits: number[]): number[] {
+  const mergedHits = nextHits.map((hits, index) => Math.max(hits, existingHits[index] ?? 0));
+  for (let index = mergedHits.length; index < existingHits.length; index += 1) {
+    mergedHits.push(existingHits[index]);
+  }
+  return mergedHits;
 }

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -4,6 +4,38 @@ import ts from "typescript";
 import { resolveScriptKind } from "./utils";
 import type { MethodDescriptor, SourceSpan } from "./types";
 
+const COMPLEXITY_INCREMENT_KINDS = new Set([
+  ts.SyntaxKind.IfStatement,
+  ts.SyntaxKind.ForStatement,
+  ts.SyntaxKind.ForInStatement,
+  ts.SyntaxKind.ForOfStatement,
+  ts.SyntaxKind.WhileStatement,
+  ts.SyntaxKind.DoStatement,
+  ts.SyntaxKind.CatchClause,
+  ts.SyntaxKind.ConditionalExpression,
+  ts.SyntaxKind.CaseClause
+]);
+const SHORT_CIRCUIT_KINDS = new Set([
+  ts.SyntaxKind.AmpersandAmpersandToken,
+  ts.SyntaxKind.BarBarToken,
+  ts.SyntaxKind.QuestionQuestionToken
+]);
+const BRANCH_SYNTAX_KINDS = new Set([
+  ts.SyntaxKind.IfStatement,
+  ts.SyntaxKind.ConditionalExpression,
+  ts.SyntaxKind.SwitchStatement
+]);
+const NESTED_BOUNDARY_KINDS = new Set([
+  ts.SyntaxKind.FunctionDeclaration,
+  ts.SyntaxKind.FunctionExpression,
+  ts.SyntaxKind.ArrowFunction,
+  ts.SyntaxKind.MethodDeclaration,
+  ts.SyntaxKind.GetAccessor,
+  ts.SyntaxKind.SetAccessor,
+  ts.SyntaxKind.ClassDeclaration,
+  ts.SyntaxKind.ClassExpression
+]);
+
 export async function parseFileMethods(filePath: string): Promise<MethodDescriptor[]> {
   const sourceText = await readFile(filePath, "utf8");
   const scriptKind = resolveScriptKind(filePath) === "tsx" ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
@@ -23,40 +55,59 @@ export async function parseFileMethods(filePath: string): Promise<MethodDescript
 }
 
 function toMethodDescriptor(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
-  if (ts.isFunctionDeclaration(node)) {
-    if (!node.body) {
-      return null;
+  for (const builder of DESCRIPTOR_BUILDERS) {
+    const descriptor = builder(node, sourceFile);
+    if (descriptor) {
+      return descriptor;
     }
-    const functionName = node.name?.text ?? inferFunctionDeclarationName(node);
-    if (!functionName) {
-      return null;
-    }
-    return buildMethodDescriptor(functionName, findContainerName(node), node, sourceFile);
-  }
-
-  if (ts.isMethodDeclaration(node)) {
-    if (!node.body) {
-      return null;
-    }
-    return buildMethodDescriptor(propertyName(node.name), findContainerName(node), node, sourceFile);
-  }
-
-  if (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) {
-    if (!node.body) {
-      return null;
-    }
-    return buildMethodDescriptor(accessorName(node), findContainerName(node), node, sourceFile);
-  }
-
-  if (ts.isFunctionExpression(node) || ts.isArrowFunction(node)) {
-    const assignedName = findAssignedFunctionName(node);
-    if (!assignedName) {
-      return null;
-    }
-    return buildMethodDescriptor(assignedName.name, assignedName.containerName, node, sourceFile);
   }
 
   return null;
+}
+
+type DescriptorBuilder = (node: ts.Node, sourceFile: ts.SourceFile) => MethodDescriptor | null;
+
+const DESCRIPTOR_BUILDERS: DescriptorBuilder[] = [
+  descriptorFromFunctionDeclaration,
+  descriptorFromMethodDeclaration,
+  descriptorFromAccessorDeclaration,
+  descriptorFromAssignedFunction
+];
+
+function descriptorFromFunctionDeclaration(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
+  if (!ts.isFunctionDeclaration(node) || !node.body) {
+    return null;
+  }
+  const functionName = node.name?.text ?? inferFunctionDeclarationName(node);
+  if (!functionName) {
+    return null;
+  }
+  return buildMethodDescriptor(functionName, findContainerName(node), node, sourceFile);
+}
+
+function descriptorFromMethodDeclaration(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
+  if (!ts.isMethodDeclaration(node) || !node.body) {
+    return null;
+  }
+  return buildMethodDescriptor(propertyName(node.name), findContainerName(node), node, sourceFile);
+}
+
+function descriptorFromAccessorDeclaration(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
+  if (!(ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) || !node.body) {
+    return null;
+  }
+  return buildMethodDescriptor(accessorName(node), findContainerName(node), node, sourceFile);
+}
+
+function descriptorFromAssignedFunction(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
+  if (!(ts.isFunctionExpression(node) || ts.isArrowFunction(node))) {
+    return null;
+  }
+  const assignedName = findAssignedFunctionName(node);
+  if (!assignedName) {
+    return null;
+  }
+  return buildMethodDescriptor(assignedName.name, assignedName.containerName, node, sourceFile);
 }
 
 function inferFunctionDeclarationName(node: ts.FunctionDeclaration): string | null {
@@ -134,46 +185,102 @@ function findContainerName(node: ts.Node): string | null {
 }
 
 function inferObjectContainerName(node: ts.ObjectLiteralExpression): string | null {
-  const parent = node.parent;
-  if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
-    return parent.name.text;
-  }
-  if (ts.isPropertyAssignment(parent)) {
-    return propertyName(parent.name);
-  }
-  if (ts.isPropertyDeclaration(parent)) {
-    return propertyName(parent.name);
-  }
-  if (ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-    const target = assignmentTarget(parent.left);
-    return toDisplayName(target.containerName, target.name);
+  for (const resolver of OBJECT_CONTAINER_RESOLVERS) {
+    const containerName = resolver(node.parent);
+    if (containerName) {
+      return containerName;
+    }
   }
   return null;
 }
 
 function assignmentTarget(node: ts.Expression): { name: string; containerName: string | null } {
+  for (const resolver of ASSIGNMENT_TARGET_RESOLVERS) {
+    const target = resolver(node);
+    if (target) {
+      return target;
+    }
+  }
+  return {
+    name: "<assigned>",
+    containerName: null
+  };
+}
+
+type ObjectContainerResolver = (parent: ts.Node) => string | null;
+
+const OBJECT_CONTAINER_RESOLVERS: ObjectContainerResolver[] = [
+  containerFromVariableDeclaration,
+  containerFromPropertyAssignment,
+  containerFromPropertyDeclaration,
+  containerFromBinaryAssignment
+];
+
+function containerFromVariableDeclaration(parent: ts.Node): string | null {
+  if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+    return parent.name.text;
+  }
+  return null;
+}
+
+function containerFromPropertyAssignment(parent: ts.Node): string | null {
+  if (ts.isPropertyAssignment(parent)) {
+    return propertyName(parent.name);
+  }
+  return null;
+}
+
+function containerFromPropertyDeclaration(parent: ts.Node): string | null {
+  if (ts.isPropertyDeclaration(parent)) {
+    return propertyName(parent.name);
+  }
+  return null;
+}
+
+function containerFromBinaryAssignment(parent: ts.Node): string | null {
+  if (!isAssignmentExpression(parent)) {
+    return null;
+  }
+  const target = assignmentTarget(parent.left);
+  return toDisplayName(target.containerName, target.name);
+}
+
+type AssignmentTargetResolver = (node: ts.Expression) => { name: string; containerName: string | null } | null;
+
+const ASSIGNMENT_TARGET_RESOLVERS: AssignmentTargetResolver[] = [
+  assignmentFromIdentifier,
+  assignmentFromPropertyAccess,
+  assignmentFromElementAccess
+];
+
+function assignmentFromIdentifier(node: ts.Expression): { name: string; containerName: string | null } | null {
   if (ts.isIdentifier(node)) {
     return {
       name: node.text,
       containerName: null
     };
   }
+  return null;
+}
+
+function assignmentFromPropertyAccess(node: ts.Expression): { name: string; containerName: string | null } | null {
   if (ts.isPropertyAccessExpression(node)) {
     return {
       name: node.name.text,
       containerName: node.expression.getText()
     };
   }
+  return null;
+}
+
+function assignmentFromElementAccess(node: ts.Expression): { name: string; containerName: string | null } | null {
   if (ts.isElementAccessExpression(node)) {
     return {
       name: `[${node.argumentExpression?.getText() ?? ""}]`,
       containerName: node.expression.getText()
     };
   }
-  return {
-    name: "<assigned>",
-    containerName: null
-  };
+  return null;
 }
 
 function accessorName(node: ts.GetAccessorDeclaration | ts.SetAccessorDeclaration): string {
@@ -206,31 +313,7 @@ function countCyclomaticComplexity(node: ts.FunctionLikeDeclaration): number {
     if (current !== node && isNestedBoundary(current)) {
       return;
     }
-
-    if (
-      ts.isIfStatement(current) ||
-      ts.isForStatement(current) ||
-      ts.isForInStatement(current) ||
-      ts.isForOfStatement(current) ||
-      ts.isWhileStatement(current) ||
-      ts.isDoStatement(current) ||
-      ts.isCatchClause(current) ||
-      ts.isConditionalExpression(current)
-    ) {
-      complexity += 1;
-    } else if (ts.isCaseClause(current)) {
-      complexity += 1;
-    } else if (ts.isBinaryExpression(current)) {
-      const kind = current.operatorToken.kind;
-      if (
-        kind === ts.SyntaxKind.AmpersandAmpersandToken ||
-        kind === ts.SyntaxKind.BarBarToken ||
-        kind === ts.SyntaxKind.QuestionQuestionToken
-      ) {
-        complexity += 1;
-      }
-    }
-
+    complexity += complexityContribution(current);
     ts.forEachChild(current, visit);
   };
 
@@ -267,24 +350,9 @@ function hasAttributableBranches(body: ts.ConciseBody): boolean {
     if (current !== body && isNestedBoundary(current)) {
       return;
     }
-    if (
-      ts.isIfStatement(current) ||
-      ts.isConditionalExpression(current) ||
-      ts.isSwitchStatement(current)
-    ) {
+    if (hasBranchSyntax(current)) {
       found = true;
       return;
-    }
-    if (ts.isBinaryExpression(current)) {
-      const kind = current.operatorToken.kind;
-      if (
-        kind === ts.SyntaxKind.AmpersandAmpersandToken ||
-        kind === ts.SyntaxKind.BarBarToken ||
-        kind === ts.SyntaxKind.QuestionQuestionToken
-      ) {
-        found = true;
-        return;
-      }
     }
 
     ts.forEachChild(current, visit);
@@ -295,17 +363,31 @@ function hasAttributableBranches(body: ts.ConciseBody): boolean {
 }
 
 function isNestedBoundary(node: ts.Node): boolean {
-  return ts.isFunctionDeclaration(node) ||
-    ts.isFunctionExpression(node) ||
-    ts.isArrowFunction(node) ||
-    ts.isMethodDeclaration(node) ||
-    ts.isGetAccessorDeclaration(node) ||
-    ts.isSetAccessorDeclaration(node) ||
-    ts.isClassDeclaration(node) ||
-    ts.isClassExpression(node);
+  return NESTED_BOUNDARY_KINDS.has(node.kind);
 }
 
 function isProvablyNonExecutableDeclarationStatement(statement: ts.Statement): boolean {
   return ts.isInterfaceDeclaration(statement) ||
     ts.isTypeAliasDeclaration(statement);
+}
+
+function complexityContribution(node: ts.Node): number {
+  if (COMPLEXITY_INCREMENT_KINDS.has(node.kind)) {
+    return 1;
+  }
+  if (!ts.isBinaryExpression(node)) {
+    return 0;
+  }
+  return SHORT_CIRCUIT_KINDS.has(node.operatorToken.kind) ? 1 : 0;
+}
+
+function hasBranchSyntax(node: ts.Node): boolean {
+  if (BRANCH_SYNTAX_KINDS.has(node.kind)) {
+    return true;
+  }
+  return ts.isBinaryExpression(node) && SHORT_CIRCUIT_KINDS.has(node.operatorToken.kind);
+}
+
+function isAssignmentExpression(node: ts.Node): node is ts.BinaryExpression {
+  return ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken;
 }

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -23,6 +23,39 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--changed", "src/app.ts"])).toThrow("--changed cannot be combined");
   });
 
+  it("parses explicit paths, help mode, and alternate package-manager and test-runner selections", () => {
+    expect(parseCliArguments(["packages/core", "--package-manager", "pnpm", "--test-runner", "jest"])).toEqual({
+      mode: "explicit",
+      fileArgs: ["packages/core"],
+      packageManager: "pnpm",
+      testRunner: "jest"
+    });
+    expect(parseCliArguments(["--help", "--package-manager", "yarn"])).toEqual({
+      mode: "help",
+      fileArgs: [],
+      packageManager: "yarn",
+      testRunner: "auto"
+    });
+  });
+
+  it("rejects duplicate, missing, invalid, and unknown options", () => {
+    expect(() => parseCliArguments(["--package-manager", "npm", "--package-manager", "pnpm"])).toThrow(
+      "--package-manager can only be provided once"
+    );
+    expect(() => parseCliArguments(["--test-runner", "vitest", "--test-runner", "jest"])).toThrow(
+      "--test-runner can only be provided once"
+    );
+    expect(() => parseCliArguments(["--package-manager"])).toThrow("--package-manager requires one of: auto, npm, pnpm, yarn");
+    expect(() => parseCliArguments(["--test-runner"])).toThrow("--test-runner requires one of: auto, vitest, jest");
+    expect(() => parseCliArguments(["--package-manager", "bun"])).toThrow(
+      "--package-manager requires one of: auto, npm, pnpm, yarn"
+    );
+    expect(() => parseCliArguments(["--test-runner", "mocha"])).toThrow(
+      "--test-runner requires one of: auto, vitest, jest"
+    );
+    expect(() => parseCliArguments(["--unknown"])).toThrow("Unknown option: --unknown");
+  });
+
   it("prints help", async () => {
     const stdout = new StringWriter();
     const stderr = new StringWriter();

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -467,6 +467,108 @@ export function enumDeclOnly(): void {
       }
     ]);
   });
+
+  it("parses fallback branch and function spans and deduplicates hits conservatively", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            },
+            "1": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            }
+          },
+          branchMap: {
+            "0": {
+              line: 3,
+              locations: [
+                {
+                  start: { line: 3, column: 2 },
+                  end: { line: 5, column: 3 }
+                }
+              ]
+            },
+            "1": {
+              loc: {
+                start: { line: 3, column: 2 },
+                end: { line: 5, column: 3 }
+              }
+            }
+          },
+          fnMap: {
+            "0": {
+              decl: {
+                start: { line: 1, column: 0 },
+                end: { line: 6, column: 1 }
+              }
+            },
+            "1": {
+              line: 1
+            }
+          },
+          s: {
+            "0": 1,
+            "1": 3
+          },
+          b: {
+            "0": [1, 0],
+            "1": [0, 2, 4]
+          },
+          f: {}
+        }
+      })
+    });
+
+    const [fileCoverage] = (await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)).values();
+    expect(fileCoverage.statements).toEqual([
+      {
+        span: {
+          startLine: 2,
+          startColumn: 2,
+          endLine: 2,
+          endColumn: 19
+        },
+        hits: 3
+      }
+    ]);
+    expect(fileCoverage.branches).toEqual([
+      {
+        span: {
+          startLine: 3,
+          startColumn: 2,
+          endLine: 5,
+          endColumn: 3
+        },
+        hits: [1, 2, 4]
+      }
+    ]);
+    expect(fileCoverage.functions).toEqual([
+      {
+        span: {
+          startLine: 1,
+          startColumn: 0,
+          endLine: 6,
+          endColumn: 1
+        }
+      },
+      {
+        span: {
+          startLine: 1,
+          startColumn: 0,
+          endLine: 1,
+          endColumn: Number.MAX_SAFE_INTEGER
+        }
+      }
+    ]);
+  });
 });
 
 function summarizeMethodCoverage(coverage: {

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -6,7 +6,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   changedTypeScriptFilesUnderSourceRoots,
   expandExplicitPaths,
-  findAllTypeScriptFilesUnderSourceRoots
+  findAllTypeScriptFilesUnderSourceRoots,
+  isAnalyzableFile
 } from "../src/fileSelection";
 import { createTempDir, disposeTempDir, initGitRepository, runProcess, writeProjectFiles } from "./testUtils";
 
@@ -107,5 +108,63 @@ describe("file selection", () => {
     expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
       "src/hello world.ts"
     ]);
+  });
+
+  it("tracks renamed source files under src trees", async () => {
+    const tempDir = await createTempDir("crap-files-");
+    tempDirs.push(tempDir);
+    await initGitRepository(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/old-name.ts": "export const app = 1;\n"
+    });
+    await runProcess("git", ["add", "."], tempDir);
+    await runProcess("git", ["commit", "-m", "initial"], tempDir);
+
+    await runProcess("git", ["mv", "src/old-name.ts", "src/new-name.ts"], tempDir);
+
+    const files = await changedTypeScriptFilesUnderSourceRoots(tempDir);
+    expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
+      "src/new-name.ts"
+    ]);
+  });
+
+  it("filters declaration, test, dist, coverage, and node_modules paths from analyzable files", () => {
+    expect(isAnalyzableFile("C:/repo/src/app.ts")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/component.tsx")).toBe(true);
+    expect(isAnalyzableFile("C:/repo/src/types.d.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/src/app.spec.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/src/app.test.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/src/__tests__/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/dist/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/coverage/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/node_modules/pkg/index.ts")).toBe(false);
+  });
+
+  it("ignores deleted and non-source changes and reports git errors clearly", async () => {
+    const tempDir = await createTempDir("crap-files-");
+    tempDirs.push(tempDir);
+    await initGitRepository(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/app.ts": "export const app = 1;\n",
+      "src/remove.ts": "export const removeMe = 1;\n",
+      "docs/readme.ts": "export const docs = 1;\n"
+    });
+    await runProcess("git", ["add", "."], tempDir);
+    await runProcess("git", ["commit", "-m", "initial"], tempDir);
+
+    await writeFile(path.join(tempDir, "src/app.ts"), "export const app = 2;\n", "utf8");
+    await writeFile(path.join(tempDir, "docs/readme.ts"), "export const docs = 2;\n", "utf8");
+    await runProcess("git", ["rm", "src/remove.ts"], tempDir);
+
+    const files = await changedTypeScriptFilesUnderSourceRoots(tempDir);
+    expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
+      "src/app.ts"
+    ]);
+
+    const nonRepoDir = await createTempDir("crap-files-nonrepo-");
+    tempDirs.push(nonRepoDir);
+    await expect(changedTypeScriptFilesUnderSourceRoots(nonRepoDir)).rejects.toThrow("not a git repository");
   });
 });

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -1,12 +1,102 @@
+import path from "node:path";
+
 import { afterEach, describe, expect, it } from "vitest";
 
-import { resolveTestRunner } from "../src/moduleResolution";
+import {
+  locateCoverageReport,
+  resolveModuleRoot,
+  resolvePackageManager,
+  resolveTestRunner
+} from "../src/moduleResolution";
 import { createTempDir, disposeTempDir, writeProjectFiles } from "./testUtils";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(disposeTempDir));
+});
+
+describe("resolveModuleRoot", () => {
+  it("returns the nearest package root for nested workspace files and falls back to the project root", async () => {
+    const tempDir = await createTempDir("crap-module-root-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"root","private":true}',
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/src/example.ts": "export const example = 1;\n",
+      "tools/script.ts": "export const script = 1;\n"
+    });
+
+    await expect(resolveModuleRoot(tempDir, `${tempDir}/packages/demo/src/example.ts`)).resolves.toBe(`${tempDir}/packages/demo`);
+    await expect(resolveModuleRoot(tempDir, `${tempDir}/tools/script.ts`)).resolves.toBe(tempDir);
+  });
+});
+
+describe("locateCoverageReport", () => {
+  it("prefers the module coverage report when both module and project reports exist", async () => {
+    const tempDir = await createTempDir("crap-coverage-source-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"root","private":true}',
+      "coverage/coverage-final.json": "{}",
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/coverage/coverage-final.json": "{}"
+    });
+
+    await expect(locateCoverageReport(tempDir, `${tempDir}/packages/demo`)).resolves.toEqual({
+      reportPath: path.join(tempDir, "packages", "demo", "coverage", "coverage-final.json"),
+      sourceRoot: `${tempDir}/packages/demo`
+    });
+  });
+
+  it("falls back to the project coverage report when the module report is missing", async () => {
+    const tempDir = await createTempDir("crap-coverage-source-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"root","private":true}',
+      "coverage/coverage-final.json": "{}",
+      "packages/demo/package.json": '{"name":"demo","private":true}'
+    });
+
+    await expect(
+      locateCoverageReport(tempDir, `${tempDir}/packages/demo`, "coverage/coverage-final.json")
+    ).resolves.toEqual({
+      reportPath: path.join(tempDir, "coverage", "coverage-final.json"),
+      sourceRoot: tempDir
+    });
+  });
+});
+
+describe("resolvePackageManager", () => {
+  it("honors explicit selection and auto-detects lockfiles", async () => {
+    const tempDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"root","private":true}',
+      "pnpm-lock.yaml": "lockfileVersion: 9.0\n",
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/yarn.lock": ""
+    });
+
+    await expect(resolvePackageManager("pnpm", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("pnpm");
+    await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("yarn");
+
+    await writeProjectFiles(tempDir, {
+      "packages/demo/yarn.lock": ""
+    });
+  });
+
+  it("falls back to npm when npm lockfiles are present or nothing is detected", async () => {
+    const tempDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"root","private":true}',
+      "npm-shrinkwrap.json": "{}",
+      "packages/demo/package.json": '{"name":"demo","private":true}'
+    });
+
+    await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("npm");
+  });
 });
 
 describe("resolveTestRunner", () => {
@@ -28,5 +118,29 @@ describe("resolveTestRunner", () => {
     });
 
     await expect(resolveTestRunner("auto", tempDir, tempDir)).resolves.toBe("jest");
+  });
+
+  it("honors explicit selection, falls back to dependencies, and errors when nothing can be detected", async () => {
+    const tempDir = await createTempDir("crap-runner-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        devDependencies: {
+          vitest: "^4.0.0"
+        }
+      }),
+      "packages/demo/package.json": JSON.stringify({
+        name: "demo",
+        private: true
+      })
+    });
+
+    await expect(resolveTestRunner("vitest", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", `${tempDir}/packages/demo`, `${tempDir}/packages/demo`)).rejects.toThrow(
+      "Unable to detect a test runner"
+    );
   });
 });

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -430,4 +430,105 @@ namespace TypesOnly {
       }
     ]);
   });
+
+  it("infers container names for nested object literals and assignment targets", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "containers.ts");
+    await writeFile(
+      filePath,
+      `const registry: Record<string, unknown> = {};
+
+registry.render = {
+  nested(value: string): string {
+    return value.trim();
+  }
+};
+
+const root = {
+  child: {
+    leaf(value: number): number {
+      return value + 1;
+    }
+  }
+};
+
+class Example {
+  helper = {
+    format(value: string): string {
+      return value.toUpperCase();
+    }
+  };
+}
+`,
+      "utf8"
+    );
+
+    expect(await parseFileMethods(filePath)).toMatchObject([
+      {
+        displayName: "registry.render.nested"
+      },
+      {
+        displayName: "child.leaf"
+      },
+      {
+        displayName: "helper.format"
+      }
+    ]);
+  });
+
+  it("handles identifier, property, element, fallback, and unowned object-literal assignment targets", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "assignment-targets.ts");
+    await writeFile(
+      filePath,
+      `let direct: ((value: string) => string) | undefined;
+const registry: Record<string, unknown> = {};
+
+direct = function (value: string): string {
+  return value.trim();
+};
+
+registry.format = function (value: string): string {
+  return value.toUpperCase();
+};
+
+registry["upper"] = function (value: string): string {
+  return value ? value.toUpperCase() : value;
+};
+
+(registry as Record<string, unknown>) = function (value: string): string {
+  return value;
+};
+
+export function createHandlers() {
+  return {
+    returned(value: number): number {
+      return value + 1;
+    }
+  };
+}
+`,
+      "utf8"
+    );
+
+    expect(await parseFileMethods(filePath)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        displayName: "direct"
+      }),
+      expect.objectContaining({
+        displayName: "registry.format"
+      }),
+      expect.objectContaining({
+        displayName: "registry[\"upper\"]"
+      }),
+      expect.objectContaining({
+        displayName: "<assigned>"
+      }),
+      expect.objectContaining({
+        displayName: "returned"
+      })
+    ]));
+  });
 });

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -31,29 +31,28 @@ export class CrapTypescriptVitestReporter {
   constructor(private readonly options: CrapTypescriptVitestOptions = {}) {}
 
   async onFinishedReportCoverage(): Promise<void> {
-    const stdout = this.options.stdout ?? process.stdout;
-    const stderr = this.options.stderr ?? process.stderr;
+    const options = resolveReporterOptions(this.options);
     const result = await analyzeProject({
-      projectRoot: this.options.projectRoot ?? process.cwd(),
-      explicitPaths: this.options.paths ?? [],
-      changedOnly: this.options.changedOnly ?? false,
-      packageManager: this.options.packageManager ?? "auto",
+      projectRoot: options.projectRoot,
+      explicitPaths: options.paths,
+      changedOnly: options.changedOnly,
+      packageManager: options.packageManager,
       testRunner: "vitest",
       coverageMode: "existing-only",
-      coverageReportPath: this.options.coverageReportPath,
-      stdout,
-      stderr
+      coverageReportPath: options.coverageReportPath,
+      stdout: options.stdout,
+      stderr: options.stderr
     });
 
     if (result.selectedFiles.length === 0) {
-      stdout.write(`${NO_FILES_MESSAGE}\n`);
+      options.stdout.write(`${NO_FILES_MESSAGE}\n`);
       return;
     }
 
-    stdout.write(`${formatReport(result.metrics)}\n`);
+    options.stdout.write(`${formatReport(result.metrics)}\n`);
     if (result.thresholdExceeded) {
       const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${CRAP_THRESHOLD.toFixed(1)}`;
-      stderr.write(`${error}\n`);
+      options.stderr.write(`${error}\n`);
       process.exitCode = 1;
     }
   }
@@ -120,4 +119,26 @@ function ensureDefaultReporter(existing: VitestReporterEntry[]): VitestReporterE
 
 function buildCoverageReportPath(reportsDirectory: string | undefined): string {
   return `${reportsDirectory ?? "coverage"}/coverage-final.json`;
+}
+
+interface ResolvedReporterOptions {
+  projectRoot: string;
+  paths: string[];
+  changedOnly: boolean;
+  packageManager: PackageManagerSelection;
+  coverageReportPath: string | undefined;
+  stdout: Writer;
+  stderr: Writer;
+}
+
+function resolveReporterOptions(options: CrapTypescriptVitestOptions): ResolvedReporterOptions {
+  return {
+    projectRoot: options.projectRoot ?? process.cwd(),
+    paths: options.paths ?? [],
+    changedOnly: options.changedOnly ?? false,
+    packageManager: options.packageManager ?? "auto",
+    coverageReportPath: options.coverageReportPath,
+    stdout: options.stdout ?? process.stdout,
+    stderr: options.stderr ?? process.stderr
+  };
 }

--- a/packages/vitest/test/config.test.ts
+++ b/packages/vitest/test/config.test.ts
@@ -17,4 +17,23 @@ describe("withCrapTypescriptVitest", () => {
     expect(reporters?.[1]).toBeInstanceOf(CrapTypescriptVitestReporter);
     expect(coverageReporters).toEqual(["json", "text"]);
   });
+
+  it("preserves existing default reporters and augments single coverage reporter values", () => {
+    const config = withCrapTypescriptVitest({
+      test: {
+        reporters: ["default"],
+        coverage: {
+          reporter: "json",
+          reportsDirectory: "custom-coverage"
+        }
+      }
+    });
+
+    expect(config.test?.reporters).toEqual([
+      "default",
+      expect.any(CrapTypescriptVitestReporter)
+    ]);
+    expect(config.test?.coverage?.reporter).toEqual(["json", "text"]);
+    expect(config.test?.coverage?.reportsDirectory).toBe("custom-coverage");
+  });
 });

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "../../core/test/testUtils";
+import { CrapTypescriptVitestReporter } from "../src/index";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  process.exitCode = 0;
+  await Promise.all(tempDirs.splice(0).map(disposeTempDir));
+});
+
+describe("CrapTypescriptVitestReporter", () => {
+  it("prints the no-files message when no analyzable source files are selected", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}'
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    expect(stdout.toString()).toContain("No TypeScript files to analyze.");
+    expect(stderr.toString()).toBe("");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints the CRAP report and sets a failure exit code when the threshold is exceeded", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function risky(flagA: boolean, flagB: boolean): number {
+  if (flagA && flagB) {
+    return 1;
+  }
+  return 0;
+}
+`,
+      "custom-coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 3, column: 4 },
+              end: { line: 3, column: 13 }
+            },
+            "1": {
+              start: { line: 5, column: 2 },
+              end: { line: 5, column: 11 }
+            }
+          },
+          fnMap: {},
+          branchMap: {
+            "0": {
+              line: 2,
+              type: "if",
+              loc: {
+                start: { line: 2, column: 2 },
+                end: { line: 4, column: 3 }
+              },
+              locations: [
+                {
+                  start: { line: 2, column: 2 },
+                  end: { line: 4, column: 3 }
+                },
+                {}
+              ]
+            },
+            "1": {
+              line: 2,
+              type: "binary-expr",
+              loc: {
+                start: { line: 2, column: 6 },
+                end: { line: 2, column: 31 }
+              },
+              locations: [
+                {
+                  start: { line: 2, column: 6 },
+                  end: { line: 2, column: 20 }
+                },
+                {
+                  start: { line: 2, column: 24 },
+                  end: { line: 2, column: 29 }
+                }
+              ]
+            }
+          },
+          s: {
+            "0": 0,
+            "1": 0
+          },
+          f: {},
+          b: {
+            "0": [0, 0],
+            "1": [0, 0]
+          }
+        }
+      })
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      changedOnly: false,
+      packageManager: "npm",
+      coverageReportPath: "custom-coverage/coverage-final.json",
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    expect(stdout.toString()).toContain("risky");
+    expect(stderr.toString()).toContain("CRAP threshold exceeded");
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/vitest.crap.config.ts
+++ b/vitest.crap.config.ts
@@ -1,0 +1,9 @@
+import { withCrapTypescriptVitest } from "@barney-media/crap-typescript-vitest";
+
+import baseConfig from "./vitest.config";
+
+export default withCrapTypescriptVitest(baseConfig, {
+  packageManager: "npm",
+  paths: ["packages"],
+  projectRoot: process.cwd()
+});


### PR DESCRIPTION
Closes #33

## Summary

- add a dedicated `npm run crap-typescript-check` command and root Vitest gate config
- add a separate `crap-typescript Gate` job to the build workflow
- refactor high-CRAP internals and expand tests so the repository passes its own gate
- document the new local gate command in the README

## Test plan

- [x] `npm test`
- [x] `npm run crap-typescript-check`