### PR TITLE
Add Karma/Jasmine support for Angular/Ionic projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
-- No unreleased changes.
+### Added
+
+- Added CLI support for Angular CLI Karma/Jasmine coverage runs through `--test-runner karma`.
+- Added `--coverage-report-path` so projects with custom or nested Istanbul JSON output can point the CLI at the generated report.
 
 ## [0.2.2] - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `crap-typescript` is a shared CRAP metric toolkit for TypeScript projects.
 
-It combines cyclomatic complexity with function-level coverage derived from Istanbul statement and branch counters and reports CRAP scores for concrete TypeScript function bodies. The repository publishes a standalone CLI plus dedicated Vitest and Jest adapters.
+It combines cyclomatic complexity with function-level coverage derived from Istanbul statement and branch counters and reports CRAP scores for concrete TypeScript function bodies. The repository publishes a standalone CLI plus dedicated Vitest and Jest adapters. The CLI can also drive Angular CLI Karma/Jasmine test suites when they emit Istanbul JSON coverage.
 
 ## Modules
 
@@ -83,7 +83,9 @@ npx crap-typescript
 (no args)                    Analyze all TypeScript files under any nested src/ tree
 --changed                    Analyze changed TypeScript files under src/
 --package-manager <tool>     Force auto, npm, pnpm, or yarn
---test-runner <runner>       Force auto, vitest, or jest
+--test-runner <runner>       Force auto, vitest, jest, or karma
+--coverage-report-path <path>
+                             Reuse or generate a custom Istanbul JSON coverage report path
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
@@ -95,6 +97,7 @@ npx crap-typescript --help
 npx crap-typescript
 npx crap-typescript --changed
 npx crap-typescript --package-manager npm --test-runner vitest
+npx crap-typescript --test-runner karma --coverage-report-path coverage/app/coverage-final.json
 npx crap-typescript src/sample.ts
 npx crap-typescript packages/api packages/web
 ```
@@ -121,6 +124,25 @@ const { withCrapTypescriptJest } = require("@barney-media/crap-typescript-jest")
 module.exports = withCrapTypescriptJest({
   testEnvironment: "node"
 });
+```
+
+Karma/Jasmine for Angular or Ionic:
+
+```bash
+npx crap-typescript --test-runner karma
+```
+
+The Karma path runs `ng test --watch=false --code-coverage`, then reads Istanbul JSON from `coverage/coverage-final.json` unless `--coverage-report-path` is provided. For older Angular/Karma projects, make sure `karma.conf.js` writes JSON coverage at that path:
+
+```js
+coverageReporter: {
+  dir: require("path").join(__dirname, "./coverage"),
+  reporters: [
+    { type: "html" },
+    { type: "text-summary" },
+    { type: "json", subdir: ".", file: "coverage-final.json" }
+  ]
+}
 ```
 
 ## Exit Codes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,6 +13,7 @@ npm install --save-dev @barney-media/crap-typescript
 ```bash
 npx crap-typescript
 npx crap-typescript --changed
+npx crap-typescript --test-runner karma --coverage-report-path coverage/app/coverage-final.json
 npx crap-typescript src/sample.ts
 npx crap-typescript packages/api packages/web
 ```
@@ -24,7 +25,8 @@ npx crap-typescript packages/api packages/web
 (no args)                    Analyze all TypeScript files under any nested src/ tree
 --changed                    Analyze changed TypeScript files under src/
 --package-manager <tool>     Force auto, npm, pnpm, or yarn
