### PR TITLE
Prepare v0.2.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Verify release versions
         run: npm run verify-release-version
 
+      - name: Render release notes
+        run: npm run render-release-notes -- "${GITHUB_REF_NAME}" > release-notes.md
+
       - name: Run build and tests
         run: npm test
 
@@ -57,16 +60,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          version="${GITHUB_REF_NAME#v}"
-          cat > release-notes.md <<EOF
-          ## Packages
-
-          - \`@barney-media/crap-typescript-core@${version}\`
-          - \`@barney-media/crap-typescript@${version}\`
-          - \`@barney-media/crap-typescript-vitest@${version}\`
-          - \`@barney-media/crap-typescript-jest@${version}\`
-          EOF
-
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
             gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.md
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+
+- No unreleased changes.
+
+## [0.2.2] - 2026-04-10
+
+### Fixed
+
+- Improved fnMap attribution, including unmatched fallback handling when mapping Istanbul coverage to TypeScript functions.
+- Made coverage path handling and compatibility-matrix coverage fixtures work across Windows absolute paths and cross-platform test environments.
+
+### Changed
+
+- Added direct self-gate coverage for the Jest adapter so repository gating exercises the published Jest integration path.
+
+## [0.2.1] - 2026-04-08
+
+### Changed
+
+- Switched npm publishing to pure Trusted Publishing.
+- Documented release provenance behavior for published packages.
+
+## [0.2.0] - 2026-04-08
+
+### Added
+
+- Published the initial `@barney-media` package set for the CLI, core library, and Vitest and Jest adapters.
+
+### Fixed
+
+- Corrected the release package contents for the first public `@barney-media` release line.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ module.exports = withCrapTypescriptJest({
 
 ## Release
 
-Tag `v<version>` from `main` after the build workflow is green. The tag-triggered release workflow verifies the package versions, publishes the four npm packages, and creates the GitHub release.
+Update `CHANGELOG.md` with the tagged version entry before releasing. Tag `v<version>` from `main` after the build workflow is green. The tag-triggered release workflow verifies the package versions, renders the GitHub release notes from `CHANGELOG.md`, publishes the four npm packages, and creates the GitHub release.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crap-typescript-parent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crap-typescript-parent",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5360,10 +5360,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/crap-typescript",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.1"
+        "@barney-media/crap-typescript-core": "^0.2.2"
       },
       "bin": {
         "crap-typescript": "dist/bin.js"
@@ -5374,7 +5374,7 @@
     },
     "packages/core": {
       "name": "@barney-media/crap-typescript-core",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "typescript": "^6.0.2"
@@ -5385,10 +5385,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/crap-typescript-jest",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.1"
+        "@barney-media/crap-typescript-core": "^0.2.2"
       },
       "engines": {
         "node": ">=18"
@@ -5399,10 +5399,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/crap-typescript-vitest",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.1"
+        "@barney-media/crap-typescript-core": "^0.2.2"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crap-typescript-parent",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CRAP metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -25,6 +25,7 @@
     "crap-typescript-check": "npm run build && vitest run --config vitest.crap.config.ts",
     "test": "npm run build && vitest run",
     "pack": "npm pack --workspaces",
+    "render-release-notes": "node ./scripts/render-release-notes.mjs",
     "verify-release-version": "node ./scripts/verify-release-version.mjs"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for CRAP metric analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -44,6 +44,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.2.1"
+    "@barney-media/crap-typescript-core": "^0.2.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Core CRAP metric analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-jest",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Jest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -44,7 +44,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.2.1"
+    "@barney-media/crap-typescript-core": "^0.2.2"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-vitest",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Vitest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -40,7 +40,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.2.1"
+    "@barney-media/crap-typescript-core": "^0.2.2"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"

--- a/scripts/render-release-notes.mjs
+++ b/scripts/render-release-notes.mjs
@@ -1,0 +1,33 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const tagRef = process.env.GITHUB_REF_NAME ?? process.argv[2];
+if (!tagRef) {
+  throw new Error("A tag name is required.");
+}
+
+const expectedVersion = tagRef.startsWith("v") ? tagRef.slice(1) : tagRef;
+const changelog = await readFile(path.resolve("CHANGELOG.md"), "utf8");
+const lines = changelog.replace(/\r\n/g, "\n").split("\n");
+const sectionHeader = `## [${expectedVersion}]`;
+const startIndex = lines.findIndex((line) => line.startsWith(sectionHeader));
+
+if (startIndex === -1) {
+  throw new Error(`CHANGELOG.md does not contain a section for ${expectedVersion}.`);
+}
+
+const sectionLines = [];
+for (let index = startIndex + 1; index < lines.length; index += 1) {
+  const line = lines[index];
+  if (line.startsWith("## [")) {
+    break;
+  }
+  sectionLines.push(line);
+}
+
+const releaseNotes = sectionLines.join("\n").trim();
+if (!releaseNotes) {
+  throw new Error(`CHANGELOG.md section ${expectedVersion} is empty.`);
+}
+
+process.stdout.write(`${releaseNotes}\n`);

--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -7,18 +7,18 @@ if (!tagRef) {
 }
 
 const expectedVersion = tagRef.startsWith("v") ? tagRef.slice(1) : tagRef;
-const packageFiles = [
+const versionFiles = [
+  "package.json",
   "packages/core/package.json",
   "packages/cli/package.json",
   "packages/vitest/package.json",
   "packages/jest/package.json"
 ];
 
-for (const packageFile of packageFiles) {
-  const raw = await readFile(path.resolve(packageFile), "utf8");
+for (const versionFile of versionFiles) {
+  const raw = await readFile(path.resolve(versionFile), "utf8");
   const parsed = JSON.parse(raw);
   if (parsed.version !== expectedVersion) {
-    throw new Error(`${packageFile} has version ${parsed.version}, expected ${expectedVersion}`);
+    throw new Error(`${versionFile} has version ${parsed.version}, expected ${expectedVersion}`);
   }
 }
-


### PR DESCRIPTION
## Summary
- bump the workspace packages to v0.2.2
- add a root changelog and render GitHub release notes from it
- document and enforce the release metadata used by the tag workflow

## Testing
- npm run render-release-notes -- v0.2.2
- npm run verify-release-version -- v0.2.2
- npm test
- npm run crap-typescript-check
- npm pack --workspaces