### PR TITLE
Fix release notes rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm run verify-release-version
 
       - name: Render release notes
-        run: npm run render-release-notes -- "${GITHUB_REF_NAME}" > release-notes.md
+        run: node ./scripts/render-release-notes.mjs "${GITHUB_REF_NAME}" > release-notes.md
 
       - name: Run build and tests
         run: npm test


### PR DESCRIPTION
## Summary
- call the release-notes renderer directly in the workflow
- avoid `npm run` wrapper output in GitHub release bodies

## Testing
- node ./scripts/render-release-notes.mjs v0.2.2