---test-runner <runner>       Force auto, vitest, or jest
+--test-runner <runner>       Force auto, vitest, jest, or karma
+--coverage-report-path <path> Reuse or generate a custom Istanbul JSON coverage report path
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -10,14 +10,16 @@ const HELP_TEXT = `crap-typescript
 
 Usage:
   crap-typescript [--help]
-  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>]
-  crap-typescript [--package-manager <tool>] [--test-runner <runner>] <path ...>
+  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>] [--coverage-report-path <path>]
+  crap-typescript [--package-manager <tool>] [--test-runner <runner>] [--coverage-report-path <path>] <path ...>
 
 Options:
   --help                     Print usage to stdout
   --changed                  Analyze changed TypeScript files under src/
   --package-manager <tool>   Force auto, npm, pnpm, or yarn
-  --test-runner <runner>     Force auto, vitest, or jest
+  --test-runner <runner>     Force auto, vitest, jest, or karma
+  --coverage-report-path <path>
+                             Reuse or generate a custom Istanbul JSON coverage report path
 
 Behavior:
   (no args)                  Analyze all TypeScript files under any nested src/ tree
@@ -58,8 +60,10 @@ interface ParseState {
   changed: boolean;
   packageManager: PackageManagerSelection;
   testRunner: TestRunnerSelection;
+  coverageReportPath?: string;
   packageManagerSeen: boolean;
   testRunnerSeen: boolean;
+  coverageReportPathSeen: boolean;
   fileArgs: string[];
 }
 
@@ -85,6 +89,12 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = {
     state.testRunner = parseTestRunnerSelection(args[index + 1]);
     state.testRunnerSeen = true;
     return index + 1;
+  },
+  "--coverage-report-path": (state, args, index) => {
+    ensureOptionIsUnique(state.coverageReportPathSeen, "--coverage-report-path");
+    state.coverageReportPath = parseCoverageReportPath(args[index + 1]);
+    state.coverageReportPathSeen = true;
+    return index + 1;
   }
 };
 
@@ -94,8 +104,10 @@ function createParseState(): ParseState {
     changed: false,
     packageManager: "auto",
     testRunner: "auto",
+    coverageReportPath: undefined,
     packageManagerSeen: false,
     testRunnerSeen: false,
+    coverageReportPathSeen: false,
     fileArgs: []
   };
 }
@@ -120,7 +132,8 @@ function finalizeCliArguments(state: ParseState): CliArguments {
       mode: "help",
       fileArgs: [],
       packageManager: state.packageManager,
-      testRunner: state.testRunner
+      testRunner: state.testRunner,
+      ...coverageReportPathArgument(state)
     };
   }
   if (state.changed && state.fileArgs.length > 0) {
@@ -130,8 +143,13 @@ function finalizeCliArguments(state: ParseState): CliArguments {
     mode: state.changed ? "changed" : state.fileArgs.length > 0 ? "explicit" : "all",
     fileArgs: state.fileArgs,
     packageManager: state.packageManager,
-    testRunner: state.testRunner
+    testRunner: state.testRunner,
+    ...coverageReportPathArgument(state)
   };
+}
+
+function coverageReportPathArgument(state: ParseState): Pick<CliArguments, "coverageReportPath"> {
+  return state.coverageReportPath === undefined ? {} : { coverageReportPath: state.coverageReportPath };
 }
 
 function parsePackageManagerSelection(value: string | undefined): PackageManagerSelection {
@@ -146,12 +164,19 @@ function parsePackageManagerSelection(value: string | undefined): PackageManager
 
 function parseTestRunnerSelection(value: string | undefined): TestRunnerSelection {
   if (!value) {
-    throw new Error("--test-runner requires one of: auto, vitest, jest");
+    throw new Error("--test-runner requires one of: auto, vitest, jest, karma");
   }
-  if (value === "auto" || value === "vitest" || value === "jest") {
+  if (value === "auto" || value === "vitest" || value === "jest" || value === "karma") {
     return value;
   }
-  throw new Error("--test-runner requires one of: auto, vitest, jest");
+  throw new Error("--test-runner requires one of: auto, vitest, jest, karma");
+}
+
+function parseCoverageReportPath(value: string | undefined): string {
+  if (!value) {
+    throw new Error("--coverage-report-path requires a path");
+  }
+  return value;
 }
 
 export async function runCli(
@@ -195,6 +220,7 @@ async function analyzeCliProject(
       changedOnly: parsed.mode === "changed",
       packageManager: parsed.packageManager,
       testRunner: parsed.testRunner,
+      coverageReportPath: parsed.coverageReportPath,
       stdout,
       stderr
     });

--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -43,13 +43,26 @@ export function buildCoverageCommand(
 ): CoverageCommand {
   return {
     command: packageManager,
-    args: testRunner === "vitest"
-      ? vitestArguments(packageManager, coverageReportPath)
-      : jestArguments(packageManager, coverageReportPath),
+    args: coverageArguments(packageManager, testRunner, coverageReportPath),
     cwd,
     packageManager,
     testRunner
   };
+}
+
+function coverageArguments(
+  packageManager: PackageManager,
+  testRunner: TestRunner,
+  coverageReportPath: string
+): string[] {
+  switch (testRunner) {
+    case "vitest":
+      return vitestArguments(packageManager, coverageReportPath);
+    case "jest":
+      return jestArguments(packageManager, coverageReportPath);
+    case "karma":
+      return karmaArguments(packageManager);
+  }
 }
 
 async function resolveExistingCoverage(
@@ -157,6 +170,36 @@ function jestArguments(packageManager: PackageManager, coverageReportPath: strin
         "--coverageReporters=json",
         "--coverageReporters=text",
         `--coverageDirectory=${coverageDirectory}`
+      ];
+  }
+}
+
+function karmaArguments(packageManager: PackageManager): string[] {
+  switch (packageManager) {
+    case "npm":
+      return [
+        "exec",
+        "--no",
+        "--",
+        "ng",
+        "test",
+        "--watch=false",
+        "--code-coverage"
+      ];
+    case "pnpm":
+      return [
+        "exec",
+        "ng",
+        "test",
+        "--watch=false",
+        "--code-coverage"
+      ];
+    case "yarn":
+      return [
+        "ng",
+        "test",
+        "--watch=false",
+        "--code-coverage"
       ];
   }
 }

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -130,10 +130,18 @@ function detectRunnerFromDependencies(packageJson: PackageJsonShape): TestRunner
 function detectSingleRunner(text: string): TestRunner | null {
   const hasVitest = /\bvitest\b/.test(text);
   const hasJest = /\bjest\b/.test(text) || /\bts-jest\b/.test(text);
-  if (hasVitest === hasJest) {
-    return null;
+  const hasKarma = /\bkarma\b/.test(text);
+  const detected: TestRunner[] = [];
+  if (hasVitest) {
+    detected.push("vitest");
   }
-  return hasVitest ? "vitest" : "jest";
+  if (hasJest) {
+    detected.push("jest");
+  }
+  if (hasKarma) {
+    detected.push("karma");
+  }
+  return detected.length === 1 ? detected[0] : null;
 }
 
 async function readPackageJson(root: string): Promise<PackageJsonShape | null> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
 export type CliMode = "all" | "changed" | "explicit" | "help";
 export type PackageManager = "npm" | "pnpm" | "yarn";
 export type PackageManagerSelection = PackageManager | "auto";
-export type TestRunner = "vitest" | "jest";
+export type TestRunner = "vitest" | "jest" | "karma";
 export type TestRunnerSelection = TestRunner | "auto";
 export type CoverageMode = "auto" | "existing-only";
 export type CoverageStatus = "measured" | "structural_na" | "unknown";
@@ -35,6 +35,7 @@ export interface CliArguments {
   fileArgs: string[];
   packageManager: PackageManagerSelection;
   testRunner: TestRunnerSelection;
+  coverageReportPath?: string;
 }
 
 export interface MethodDescriptor {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -11,11 +11,20 @@ afterEach(async () => {
 
 describe("cli", () => {
   it("parses supported options", () => {
-    expect(parseCliArguments(["--changed", "--package-manager", "npm", "--test-runner", "vitest"])).toEqual({
+    expect(parseCliArguments([
+      "--changed",
+      "--package-manager",
+      "npm",
+      "--test-runner",
+      "karma",
+      "--coverage-report-path",
+      "coverage/app/coverage-final.json"
+    ])).toEqual({
       mode: "changed",
       fileArgs: [],
       packageManager: "npm",
-      testRunner: "vitest"
+      testRunner: "karma",
+      coverageReportPath: "coverage/app/coverage-final.json"
     });
   });
 
@@ -46,12 +55,13 @@ describe("cli", () => {
       "--test-runner can only be provided once"
     );
     expect(() => parseCliArguments(["--package-manager"])).toThrow("--package-manager requires one of: auto, npm, pnpm, yarn");
-    expect(() => parseCliArguments(["--test-runner"])).toThrow("--test-runner requires one of: auto, vitest, jest");
+    expect(() => parseCliArguments(["--test-runner"])).toThrow("--test-runner requires one of: auto, vitest, jest, karma");
+    expect(() => parseCliArguments(["--coverage-report-path"])).toThrow("--coverage-report-path requires a path");
     expect(() => parseCliArguments(["--package-manager", "bun"])).toThrow(
       "--package-manager requires one of: auto, npm, pnpm, yarn"
     );
     expect(() => parseCliArguments(["--test-runner", "mocha"])).toThrow(
-      "--test-runner requires one of: auto, vitest, jest"
+      "--test-runner requires one of: auto, vitest, jest, karma"
     );
     expect(() => parseCliArguments(["--unknown"])).toThrow("Unknown option: --unknown");
   });
@@ -228,6 +238,44 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const stdout = new StringWriter();
     const stderr = new StringWriter();
     const exitCode = await runCli([], projectRoot, stdout, stderr);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.toString()).toContain("safe");
+    expect(stderr.toString()).toBe("");
+  });
+
+  it("uses a custom coverage report path", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+`,
+      "coverage/app/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            }
+          },
+          fnMap: {},
+          branchMap: {},
+          s: {
+            "0": 1
+          },
+          f: {},
+          b: {}
+        }
+      })
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const exitCode = await runCli(["--coverage-report-path", "coverage/app/coverage-final.json"], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("safe");

--- a/packages/core/test/coverageCommand.test.ts
+++ b/packages/core/test/coverageCommand.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ensureCoverageReport, expectedCoveragePath } from "../src/coverage";
+import { buildCoverageCommand, ensureCoverageReport, expectedCoveragePath } from "../src/coverage";
 import type { CoverageCommand } from "../src/types";
 import { createTempDir, disposeTempDir, writeProjectFiles } from "./testUtils";
 
