### PR TITLE
#9 add cognitive-typescript Gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,29 @@ jobs:
       - name: Verify workspace packages
         run: npm pack --workspaces
 
+  cognitive-typescript-gate:
+    name: cognitive-typescript Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run cognitive-typescript gate
+        run: npm run cognitive-typescript-check
+
   crap-typescript-gate:
     name: crap-typescript Gate
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "build": "tsc -b packages/core packages/cli packages/vitest packages/jest",
+    "cognitive-typescript-check": "node ./scripts/run-cognitive-typescript-gate.mjs packages",
     "crap-typescript-check": "npm run build && vitest run --config vitest.crap.config.ts",
     "test": "npm run build && vitest run",
     "pack": "npm pack --workspaces",

--- a/scripts/run-cognitive-typescript-gate.mjs
+++ b/scripts/run-cognitive-typescript-gate.mjs
@@ -1,0 +1,43 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const targets = process.argv.slice(2);
+
+if (targets.length === 0) {
+  console.error("Usage: node ./scripts/run-cognitive-typescript-gate.mjs <path...>");
+  process.exit(1);
+}
+
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const temporaryDirectory = mkdtempSync(join(tmpdir(), "cognitive-typescript-gate-"));
+
+try {
+  // Run the published CLI outside the repo so local workspaces never shadow npmjs.
+  const result = spawnSync(
+    npmCommand,
+    [
+      "exec",
+      "--yes",
+      "--package=@barney-media/cognitive-typescript@0.1.1",
+      "--",
+      "cognitive-typescript",
+      ...targets.map((target) => resolve(target))
+    ],
+    {
+      cwd: temporaryDirectory,
+      shell: process.platform === "win32",
+      stdio: "inherit"
+    }
+  );
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+
+  process.exit(result.status ?? 1);
+} finally {
+  rmSync(temporaryDirectory, { force: true, recursive: true });
+}

--- a/scripts/run-cognitive-typescript-gate.mjs
+++ b/scripts/run-cognitive-typescript-gate.mjs
@@ -10,34 +10,33 @@ if (targets.length === 0) {
   process.exit(1);
 }
 
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const gateArguments = [
+  "exec",
+  "--yes",
+  "--package=@barney-media/cognitive-typescript@0.1.1",
+  "--",
+  "cognitive-typescript",
+  ...targets.map((target) => resolve(target))
+];
+const npmCommand = process.env.npm_execpath ? process.execPath : process.platform === "win32" ? "npm.cmd" : "npm";
+const npmArguments = process.env.npm_execpath ? [process.env.npm_execpath, ...gateArguments] : gateArguments;
 const temporaryDirectory = mkdtempSync(join(tmpdir(), "cognitive-typescript-gate-"));
+let exitCode = 1;
 
 try {
   // Run the published CLI outside the repo so local workspaces never shadow npmjs.
-  const result = spawnSync(
-    npmCommand,
-    [
-      "exec",
-      "--yes",
-      "--package=@barney-media/cognitive-typescript@0.1.1",
-      "--",
-      "cognitive-typescript",
-      ...targets.map((target) => resolve(target))
-    ],
-    {
-      cwd: temporaryDirectory,
-      shell: process.platform === "win32",
-      stdio: "inherit"
-    }
-  );
+  const result = spawnSync(npmCommand, npmArguments, {
+    cwd: temporaryDirectory,
+    stdio: "inherit"
+  });
 
   if (result.error) {
     console.error(result.error.message);
-    process.exit(1);
+  } else {
+    exitCode = result.status ?? 1;
   }
-
-  process.exit(result.status ?? 1);
 } finally {
   rmSync(temporaryDirectory, { force: true, recursive: true });
 }
+
+process.exitCode = exitCode;


### PR DESCRIPTION
Refs fabian-barney/cognitive-typescript#9

## Summary
- add a dedicated `cognitive-typescript Gate` job to the build workflow
- standardize the gate on the published `@barney-media/cognitive-typescript@0.1.1` CLI via the shared helper script
- keep the existing build and CRAP gate behavior unchanged

## Validation
- npm run cognitive-typescript-check
- npm test