@@ -133,6 +133,48 @@ describe("ensureCoverageReport", () => {
       })
     ).rejects.toThrow("Coverage command failed with exit 3");
   });
+
+  it("auto-detects Angular Karma projects and executes ng test with coverage", async () => {
+    const projectRoot = await createTempDir("crap-coverage-command-");
+    tempDirs.push(projectRoot);
+    const moduleRoot = path.join(projectRoot, "packages", "mobile");
+
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"root","private":true}',
+      "package-lock.json": "{}",
+      "packages/mobile/package.json": JSON.stringify({
+        name: "mobile",
+        private: true,
+        devDependencies: {
+          "@angular/cli": "^18.0.0",
+          karma: "^6.4.0",
+          "karma-jasmine": "^5.1.0",
+          "jasmine-core": "^5.0.0"
+        }
+      })
+    });
+
+    const expectedCommand = buildCoverageCommand("npm", "karma", moduleRoot);
+    const executor = {
+      execute: vi.fn(async (command: CoverageCommand) => {
+        expect(command).toEqual(expectedCommand);
+
+        await writeProjectFiles(projectRoot, {
+          "packages/mobile/coverage/coverage-final.json": "{}"
+        });
+        return 0;
+      })
+    };
+
+    await expect(
+      ensureCoverageReport(projectRoot, moduleRoot, "auto", "auto", "auto", undefined, executor)
+    ).resolves.toEqual({
+      coverageSourcePath: path.join(moduleRoot, "coverage", "coverage-final.json"),
+      coverageSourceRoot: moduleRoot,
+      command: expectedCommand
+    });
+    expect(executor.execute).toHaveBeenCalledOnce();
+  });
 });
 
 describe("expectedCoveragePath", () => {
@@ -144,5 +186,38 @@ describe("expectedCoveragePath", () => {
     expect(expectedCoveragePath("C:/repo/packages/demo", "D:/coverage/coverage-final.json")).toBe(
       "D:/coverage/coverage-final.json"
     );
+  });
+});
+
+describe("buildCoverageCommand", () => {
+  it("builds Angular CLI Karma coverage commands", () => {
+    expect(buildCoverageCommand("npm", "karma", "C:/repo")).toEqual({
+      command: "npm",
+      args: [
+        "exec",
+        "--no",
+        "--",
+        "ng",
+        "test",
+        "--watch=false",
+        "--code-coverage"
+      ],
+      cwd: "C:/repo",
+      packageManager: "npm",
+      testRunner: "karma"
+    });
+    expect(buildCoverageCommand("pnpm", "karma", "C:/repo").args).toEqual([
+      "exec",
+      "ng",
+      "test",
+      "--watch=false",
+      "--code-coverage"
+    ]);
+    expect(buildCoverageCommand("yarn", "karma", "C:/repo").args).toEqual([
+      "ng",
+      "test",
+      "--watch=false",
+      "--code-coverage"
+    ]);
   });
 });

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -215,4 +215,39 @@ describe("resolveTestRunner", () => {
       resolveTestRunner("auto", missingModulePackageDir, `${missingModulePackageDir}/packages/demo`)
     ).resolves.toBe("vitest");
   });
+
+  it("detects Karma/Jasmine projects without treating Jasmine alone as Jest", async () => {
+    const tempDir = await createTempDir("crap-runner-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        devDependencies: {
+          "@angular/cli": "^18.0.0",
+          karma: "^6.4.0",
+          "karma-jasmine": "^5.1.0",
+          "jasmine-core": "^5.0.0"
+        }
+      })
+    });
+
+    await expect(resolveTestRunner("auto", tempDir, tempDir)).resolves.toBe("karma");
+
+    const jasmineOnlyDir = await createTempDir("crap-runner-");
+    tempDirs.push(jasmineOnlyDir);
+    await writeProjectFiles(jasmineOnlyDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        devDependencies: {
+          "jasmine-core": "^5.0.0"
+        }
+      })
+    });
+
+    await expect(resolveTestRunner("auto", jasmineOnlyDir, jasmineOnlyDir)).rejects.toThrow(
+      "Unable to detect a test runner"
+    );
+  });
 });

--- a/spec.md
+++ b/spec.md
@@ -45,7 +45,8 @@ The tool shall support these forms:
 It shall also accept optional overrides:
 
 - `--package-manager auto|npm|pnpm|yarn`
-- `--test-runner auto|vitest|jest`
+- `--test-runner auto|vitest|jest|karma`
+- `--coverage-report-path <path>`
 
 Invalid argument parsing shall exit with usage error and print the usage text.
 
@@ -108,6 +109,10 @@ For each module group, the tool shall:
 4. run the detected test command with JSON coverage enabled
 5. read the resulting `coverage/coverage-final.json`
 6. analyze the selected TypeScript files in that module
+
+When `--coverage-report-path` is supplied, the provided path replaces `coverage/coverage-final.json` for existing report lookup, generated report lookup, and warning messages.
+
+For the `karma` test runner, the tool shall target Angular CLI Karma/Jasmine projects by invoking `ng test --watch=false --code-coverage` through the selected package manager. The project is responsible for configuring Karma coverage to emit Istanbul JSON at the configured report path.
 
 If the expected coverage report is still missing after these steps:
 


### PR DESCRIPTION
Add Karma/Jasmine runner support for Angular/Ionic projects.

What changed:
- add `karma` as a supported test runner
- auto-detect Karma/Jasmine projects from package scripts and dependencies
- generate Angular CLI coverage commands via `ng test --watch=false --code-coverage`
- add `--coverage-report-path` for custom Istanbul JSON locations
- update docs and tests

Verification:
- `npm test`
- `npm run crap-typescript-check`

Closes #45