### PR TITLE
Add CI and agent-friendly CRAP report formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ npx crap-typescript
 --changed                    Analyze changed TypeScript files under src/
 --package-manager <tool>     Force auto, npm, pnpm, or yarn
 --test-runner <runner>       Force auto, vitest, or jest
+--format <format>            Emit toon, json, text, or junit (default: toon)
+--agent                      Emit only overall status and failed methods for toon, json, or text
+--output <path>              Write the primary report to a file instead of stdout
+--junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
@@ -95,9 +99,21 @@ npx crap-typescript --help
 npx crap-typescript
 npx crap-typescript --changed
 npx crap-typescript --package-manager npm --test-runner vitest
+npx crap-typescript --format json --output reports/crap.json
+npx crap-typescript --agent --junit-report reports/crap-junit.xml
 npx crap-typescript src/sample.ts
 npx crap-typescript packages/api packages/web
 ```
+
+## Report Formats
+
+The CLI defaults to TOON output for compact, agent-readable reports. `--format` can select `toon`, `json`, `text`, or `junit`.
+
+All report formats expose only one overall result value: `status`, either `passed` or `failed`. Per-function entries carry the details: method status, CRAP score, threshold, complexity, coverage percent, coverage kind, source path, and line range.
+
+`--agent` is a filtering mode, not a report format. It is available with `toon`, `json`, and `text`; it keeps the overall `status`, includes failed methods only, and omits method-level `status` because included method entries are implicitly failed.
+
+Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit output keeps the aggregate XML attributes required by CI parsers and puts CRAP-specific details on each testcase.
 
 ## Adapter Usage
 
@@ -113,6 +129,8 @@ module.exports = withCrapTypescriptVitest({
 });
 ```
 
+The Vitest adapter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `junitReportPath: false` to disable the JUnit artifact.
+
 Jest:
 
 ```js
@@ -122,6 +140,8 @@ module.exports = withCrapTypescriptJest({
   testEnvironment: "node"
 });
 ```
+
+The Jest adapter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `junitReportPath: false` to disable the JUnit artifact.
 
 ## Exit Codes
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,6 +13,8 @@ npm install --save-dev @barney-media/crap-typescript
 ```bash
 npx crap-typescript
 npx crap-typescript --changed
+npx crap-typescript --format json --output reports/crap.json
+npx crap-typescript --agent --junit-report reports/crap-junit.xml
 npx crap-typescript src/sample.ts
 npx crap-typescript packages/api packages/web
 ```
@@ -25,9 +27,15 @@ npx crap-typescript packages/api packages/web
 --changed                    Analyze changed TypeScript files under src/
 --package-manager <tool>     Force auto, npm, pnpm, or yarn
 --test-runner <runner>       Force auto, vitest, or jest
+--format <format>            Emit toon, json, text, or junit (default: toon)
+--agent                      Emit only overall status and failed methods for toon, json, or text
+--output <path>              Write the primary report to a file instead of stdout
+--junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
+
+The default `toon` format is compact and agent-readable. `--agent` is a filtering mode, not a format: it keeps the overall `status`, includes failed method entries only, and omits method-level `status`.
 
 ## Exit Codes
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,14 +11,16 @@ npm install @barney-media/crap-typescript-core
 ## API
 
 ```ts
-import { analyzeProject, formatReport } from "@barney-media/crap-typescript-core";
+import { analyzeProject, formatAnalysisReport } from "@barney-media/crap-typescript-core";
 
 const result = await analyzeProject({ projectRoot: "." });
-const report = formatReport(result.metrics);
+const report = formatAnalysisReport(result.metrics, { format: "toon" });
 console.log(report);
 ```
 
-Key exports: `analyzeProject`, `calculateCrapScore`, `formatReport`, `parseCoverageReport`, `parseFileMethods`.
+Key exports: `analyzeProject`, `calculateCrapScore`, `formatAnalysisReport`, `formatReport`, `parseCoverageReport`, `parseFileMethods`.
+
+`formatAnalysisReport` supports `toon`, `json`, `text`, and `junit`. The root report has only overall `status`; method-level entries contain CRAP score, threshold, complexity, coverage percent, coverage kind, source path, and line range. Pass `agent: true` with `toon`, `json`, or `text` to include failed methods only.
 
 ## Formula
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,23 +1,28 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { CRAP_THRESHOLD, NO_ANALYZABLE_FUNCTIONS_MESSAGE, NO_FILES_MESSAGE } from "./constants";
+import { CRAP_THRESHOLD } from "./constants";
 import { analyzeProject } from "./analyzeProject";
-import { formatReport } from "./report";
+import { formatAnalysisReport } from "./report";
 import { formatNumber, writeLine } from "./utils";
-import type { CliArguments, PackageManagerSelection, TestRunnerSelection, Writer } from "./types";
+import type { CliArguments, PackageManagerSelection, ReportFormat, TestRunnerSelection, Writer } from "./types";
 
 const HELP_TEXT = `crap-typescript
 
 Usage:
   crap-typescript [--help]
-  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>]
-  crap-typescript [--package-manager <tool>] [--test-runner <runner>] <path ...>
+  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>]
+  crap-typescript [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>] <path ...>
 
 Options:
   --help                     Print usage to stdout
   --changed                  Analyze changed TypeScript files under src/
   --package-manager <tool>   Force auto, npm, pnpm, or yarn
   --test-runner <runner>     Force auto, vitest, or jest
+  --format <format>          Emit toon, json, text, or junit (default: toon)
+  --agent                    Emit only overall status and failed methods for toon, json, or text
+  --output <path>            Write the primary report to a file instead of stdout
+  --junit-report <path>      Also write a full JUnit XML report for CI test-report UIs
 
 Behavior:
   (no args)                  Analyze all TypeScript files under any nested src/ tree
@@ -30,15 +35,6 @@ export function usage(): string {
 }
 
 export function parseCliArguments(args: string[]): CliArguments {
-  if (args.length === 0) {
-    return {
-      mode: "all",
-      fileArgs: [],
-      packageManager: "auto",
-      testRunner: "auto"
-    };
-  }
-
   const state = createParseState();
 
   for (let index = 0; index < args.length; index += 1) {
@@ -58,8 +54,16 @@ interface ParseState {
   changed: boolean;
   packageManager: PackageManagerSelection;
   testRunner: TestRunnerSelection;
+  format: ReportFormat;
+  agent: boolean;
+  outputPath?: string;
+  junitReportPath?: string;
   packageManagerSeen: boolean;
   testRunnerSeen: boolean;
+  formatSeen: boolean;
+  agentSeen: boolean;
+  outputPathSeen: boolean;
+  junitReportPathSeen: boolean;
   fileArgs: string[];
 }
 
@@ -74,6 +78,12 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = {
     state.changed = true;
     return index;
   },
+  "--agent": (state, _args, index) => {
+    ensureOptionIsUnique(state.agentSeen, "--agent");
+    state.agent = true;
+    state.agentSeen = true;
+    return index;
+  },
   "--package-manager": (state, args, index) => {
     ensureOptionIsUnique(state.packageManagerSeen, "--package-manager");
     state.packageManager = parsePackageManagerSelection(args[index + 1]);
@@ -85,6 +95,24 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = {
     state.testRunner = parseTestRunnerSelection(args[index + 1]);
     state.testRunnerSeen = true;
     return index + 1;
+  },
+  "--format": (state, args, index) => {
+    ensureOptionIsUnique(state.formatSeen, "--format");
+    state.format = parseReportFormat(args[index + 1]);
+    state.formatSeen = true;
+    return index + 1;
+  },
+  "--output": (state, args, index) => {
+    ensureOptionIsUnique(state.outputPathSeen, "--output");
+    state.outputPath = parsePathOption(args[index + 1], "--output");
+    state.outputPathSeen = true;
+    return index + 1;
+  },
+  "--junit-report": (state, args, index) => {
+    ensureOptionIsUnique(state.junitReportPathSeen, "--junit-report");
+    state.junitReportPath = parsePathOption(args[index + 1], "--junit-report");
+    state.junitReportPathSeen = true;
+    return index + 1;
   }
 };
 
@@ -94,8 +122,16 @@ function createParseState(): ParseState {
     changed: false,
     packageManager: "auto",
     testRunner: "auto",
+    format: "toon",
+    agent: false,
+    outputPath: undefined,
+    junitReportPath: undefined,
     packageManagerSeen: false,
     testRunnerSeen: false,
+    formatSeen: false,
+    agentSeen: false,
+    outputPathSeen: false,
+    junitReportPathSeen: false,
     fileArgs: []
   };
 }
@@ -115,23 +151,41 @@ function ensureOptionIsUnique(seen: boolean, option: string): void {
 }
 
 function finalizeCliArguments(state: ParseState): CliArguments {
-  if (state.help) {
-    return {
-      mode: "help",
-      fileArgs: [],
-      packageManager: state.packageManager,
-      testRunner: state.testRunner
-    };
-  }
+  validateCliState(state);
+
+  return {
+    mode: cliMode(state),
+    fileArgs: state.help ? [] : state.fileArgs,
+    packageManager: state.packageManager,
+    testRunner: state.testRunner,
+    format: state.format,
+    agent: state.agent,
+    ...optionalPath("outputPath", state.outputPath),
+    ...optionalPath("junitReportPath", state.junitReportPath)
+  };
+}
+
+function validateCliState(state: ParseState): void {
   if (state.changed && state.fileArgs.length > 0) {
     throw new Error("--changed cannot be combined with file arguments");
   }
-  return {
-    mode: state.changed ? "changed" : state.fileArgs.length > 0 ? "explicit" : "all",
-    fileArgs: state.fileArgs,
-    packageManager: state.packageManager,
-    testRunner: state.testRunner
-  };
+  if (!state.help && state.agent && state.format === "junit") {
+    throw new Error("--agent cannot be combined with --format junit");
+  }
+}
+
+function cliMode(state: ParseState): CliArguments["mode"] {
+  if (state.help) {
+    return "help";
+  }
+  if (state.changed) {
+    return "changed";
+  }
+  return state.fileArgs.length > 0 ? "explicit" : "all";
+}
+
+function optionalPath<K extends "outputPath" | "junitReportPath">(key: K, value: string | undefined): Pick<CliArguments, K> | {} {
+  return value === undefined ? {} : { [key]: value } as Pick<CliArguments, K>;
 }
 
 function parsePackageManagerSelection(value: string | undefined): PackageManagerSelection {
@@ -154,6 +208,23 @@ function parseTestRunnerSelection(value: string | undefined): TestRunnerSelectio
   throw new Error("--test-runner requires one of: auto, vitest, jest");
 }
 
+function parseReportFormat(value: string | undefined): ReportFormat {
+  if (!value) {
+    throw new Error("--format requires one of: toon, json, text, junit");
+  }
+  if (value === "toon" || value === "json" || value === "text" || value === "junit") {
+    return value;
+  }
+  throw new Error("--format requires one of: toon, json, text, junit");
+}
+
+function parsePathOption(value: string | undefined, option: string): string {
+  if (!value) {
+    throw new Error(`${option} requires a path`);
+  }
+  return value;
+}
+
 export async function runCli(
   args: string[],
   projectRoot = process.cwd(),
@@ -169,7 +240,7 @@ export async function runCli(
     return 0;
   }
 
-  return handleCliResult(await analyzeCliProject(parsed, projectRoot, stdout, stderr), stdout, stderr);
+  return handleCliResult(await analyzeCliProject(parsed, projectRoot, stdout, stderr), parsed, projectRoot, stdout, stderr);
 }
 
 function parseCliInputs(args: string[], stdout: Writer, stderr: Writer): CliArguments | number {
@@ -204,37 +275,52 @@ async function analyzeCliProject(
   }
 }
 
-function handleCliResult(
+async function handleCliResult(
   result: Awaited<ReturnType<typeof analyzeProject>> | null,
+  parsed: CliArguments,
+  projectRoot: string,
   stdout: Writer,
   stderr: Writer
-): number {
+): Promise<number> {
   if (!result) {
     return 1;
   }
 
-  const earlyExit = writeCliEarlyExit(result, stdout);
-  if (earlyExit !== null) {
-    return earlyExit;
+  try {
+    await writeCliReports(result.metrics, parsed, projectRoot, stdout);
+  } catch (error) {
+    writeLine(stderr, (error as Error).message);
+    return 1;
   }
 
-  writeLine(stdout, formatReport(result.metrics));
   return writeCliThresholdStatus(result, stderr);
 }
 
-function writeCliEarlyExit(
-  result: Awaited<ReturnType<typeof analyzeProject>>,
+async function writeCliReports(
+  metrics: Awaited<ReturnType<typeof analyzeProject>>["metrics"],
+  parsed: CliArguments,
+  projectRoot: string,
   stdout: Writer
-): number | null {
-  if (result.selectedFiles.length === 0) {
-    writeLine(stdout, NO_FILES_MESSAGE);
-    return 0;
+): Promise<void> {
+  const primaryReport = formatAnalysisReport(metrics, {
+    format: parsed.format,
+    agent: parsed.agent
+  });
+  if (parsed.outputPath) {
+    await writeReportFile(projectRoot, parsed.outputPath, primaryReport);
+  } else {
+    stdout.write(primaryReport);
   }
-  if (result.metrics.length === 0) {
-    writeLine(stdout, NO_ANALYZABLE_FUNCTIONS_MESSAGE);
-    return 0;
+
+  if (parsed.junitReportPath) {
+    await writeReportFile(projectRoot, parsed.junitReportPath, formatAnalysisReport(metrics, { format: "junit" }));
   }
-  return null;
+}
+
+async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
+  const absolutePath = path.resolve(projectRoot, reportPath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content);
 }
 
 function writeCliThresholdStatus(

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -166,10 +166,13 @@ function finalizeCliArguments(state: ParseState): CliArguments {
 }
 
 function validateCliState(state: ParseState): void {
+  if (state.help) {
+    return;
+  }
   if (state.changed && state.fileArgs.length > 0) {
     throw new Error("--changed cannot be combined with file arguments");
   }
-  if (!state.help && state.agent && state.format === "junit") {
+  if (state.agent && state.format === "junit") {
     throw new Error("--agent cannot be combined with --format junit");
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,13 +5,23 @@ export { buildCoverageCommand } from "./coverage";
 export { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots, isAnalyzableFile } from "./fileSelection";
 export { coverageForMethods, parseCoverageReport } from "./istanbul";
 export { parseFileMethods } from "./parser";
-export { formatReport, sortMetrics } from "./report";
+export {
+  buildAgentAnalysisReport,
+  buildAnalysisReport,
+  formatAnalysisReport,
+  formatJunitReport,
+  formatReport,
+  formatTextReport,
+  formatToonReport,
+  sortMetrics
+} from "./report";
 export { CRAP_THRESHOLD, COVERAGE_REPORT_RELATIVE_PATH, NO_FILES_MESSAGE, NO_ANALYZABLE_FUNCTIONS_MESSAGE } from "./constants";
 export type {
   AnalysisResult,
   AnalyzeProjectOptions,
   CliArguments,
   CommandExecutor,
+  CoverageKind,
   CoverageCommand,
   CoverageMetric,
   CoverageMode,
@@ -19,8 +29,11 @@ export type {
   CoverageUnknownReason,
   MethodDescriptor,
   MethodMetrics,
+  MethodReportStatus,
   PackageManager,
   PackageManagerSelection,
+  ReportFormat,
+  ReportStatus,
   TestRunner,
   TestRunnerSelection,
   Writer

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,7 +1,57 @@
+import { CRAP_THRESHOLD } from "./constants";
 import { formatNumber } from "./utils";
-import type { MethodMetrics } from "./types";
+import type {
+  CoverageKind,
+  CoverageMetric,
+  MethodMetrics,
+  MethodReportStatus,
+  ReportFormat,
+  ReportStatus
+} from "./types";
 
-const HEADERS = ["Function", "CC", "Coverage", "CRAP", "Location"];
+const TEXT_HEADERS = ["Status", "Function", "CC", "Coverage Kind", "Coverage", "CRAP", "Threshold", "Location"];
+const AGENT_TEXT_HEADERS = ["Function", "CC", "Coverage Kind", "Coverage", "CRAP", "Threshold", "Location"];
+
+export interface MethodReportEntry {
+  status: MethodReportStatus;
+  name: string;
+  sourcePath: string;
+  startLine: number;
+  endLine: number;
+  complexity: number;
+  coverageKind: CoverageKind;
+  coveragePercent: number | null;
+  crapScore: number | null;
+  threshold: number;
+}
+
+export type AgentMethodReportEntry = Omit<MethodReportEntry, "status">;
+
+export interface AnalysisReport {
+  status: ReportStatus;
+  methods: MethodReportEntry[];
+}
+
+export interface AgentAnalysisReport {
+  status: ReportStatus;
+  methods: AgentMethodReportEntry[];
+}
+
+export interface FormatAnalysisReportOptions {
+  format: ReportFormat;
+  agent?: boolean;
+}
+
+type SerializableReport = AnalysisReport | AgentAnalysisReport;
+type ReportValue = string | number | null;
+type ReportFormatter = (report: SerializableReport, agent: boolean) => string;
+
+const REPORT_FORMATTERS: Record<ReportFormat, ReportFormatter> = {
+  toon: formatToonReport,
+  json: (report) => `${JSON.stringify(report, null, 2)}\n`,
+  text: formatTextReport,
+  junit: (report) => formatJunitReport(report as AnalysisReport)
+};
 
 export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
   return [...metrics].sort((left, right) => {
@@ -21,23 +71,200 @@ export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
   });
 }
 
-export function formatReport(metrics: MethodMetrics[]): string {
-  const rows = sortMetrics(metrics).map((metric) => [
-    metric.displayName,
-    String(metric.complexity),
-    metric.coveragePercent === null ? "N/A" : `${formatNumber(metric.coveragePercent)}%`,
-    metric.crapScore === null ? "N/A" : formatNumber(metric.crapScore),
-    metric.location
-  ]);
-
-  const widths = HEADERS.map((header, index) => {
-    const rowWidth = rows.reduce((max, row) => Math.max(max, row[index].length), header.length);
-    return rowWidth;
-  });
-
-  const headerLine = HEADERS.map((header, index) => header.padEnd(widths[index])).join("  ");
-  const separator = widths.map((width) => "-".repeat(width)).join("  ");
-  const body = rows.map((row) => row.map((value, index) => value.padEnd(widths[index])).join("  "));
-  return [headerLine, separator, ...body].join("\n");
+export function buildAnalysisReport(metrics: MethodMetrics[]): AnalysisReport {
+  const methods = sortMetrics(metrics).map(toMethodReportEntry);
+  return {
+    status: methods.some((method) => method.status === "failed") ? "failed" : "passed",
+    methods
+  };
 }
 
+export function buildAgentAnalysisReport(metrics: MethodMetrics[]): AgentAnalysisReport {
+  const report = buildAnalysisReport(metrics);
+  return {
+    status: report.status,
+    methods: report.methods
+      .filter((method) => method.status === "failed")
+      .map(({ status: _status, ...method }) => method)
+  };
+}
+
+export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAnalysisReportOptions): string {
+  const agent = options.agent ?? false;
+  validateReportOptions(options.format, agent);
+  return REPORT_FORMATTERS[options.format](agent ? buildAgentAnalysisReport(metrics) : buildAnalysisReport(metrics), agent);
+}
+
+function validateReportOptions(format: ReportFormat, agent: boolean): void {
+  if (agent && format === "junit") {
+    throw new Error("--agent cannot be combined with --format junit");
+  }
+}
+
+export function formatReport(metrics: MethodMetrics[]): string {
+  return formatTextReport(buildAnalysisReport(metrics), false);
+}
+
+export function formatToonReport(report: SerializableReport, agent = false): string {
+  const lines = [`status: ${report.status}`];
+  const includeStatus = !agent && reportHasMethodStatus(report);
+  const columns = includeStatus
+    ? ["status", "name", "sourcePath", "startLine", "endLine", "complexity", "coverageKind", "coveragePercent", "crapScore", "threshold"]
+    : ["name", "sourcePath", "startLine", "endLine", "complexity", "coverageKind", "coveragePercent", "crapScore", "threshold"];
+
+  if (report.methods.length === 0) {
+    return agent ? `${lines.join("\n")}\n` : `${[...lines, "methods[0]:"].join("\n")}\n`;
+  }
+
+  lines.push(`methods[${report.methods.length}]{${columns.join(",")}}:`);
+  for (const method of report.methods) {
+    lines.push(`  ${columns.map((column) => formatToonValue(method[column as keyof typeof method] as ReportValue)).join(",")}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function formatTextReport(report: SerializableReport, agent = false): string {
+  if (report.methods.length === 0) {
+    return `Status: ${report.status}\n`;
+  }
+
+  const includeStatus = !agent && reportHasMethodStatus(report);
+  const headers = includeStatus ? TEXT_HEADERS : AGENT_TEXT_HEADERS;
+  const rows = report.methods.map((method) => {
+    const values = [
+      method.name,
+      String(method.complexity),
+      method.coverageKind,
+      formatNullablePercent(method.coveragePercent),
+      formatNullableNumber(method.crapScore),
+      formatNumber(method.threshold),
+      `${method.sourcePath}:${method.startLine}-${method.endLine}`
+    ];
+    return includeStatus && "status" in method ? [method.status, ...values] : values;
+  });
+  const widths = headers.map((header, index) =>
+    rows.reduce((max, row) => Math.max(max, row[index].length), header.length)
+  );
+  const headerLine = headers.map((header, index) => header.padEnd(widths[index])).join("  ");
+  const separator = widths.map((width) => "-".repeat(width)).join("  ");
+  const body = rows.map((row) => row.map((value, index) => value.padEnd(widths[index])).join("  "));
+
+  return [`Status: ${report.status}`, "", headerLine, separator, ...body].join("\n") + "\n";
+}
+
+export function formatJunitReport(report: AnalysisReport): string {
+  const failures = report.methods.filter((method) => method.status === "failed").length;
+  const skipped = report.methods.filter((method) => method.status === "skipped").length;
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuite name="crap-typescript" status="${report.status}" tests="${report.methods.length}" failures="${failures}" skipped="${skipped}" errors="0">`
+  ];
+
+  for (const method of report.methods) {
+    lines.push(
+      `  <testcase classname="${escapeXmlAttribute(method.sourcePath)}" name="${escapeXmlAttribute(method.name)}" file="${escapeXmlAttribute(method.sourcePath)}" line="${method.startLine}">`
+    );
+    lines.push("    <properties>");
+    for (const [name, value] of methodProperties(method)) {
+      lines.push(`      <property name="${name}" value="${escapeXmlAttribute(value)}" />`);
+    }
+    lines.push("    </properties>");
+    if (method.status === "failed") {
+      const message = `CRAP score ${formatNullableNumber(method.crapScore)} exceeds threshold ${formatNumber(method.threshold)}`;
+      lines.push(`    <failure type="crap-threshold" message="${escapeXmlAttribute(message)}">${escapeXmlText(message)}</failure>`);
+    }
+    if (method.status === "skipped") {
+      lines.push('    <skipped message="CRAP score unavailable" />');
+    }
+    lines.push("  </testcase>");
+  }
+
+  lines.push("</testsuite>");
+  return `${lines.join("\n")}\n`;
+}
+
+function toMethodReportEntry(metric: MethodMetrics): MethodReportEntry {
+  return {
+    status: methodStatus(metric),
+    name: metric.displayName,
+    sourcePath: metric.relativePath,
+    startLine: metric.startLine,
+    endLine: metric.endLine,
+    complexity: metric.complexity,
+    coverageKind: coverageKind(metric),
+    coveragePercent: metric.coveragePercent,
+    crapScore: metric.crapScore,
+    threshold: CRAP_THRESHOLD
+  };
+}
+
+function reportHasMethodStatus(report: SerializableReport): report is AnalysisReport {
+  return report.methods.every((method) => "status" in method);
+}
+
+function methodStatus(metric: MethodMetrics): MethodReportStatus {
+  if (metric.crapScore === null) {
+    return "skipped";
+  }
+  return metric.crapScore > CRAP_THRESHOLD ? "failed" : "passed";
+}
+
+function coverageKind(metric: MethodMetrics): CoverageKind {
+  if (metric.statementCoverage.status === "unknown") {
+    return "stmt";
+  }
+  if (metric.branchCoverage.status === "unknown") {
+    return "branch";
+  }
+  const statementPercent = effectivePercent(metric.statementCoverage);
+  const branchPercent = effectivePercent(metric.branchCoverage);
+  return branchPercent < statementPercent ? "branch" : "stmt";
+}
+
+function effectivePercent(metric: CoverageMetric): number {
+  return metric.percent ?? 100;
+}
+
+function formatToonValue(value: ReportValue): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? String(value) : formatNumber(value);
+  }
+  return /^[A-Za-z0-9_.:/#@$-]+$/.test(value) ? value : JSON.stringify(value);
+}
+
+function formatNullablePercent(value: number | null): string {
+  return value === null ? "N/A" : `${formatNumber(value)}%`;
+}
+
+function formatNullableNumber(value: number | null): string {
+  return value === null ? "N/A" : formatNumber(value);
+}
+
+function methodProperties(method: MethodReportEntry): Array<[string, string]> {
+  return [
+    ["status", method.status],
+    ["score", formatNullableNumber(method.crapScore)],
+    ["threshold", formatNumber(method.threshold)],
+    ["complexity", String(method.complexity)],
+    ["coveragePercent", formatNullablePercent(method.coveragePercent)],
+    ["coverageKind", method.coverageKind],
+    ["sourcePath", method.sourcePath],
+    ["startLine", String(method.startLine)],
+    ["endLine", String(method.endLine)],
+    ["lineRange", `${method.startLine}-${method.endLine}`]
+  ];
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replace(/"/g, "&quot;");
+}
+
+function escapeXmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -243,13 +243,17 @@ function formatNullableNumber(value: number | null): string {
   return value === null ? "N/A" : formatNumber(value);
 }
 
+function formatJunitNullableNumber(value: number | null): string {
+  return value === null ? "" : formatNumber(value);
+}
+
 function methodProperties(method: MethodReportEntry): Array<[string, string]> {
   return [
     ["status", method.status],
-    ["score", formatNullableNumber(method.crapScore)],
+    ["score", formatJunitNullableNumber(method.crapScore)],
     ["threshold", formatNumber(method.threshold)],
     ["complexity", String(method.complexity)],
-    ["coveragePercent", formatNullablePercent(method.coveragePercent)],
+    ["coveragePercent", formatJunitNullableNumber(method.coveragePercent)],
     ["coverageKind", method.coverageKind],
     ["sourcePath", method.sourcePath],
     ["startLine", String(method.startLine)],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,10 @@ export type PackageManagerSelection = PackageManager | "auto";
 export type TestRunner = "vitest" | "jest";
 export type TestRunnerSelection = TestRunner | "auto";
 export type CoverageMode = "auto" | "existing-only";
+export type ReportFormat = "toon" | "json" | "text" | "junit";
+export type ReportStatus = "passed" | "failed";
+export type MethodReportStatus = ReportStatus | "skipped";
+export type CoverageKind = "stmt" | "branch";
 export type CoverageStatus = "measured" | "structural_na" | "unknown";
 export type CoverageUnknownReason =
   | "missing_report"
@@ -35,6 +39,10 @@ export interface CliArguments {
   fileArgs: string[];
   packageManager: PackageManagerSelection;
   testRunner: TestRunnerSelection;
+  format: ReportFormat;
+  agent: boolean;
+  outputPath?: string;
+  junitReportPath?: string;
 }
 
 export interface MethodDescriptor {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -58,6 +58,14 @@ describe("cli", () => {
       format: "toon",
       agent: false
     });
+    expect(parseCliArguments(["--help", "--changed", "src/app.ts", "--agent", "--format", "junit"])).toEqual({
+      mode: "help",
+      fileArgs: [],
+      packageManager: "auto",
+      testRunner: "auto",
+      format: "junit",
+      agent: true
+    });
   });
 
   it("rejects duplicate, missing, invalid, and unknown options", () => {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { parseCliArguments, runCli } from "../src/cli";
-import { createTempDir, disposeTempDir, StringWriter, writeProjectFiles } from "./testUtils";
+import { createTempDir, disposeTempDir, readText, StringWriter, writeProjectFiles } from "./testUtils";
 
 const tempDirs: string[] = [];
 
@@ -11,16 +11,34 @@ afterEach(async () => {
 
 describe("cli", () => {
   it("parses supported options", () => {
-    expect(parseCliArguments(["--changed", "--package-manager", "npm", "--test-runner", "vitest"])).toEqual({
+    expect(parseCliArguments([
+      "--changed",
+      "--package-manager",
+      "npm",
+      "--test-runner",
+      "vitest",
+      "--format",
+      "json",
+      "--agent",
+      "--output",
+      "reports/crap.json",
+      "--junit-report",
+      "reports/crap.xml"
+    ])).toEqual({
       mode: "changed",
       fileArgs: [],
       packageManager: "npm",
-      testRunner: "vitest"
+      testRunner: "vitest",
+      format: "json",
+      agent: true,
+      outputPath: "reports/crap.json",
+      junitReportPath: "reports/crap.xml"
     });
   });
 
   it("rejects invalid combinations", () => {
     expect(() => parseCliArguments(["--changed", "src/app.ts"])).toThrow("--changed cannot be combined");
+    expect(() => parseCliArguments(["--agent", "--format", "junit"])).toThrow("--agent cannot be combined");
   });
 
   it("parses explicit paths, help mode, and alternate package-manager and test-runner selections", () => {
@@ -28,13 +46,17 @@ describe("cli", () => {
       mode: "explicit",
       fileArgs: ["packages/core"],
       packageManager: "pnpm",
-      testRunner: "jest"
+      testRunner: "jest",
+      format: "toon",
+      agent: false
     });
     expect(parseCliArguments(["--help", "--package-manager", "yarn"])).toEqual({
       mode: "help",
       fileArgs: [],
       packageManager: "yarn",
-      testRunner: "auto"
+      testRunner: "auto",
+      format: "toon",
+      agent: false
     });
   });
 
@@ -45,13 +67,27 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--test-runner", "vitest", "--test-runner", "jest"])).toThrow(
       "--test-runner can only be provided once"
     );
+    expect(() => parseCliArguments(["--format", "toon", "--format", "json"])).toThrow(
+      "--format can only be provided once"
+    );
+    expect(() => parseCliArguments(["--agent", "--agent"])).toThrow("--agent can only be provided once");
+    expect(() => parseCliArguments(["--output", "a", "--output", "b"])).toThrow("--output can only be provided once");
+    expect(() => parseCliArguments(["--junit-report", "a", "--junit-report", "b"])).toThrow(
+      "--junit-report can only be provided once"
+    );
     expect(() => parseCliArguments(["--package-manager"])).toThrow("--package-manager requires one of: auto, npm, pnpm, yarn");
     expect(() => parseCliArguments(["--test-runner"])).toThrow("--test-runner requires one of: auto, vitest, jest");
+    expect(() => parseCliArguments(["--format"])).toThrow("--format requires one of: toon, json, text, junit");
+    expect(() => parseCliArguments(["--output"])).toThrow("--output requires a path");
+    expect(() => parseCliArguments(["--junit-report"])).toThrow("--junit-report requires a path");
     expect(() => parseCliArguments(["--package-manager", "bun"])).toThrow(
       "--package-manager requires one of: auto, npm, pnpm, yarn"
     );
     expect(() => parseCliArguments(["--test-runner", "mocha"])).toThrow(
       "--test-runner requires one of: auto, vitest, jest"
+    );
+    expect(() => parseCliArguments(["--format", "agent"])).toThrow(
+      "--format requires one of: toon, json, text, junit"
     );
     expect(() => parseCliArguments(["--unknown"])).toThrow("Unknown option: --unknown");
   });
@@ -166,7 +202,122 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(2);
+    expect(stdout.toString()).toContain("status: failed");
+    expect(stdout.toString()).toContain("methods[2]{status,name,sourcePath,startLine,endLine,complexity,coverageKind,coveragePercent,crapScore,threshold}:");
     expect(stdout.toString()).toContain("risky");
+    expect(stderr.toString()).toContain("CRAP threshold exceeded");
+  });
+
+  it("filters primary reports in agent mode and writes full JUnit before threshold failure", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+
+export function risky(flagA: boolean, flagB: boolean): number {
+  if (flagA && flagB) {
+    return 1;
+  }
+  return 0;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            },
+            "1": {
+              start: { line: 7, column: 4 },
+              end: { line: 7, column: 13 }
+            },
+            "2": {
+              start: { line: 9, column: 2 },
+              end: { line: 9, column: 11 }
+            }
+          },
+          fnMap: {},
+          branchMap: {
+            "0": {
+              line: 6,
+              type: "if",
+              loc: {
+                start: { line: 6, column: 2 },
+                end: { line: 8, column: 3 }
+              },
+              locations: [
+                {
+                  start: { line: 6, column: 2 },
+                  end: { line: 8, column: 3 }
+                },
+                {}
+              ]
+            },
+            "1": {
+              line: 6,
+              type: "binary-expr",
+              loc: {
+                start: { line: 6, column: 6 },
+                end: { line: 6, column: 31 }
+              },
+              locations: [
+                {
+                  start: { line: 6, column: 6 },
+                  end: { line: 6, column: 20 }
+                },
+                {
+                  start: { line: 6, column: 24 },
+                  end: { line: 6, column: 29 }
+                }
+              ]
+            }
+          },
+          s: {
+            "0": 1,
+            "1": 0,
+            "2": 0
+          },
+          f: {},
+          b: {
+            "0": [0, 0],
+            "1": [0, 0]
+          }
+        }
+      })
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const exitCode = await runCli([
+      "--agent",
+      "--format",
+      "json",
+      "--output",
+      "reports/crap.json",
+      "--junit-report",
+      "reports/crap.xml"
+    ], projectRoot, stdout, stderr);
+
+    const primary = JSON.parse(await readText(`${projectRoot}/reports/crap.json`)) as {
+      status: string;
+      methods: Array<Record<string, unknown>>;
+    };
+    const junit = await readText(`${projectRoot}/reports/crap.xml`);
+
+    expect(exitCode).toBe(2);
+    expect(stdout.toString()).toBe("");
+    expect(primary.status).toBe("failed");
+    expect(primary.methods).toHaveLength(1);
+    expect(primary.methods[0].name).toBe("risky");
+    expect(primary.methods[0]).not.toHaveProperty("status");
+    expect(junit).toContain('tests="2"');
+    expect(junit).toContain('name="safe"');
+    expect(junit).toContain('name="risky"');
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
   });
 
@@ -230,11 +381,12 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
+    expect(stdout.toString()).toContain("status: passed");
     expect(stdout.toString()).toContain("safe");
     expect(stderr.toString()).toBe("");
   });
 
-  it("prints the no-files message for an empty project", async () => {
+  it("prints a passed report for an empty project", async () => {
     const projectRoot = await createTempDir("crap-cli-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -246,11 +398,11 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toContain("No TypeScript files to analyze.");
+    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 
-  it("prints a clear message when selected files contain no analyzable functions", async () => {
+  it("prints a passed report when selected files contain no analyzable functions", async () => {
     const projectRoot = await createTempDir("crap-cli-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -264,8 +416,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toContain("No analyzable functions found.");
-    expect(stdout.toString()).not.toContain("Function  CC  Coverage  CRAP  Location");
+    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -186,7 +186,26 @@ describe("report formatting", () => {
     expect(output).toContain('<testsuite name="crap-typescript" status="failed" tests="1" failures="1" skipped="0" errors="0">');
     expect(output).toContain('name="risky &lt;value&gt;"');
     expect(output).toContain('file="src/special&amp;file.ts"');
+    expect(output).toContain('<property name="score" value="20.0" />');
+    expect(output).toContain('<property name="coveragePercent" value="0.0" />');
     expect(output).toContain('<property name="coverageKind" value="stmt" />');
     expect(output).toContain("<failure");
+  });
+
+  it("formats unavailable JUnit numeric properties as empty values", () => {
+    const output = formatJunitReport(buildAnalysisReport([
+      metric({
+        displayName: "missingCoverage",
+        coverage: unknown("missing_report"),
+        statementCoverage: unknown("missing_report"),
+        branchCoverage: unknown("missing_report"),
+        coveragePercent: null,
+        crapScore: null
+      })
+    ]));
+
+    expect(output).toContain('<property name="score" value="" />');
+    expect(output).toContain('<property name="coveragePercent" value="" />');
+    expect(output).toContain("<skipped");
   });
 });

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAgentAnalysisReport,
+  buildAnalysisReport,
+  formatAnalysisReport,
+  formatJunitReport,
+  formatTextReport,
+  formatToonReport
+} from "../src/report";
+import type { CoverageMetric, MethodMetrics } from "../src/types";
+
+const measured = (percent: number): CoverageMetric => ({
+  percent,
+  status: "measured",
+  unknownReason: null
+});
+
+const structuralNa = (): CoverageMetric => ({
+  percent: null,
+  status: "structural_na",
+  unknownReason: null
+});
+
+const unknown = (unknownReason: CoverageMetric["unknownReason"]): CoverageMetric => ({
+  percent: null,
+  status: "unknown",
+  unknownReason
+});
+
+function metric(overrides: Partial<MethodMetrics> = {}): MethodMetrics {
+  return {
+    functionName: "safe",
+    containerName: null,
+    displayName: "safe",
+    startLine: 1,
+    endLine: 3,
+    complexity: 1,
+    bodySpan: {
+      startLine: 1,
+      startColumn: 0,
+      endLine: 3,
+      endColumn: 1
+    },
+    expectsStatementCoverage: true,
+    expectsBranchCoverage: false,
+    filePath: "/repo/src/sample.ts",
+    relativePath: "src/sample.ts",
+    location: "src/sample.ts:1-3",
+    moduleRoot: "/repo",
+    coverage: measured(100),
+    statementCoverage: measured(100),
+    branchCoverage: structuralNa(),
+    coveragePercent: 100,
+    crapScore: 1,
+    ...overrides
+  };
+}
+
+describe("report formatting", () => {
+  it("builds status, method status, and coverage kind from metrics", () => {
+    const report = buildAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        startLine: 5,
+        endLine: 10,
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(50),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      }),
+      metric({
+        displayName: "unknownCoverage",
+        startLine: 12,
+        endLine: 14,
+        coverage: unknown("missing_report"),
+        statementCoverage: unknown("missing_report"),
+        branchCoverage: unknown("missing_report"),
+        coveragePercent: null,
+        crapScore: null
+      })
+    ]);
+
+    expect(report.status).toBe("failed");
+    expect(report.methods).toMatchObject([
+      {
+        status: "failed",
+        name: "risky",
+        coverageKind: "branch"
+      },
+      {
+        status: "passed",
+        name: "safe",
+        coverageKind: "stmt"
+      },
+      {
+        status: "skipped",
+        name: "unknownCoverage",
+        coverageKind: "stmt"
+      }
+    ]);
+  });
+
+  it("chooses branch coverage when branch coverage blocks the score", () => {
+    const report = buildAnalysisReport([
+      metric({
+        coverage: unknown("branch_unattributed"),
+        statementCoverage: measured(100),
+        branchCoverage: unknown("branch_unattributed"),
+        coveragePercent: null,
+        crapScore: null
+      })
+    ]);
+
+    expect(report.methods[0]).toMatchObject({
+      status: "skipped",
+      coverageKind: "branch"
+    });
+  });
+
+  it("formats JSON without global aggregate fields", () => {
+    const parsed = JSON.parse(formatAnalysisReport([metric()], { format: "json" })) as Record<string, unknown>;
+
+    expect(Object.keys(parsed)).toEqual(["status", "methods"]);
+    expect(parsed.status).toBe("passed");
+    expect(parsed.methods).toEqual([
+      expect.objectContaining({
+        status: "passed",
+        name: "safe",
+        threshold: 8
+      })
+    ]);
+  });
+
+  it("formats TOON reports and omits status from agent method entries", () => {
+    const output = formatAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      })
+    ], { format: "toon", agent: true });
+
+    expect(output).toContain("status: failed");
+    expect(output).toContain("methods[1]{name,sourcePath,startLine,endLine,complexity,coverageKind,coveragePercent,crapScore,threshold}:");
+    expect(output).toContain("risky");
+    expect(output).not.toContain("safe");
+    expect(output).not.toContain("failed,risky");
+  });
+
+  it("formats text reports with only method-level details", () => {
+    const output = formatTextReport(buildAnalysisReport([metric()]));
+
+    expect(output).toContain("Status: passed");
+    expect(output).toContain("Function");
+    expect(output).toContain("safe");
+    expect(output).not.toContain("Summary");
+  });
+
+  it("formats empty agent reports as status only", () => {
+    expect(formatToonReport(buildAgentAnalysisReport([]), true)).toBe("status: passed\n");
+  });
+
+  it("formats JUnit XML with testcase properties and escaped values", () => {
+    const output = formatJunitReport(buildAnalysisReport([
+      metric({
+        displayName: "risky <value>",
+        relativePath: "src/special&file.ts",
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      })
+    ]));
+
+    expect(output).toContain('<testsuite name="crap-typescript" status="failed" tests="1" failures="1" skipped="0" errors="0">');
+    expect(output).toContain('name="risky &lt;value&gt;"');
+    expect(output).toContain('file="src/special&amp;file.ts"');
+    expect(output).toContain('<property name="coverageKind" value="stmt" />');
+    expect(output).toContain("<failure");
+  });
+});

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -20,6 +20,8 @@ module.exports = withCrapTypescriptJest({
 
 `withCrapTypescriptJest` wraps your Jest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
+The reporter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+
 The reporter is also available as a standalone export at `@barney-media/crap-typescript-jest/reporter` for direct configuration.
 
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import type { PackageManagerSelection, Writer } from "@barney-media/crap-typescript-core";
+import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
 
 import CrapTypescriptJestReporter from "./reporter";
 
@@ -11,6 +11,10 @@ export interface CrapTypescriptJestOptions {
   paths?: string[];
   packageManager?: PackageManagerSelection;
   coverageReportPath?: string;
+  format?: ReportFormat;
+  agent?: boolean;
+  outputPath?: string;
+  junitReportPath?: string | false;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -33,7 +37,10 @@ export function withCrapTypescriptJest(
     resolveReporterPath(),
     {
       ...options,
-      coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(config.coverageDirectory as string | undefined)
+      coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(config.coverageDirectory as string | undefined),
+      junitReportPath: options.junitReportPath === undefined
+        ? buildJunitReportPath(config.coverageDirectory as string | undefined)
+        : options.junitReportPath
     }
   ]);
 
@@ -78,6 +85,10 @@ export default CrapTypescriptJestReporter;
 
 function buildCoverageReportPath(coverageDirectory: string | undefined): string {
   return `${coverageDirectory ?? "coverage"}/coverage-final.json`;
+}
+
+function buildJunitReportPath(coverageDirectory: string | undefined): string {
+  return `${coverageDirectory ?? "coverage"}/crap-typescript-junit.xml`;
 }
 
 function resolveReporterPath(): string {

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -1,14 +1,13 @@
-import { access } from "node:fs/promises";
+import { access, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
   analyzeProject,
   COVERAGE_REPORT_RELATIVE_PATH,
   CRAP_THRESHOLD,
-  formatReport,
-  NO_FILES_MESSAGE
+  formatAnalysisReport
 } from "@barney-media/crap-typescript-core";
-import type { PackageManagerSelection, Writer } from "@barney-media/crap-typescript-core";
+import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
 
 export interface CrapTypescriptJestOptions {
   projectRoot?: string;
@@ -16,6 +15,10 @@ export interface CrapTypescriptJestOptions {
   paths?: string[];
   packageManager?: PackageManagerSelection;
   coverageReportPath?: string;
+  format?: ReportFormat;
+  agent?: boolean;
+  outputPath?: string;
+  junitReportPath?: string | false;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -26,6 +29,10 @@ interface ResolvedReporterOptions {
   changedOnly: boolean;
   packageManager: PackageManagerSelection;
   coverageReportPath: string;
+  format: ReportFormat;
+  agent: boolean;
+  outputPath: string | undefined;
+  junitReportPath: string | false;
   stdout: Writer;
   stderr: Writer;
 }
@@ -65,12 +72,7 @@ export default class CrapTypescriptJestReporter {
         stderr: options.stderr
       });
 
-      if (result.selectedFiles.length === 0) {
-        options.stdout.write(`${NO_FILES_MESSAGE}\n`);
-        return;
-      }
-
-      options.stdout.write(`${formatReport(result.metrics)}\n`);
+      await writeReporterReports(result.metrics, options);
       if (result.thresholdExceeded) {
         this.error = createThresholdExceededError(result.maxCrap);
         options.stderr.write(`${this.error.message}\n`);
@@ -126,13 +128,52 @@ function toError(error: unknown): Error {
 function resolveAnalysisOptions(
   options: CrapTypescriptJestOptions
 ): Omit<ResolvedReporterOptions, "stdout" | "stderr"> {
+  const coverageReportPath = resolveCoverageReportPathOption(options);
   return {
-    projectRoot: options.projectRoot ?? process.cwd(),
-    paths: options.paths ?? [],
-    changedOnly: options.changedOnly ?? false,
-    packageManager: options.packageManager ?? "auto",
-    coverageReportPath: options.coverageReportPath ?? COVERAGE_REPORT_RELATIVE_PATH
+    projectRoot: resolveProjectRoot(options),
+    paths: resolvePaths(options),
+    changedOnly: resolveChangedOnly(options),
+    packageManager: resolvePackageManager(options),
+    coverageReportPath,
+    format: resolveFormat(options),
+    agent: resolveAgent(options),
+    outputPath: options.outputPath,
+    junitReportPath: resolveJunitReportPath(options, coverageReportPath)
   };
+}
+
+function resolveProjectRoot(options: CrapTypescriptJestOptions): string {
+  return options.projectRoot ?? process.cwd();
+}
+
+function resolvePaths(options: CrapTypescriptJestOptions): string[] {
+  return options.paths ?? [];
+}
+
+function resolveChangedOnly(options: CrapTypescriptJestOptions): boolean {
+  return options.changedOnly ?? false;
+}
+
+function resolvePackageManager(options: CrapTypescriptJestOptions): PackageManagerSelection {
+  return options.packageManager ?? "auto";
+}
+
+function resolveCoverageReportPathOption(options: CrapTypescriptJestOptions): string {
+  return options.coverageReportPath ?? COVERAGE_REPORT_RELATIVE_PATH;
+}
+
+function resolveFormat(options: CrapTypescriptJestOptions): ReportFormat {
+  return options.format ?? "toon";
+}
+
+function resolveAgent(options: CrapTypescriptJestOptions): boolean {
+  return options.agent ?? false;
+}
+
+function resolveJunitReportPath(options: CrapTypescriptJestOptions, coverageReportPath: string): string | false {
+  return options.junitReportPath === undefined
+    ? buildJunitReportPathFromCoveragePath(coverageReportPath)
+    : options.junitReportPath;
 }
 
 function resolveOutputWriters(
@@ -142,4 +183,33 @@ function resolveOutputWriters(
     stdout: options.stdout ?? process.stdout,
     stderr: options.stderr ?? process.stderr
   };
+}
+
+async function writeReporterReports(
+  metrics: Awaited<ReturnType<typeof analyzeProject>>["metrics"],
+  options: ResolvedReporterOptions
+): Promise<void> {
+  const primaryReport = formatAnalysisReport(metrics, {
+    format: options.format,
+    agent: options.agent
+  });
+  if (options.outputPath) {
+    await writeReportFile(options.projectRoot, options.outputPath, primaryReport);
+  } else {
+    options.stdout.write(primaryReport);
+  }
+
+  if (options.junitReportPath !== false) {
+    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, { format: "junit" }));
+  }
+}
+
+async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
+  const absolutePath = path.resolve(projectRoot, reportPath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content);
+}
+
+function buildJunitReportPathFromCoveragePath(coverageReportPath: string): string {
+  return path.join(path.dirname(coverageReportPath), "crap-typescript-junit.xml");
 }

--- a/packages/jest/test/config.test.ts
+++ b/packages/jest/test/config.test.ts
@@ -11,12 +11,13 @@ describe("withCrapTypescriptJest", () => {
     expect(config.coverageReporters).toEqual(["json", "text"]);
 
     const reporters = config.reporters as unknown[];
-    const reporterEntry = reporters[1] as [string, { coverageReportPath: string }];
+    const reporterEntry = reporters[1] as [string, { coverageReportPath: string; junitReportPath: string }];
     expect(reporters[0]).toBe("default");
     expect(Array.isArray(reporterEntry)).toBe(true);
     expect(reporterEntry[0].replace(/\\/g, "/")).toContain("/packages/jest/src/reporter");
     expect(reporterEntry[1]).toMatchObject({
-      coverageReportPath: "coverage/coverage-final.json"
+      coverageReportPath: "coverage/coverage-final.json",
+      junitReportPath: "coverage/crap-typescript-junit.xml"
     });
   });
 
@@ -34,7 +35,8 @@ describe("withCrapTypescriptJest", () => {
       [
         expect.any(String),
         expect.objectContaining({
-          coverageReportPath: "custom-coverage/coverage-final.json"
+          coverageReportPath: "custom-coverage/coverage-final.json",
+          junitReportPath: "custom-coverage/crap-typescript-junit.xml"
         })
       ]
     ]);
@@ -57,7 +59,8 @@ describe("withCrapTypescriptJest", () => {
       [
         expect.any(String),
         expect.objectContaining({
-          coverageReportPath: "custom-coverage/coverage-final.json"
+          coverageReportPath: "custom-coverage/coverage-final.json",
+          junitReportPath: "custom-coverage/crap-typescript-junit.xml"
         })
       ]
     ]);

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -2,9 +2,7 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { NO_FILES_MESSAGE } from "@barney-media/crap-typescript-core";
-
-import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "../../core/test/testUtils";
+import { StringWriter, createTempDir, disposeTempDir, readText, writeProjectFiles } from "../../core/test/testUtils";
 import CrapTypescriptJestReporter from "../src/reporter";
 
 const tempDirs: string[] = [];
@@ -48,7 +46,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(finalize).toHaveBeenCalledTimes(1);
   });
 
-  it("prints the no-files message when no analyzable source files are selected", async () => {
+  it("prints a passed TOON report when no analyzable source files are selected", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -66,7 +64,8 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
-    expect(stdout.toString()).toContain(NO_FILES_MESSAGE);
+    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
+    expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
     expect(reporter.getLastError()).toBeUndefined();
     expect(process.exitCode).toBe(originalExitCode);
@@ -161,10 +160,66 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
+    const junit = await readText(`${projectRoot}/custom-coverage/crap-typescript-junit.xml`);
+
+    expect(stdout.toString()).toContain("status: failed");
     expect(stdout.toString()).toContain("risky");
+    expect(junit).toContain('tests="1"');
+    expect(junit).toContain("<failure");
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
     expect(reporter.getLastError()).toBeInstanceOf(Error);
     expect(reporter.getLastError()?.message).toContain("CRAP threshold exceeded");
     expect(process.exitCode).toBe(1);
+  });
+
+  it("supports agent filtering and disabled JUnit output", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            }
+          },
+          fnMap: {},
+          branchMap: {},
+          s: {
+            "0": 1
+          },
+          f: {},
+          b: {}
+        }
+      })
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptJestReporter(undefined, {
+      projectRoot,
+      format: "json",
+      agent: true,
+      junitReportPath: false,
+      stdout,
+      stderr
+    });
+
+    await callFinalize(reporter);
+
+    expect(JSON.parse(stdout.toString())).toEqual({
+      status: "passed",
+      methods: []
+    });
+    await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();
+    expect(stderr.toString()).toBe("");
+    expect(reporter.getLastError()).toBeUndefined();
   });
 });

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -22,6 +22,8 @@ module.exports = withCrapTypescriptVitest({
 
 `withCrapTypescriptVitest` wraps your Vitest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
+The reporter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.
 
 ## License

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -39,22 +39,27 @@ export class CrapTypescriptVitestReporter {
 
   async onFinishedReportCoverage(): Promise<void> {
     const options = resolveReporterOptions(this.options);
-    const result = await analyzeProject({
-      projectRoot: options.projectRoot,
-      explicitPaths: options.paths,
-      changedOnly: options.changedOnly,
-      packageManager: options.packageManager,
-      testRunner: "vitest",
-      coverageMode: "existing-only",
-      coverageReportPath: options.coverageReportPath,
-      stdout: options.stdout,
-      stderr: options.stderr
-    });
+    try {
+      const result = await analyzeProject({
+        projectRoot: options.projectRoot,
+        explicitPaths: options.paths,
+        changedOnly: options.changedOnly,
+        packageManager: options.packageManager,
+        testRunner: "vitest",
+        coverageMode: "existing-only",
+        coverageReportPath: options.coverageReportPath,
+        stdout: options.stdout,
+        stderr: options.stderr
+      });
 
-    await writeReporterReports(result.metrics, options);
-    if (result.thresholdExceeded) {
-      const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${CRAP_THRESHOLD.toFixed(1)}`;
-      options.stderr.write(`${error}\n`);
+      await writeReporterReports(result.metrics, options);
+      if (result.thresholdExceeded) {
+        const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${CRAP_THRESHOLD.toFixed(1)}`;
+        options.stderr.write(`${error}\n`);
+        process.exitCode = 1;
+      }
+    } catch (error) {
+      options.stderr.write(`${toError(error).message}\n`);
       process.exitCode = 1;
     }
   }
@@ -128,6 +133,10 @@ function buildCoverageReportPath(reportsDirectory: string | undefined): string {
 
 function buildJunitReportPath(reportsDirectory: string | undefined): string {
   return `${reportsDirectory ?? "coverage"}/crap-typescript-junit.xml`;
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 interface ResolvedReporterOptions {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,5 +1,8 @@
-import { analyzeProject, CRAP_THRESHOLD, formatReport, NO_FILES_MESSAGE } from "@barney-media/crap-typescript-core";
-import type { PackageManagerSelection, Writer } from "@barney-media/crap-typescript-core";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { analyzeProject, CRAP_THRESHOLD, formatAnalysisReport } from "@barney-media/crap-typescript-core";
+import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
 
 type VitestReporterEntry = string | [string, unknown] | {
   onTestRunEnd?: () => Promise<void>;
@@ -23,6 +26,10 @@ export interface CrapTypescriptVitestOptions {
   paths?: string[];
   packageManager?: PackageManagerSelection;
   coverageReportPath?: string;
+  format?: ReportFormat;
+  agent?: boolean;
+  outputPath?: string;
+  junitReportPath?: string | false;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -44,12 +51,7 @@ export class CrapTypescriptVitestReporter {
       stderr: options.stderr
     });
 
-    if (result.selectedFiles.length === 0) {
-      options.stdout.write(`${NO_FILES_MESSAGE}\n`);
-      return;
-    }
-
-    options.stdout.write(`${formatReport(result.metrics)}\n`);
+    await writeReporterReports(result.metrics, options);
     if (result.thresholdExceeded) {
       const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${CRAP_THRESHOLD.toFixed(1)}`;
       options.stderr.write(`${error}\n`);
@@ -68,7 +70,10 @@ export function withCrapTypescriptVitest(
   const reporters = ensureDefaultReporter(asArray(testConfig.reporters));
   reporters.push(new CrapTypescriptVitestReporter({
     ...options,
-    coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory)
+    coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory),
+    junitReportPath: options.junitReportPath === undefined
+      ? buildJunitReportPath(coverage.reportsDirectory)
+      : options.junitReportPath
   }));
 
   return {
@@ -121,24 +126,95 @@ function buildCoverageReportPath(reportsDirectory: string | undefined): string {
   return `${reportsDirectory ?? "coverage"}/coverage-final.json`;
 }
 
+function buildJunitReportPath(reportsDirectory: string | undefined): string {
+  return `${reportsDirectory ?? "coverage"}/crap-typescript-junit.xml`;
+}
+
 interface ResolvedReporterOptions {
   projectRoot: string;
   paths: string[];
   changedOnly: boolean;
   packageManager: PackageManagerSelection;
   coverageReportPath: string | undefined;
+  format: ReportFormat;
+  agent: boolean;
+  outputPath: string | undefined;
+  junitReportPath: string | false;
   stdout: Writer;
   stderr: Writer;
 }
 
 function resolveReporterOptions(options: CrapTypescriptVitestOptions): ResolvedReporterOptions {
   return {
-    projectRoot: options.projectRoot ?? process.cwd(),
-    paths: options.paths ?? [],
-    changedOnly: options.changedOnly ?? false,
-    packageManager: options.packageManager ?? "auto",
+    projectRoot: resolveProjectRoot(options),
+    paths: resolvePaths(options),
+    changedOnly: resolveChangedOnly(options),
+    packageManager: resolvePackageManager(options),
     coverageReportPath: options.coverageReportPath,
+    format: resolveFormat(options),
+    agent: resolveAgent(options),
+    outputPath: options.outputPath,
+    junitReportPath: resolveJunitReportPath(options),
     stdout: options.stdout ?? process.stdout,
     stderr: options.stderr ?? process.stderr
   };
+}
+
+function resolveProjectRoot(options: CrapTypescriptVitestOptions): string {
+  return options.projectRoot ?? process.cwd();
+}
+
+function resolvePaths(options: CrapTypescriptVitestOptions): string[] {
+  return options.paths ?? [];
+}
+
+function resolveChangedOnly(options: CrapTypescriptVitestOptions): boolean {
+  return options.changedOnly ?? false;
+}
+
+function resolvePackageManager(options: CrapTypescriptVitestOptions): PackageManagerSelection {
+  return options.packageManager ?? "auto";
+}
+
+function resolveFormat(options: CrapTypescriptVitestOptions): ReportFormat {
+  return options.format ?? "toon";
+}
+
+function resolveAgent(options: CrapTypescriptVitestOptions): boolean {
+  return options.agent ?? false;
+}
+
+function resolveJunitReportPath(options: CrapTypescriptVitestOptions): string | false {
+  return options.junitReportPath === undefined
+    ? buildJunitReportPathFromCoveragePath(options.coverageReportPath)
+    : options.junitReportPath;
+}
+
+async function writeReporterReports(
+  metrics: Awaited<ReturnType<typeof analyzeProject>>["metrics"],
+  options: ResolvedReporterOptions
+): Promise<void> {
+  const primaryReport = formatAnalysisReport(metrics, {
+    format: options.format,
+    agent: options.agent
+  });
+  if (options.outputPath) {
+    await writeReportFile(options.projectRoot, options.outputPath, primaryReport);
+  } else {
+    options.stdout.write(primaryReport);
+  }
+
+  if (options.junitReportPath !== false) {
+    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, { format: "junit" }));
+  }
+}
+
+async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {
+  const absolutePath = path.resolve(projectRoot, reportPath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content);
+}
+
+function buildJunitReportPathFromCoveragePath(coverageReportPath: string | undefined): string {
+  return path.join(path.dirname(coverageReportPath ?? "coverage/coverage-final.json"), "crap-typescript-junit.xml");
 }

--- a/packages/vitest/test/config.test.ts
+++ b/packages/vitest/test/config.test.ts
@@ -12,9 +12,15 @@ describe("withCrapTypescriptVitest", () => {
 
     const reporters = config.test?.reporters;
     const coverageReporters = config.test?.coverage?.reporter;
+    const crapReporter = reporters?.[1] as CrapTypescriptVitestReporter;
     expect(Array.isArray(reporters)).toBe(true);
     expect(reporters?.[0]).toBe("default");
-    expect(reporters?.[1]).toBeInstanceOf(CrapTypescriptVitestReporter);
+    expect(crapReporter).toBeInstanceOf(CrapTypescriptVitestReporter);
+    expect(crapReporter).toMatchObject({
+      options: expect.objectContaining({
+        junitReportPath: "coverage/crap-typescript-junit.xml"
+      })
+    });
     expect(coverageReporters).toEqual(["json", "text"]);
   });
 
@@ -35,5 +41,10 @@ describe("withCrapTypescriptVitest", () => {
     ]);
     expect(config.test?.coverage?.reporter).toEqual(["json", "text"]);
     expect(config.test?.coverage?.reportsDirectory).toBe("custom-coverage");
+    expect(config.test?.reporters?.[1]).toMatchObject({
+      options: expect.objectContaining({
+        junitReportPath: "custom-coverage/crap-typescript-junit.xml"
+      })
+    });
   });
 });

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -186,4 +186,29 @@ describe("CrapTypescriptVitestReporter", () => {
     await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();
     expect(stderr.toString()).toBe("");
   });
+
+  it("reports configuration errors without throwing", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}'
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      format: "junit",
+      agent: true,
+      junitReportPath: false,
+      stdout,
+      stderr
+    });
+
+    await expect(reporter.onFinishedReportCoverage()).resolves.toBeUndefined();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toContain("--agent cannot be combined with --format junit");
+    expect(process.exitCode).toBe(1);
+  });
 });

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { StringWriter, createTempDir, disposeTempDir, writeProjectFiles } from "../../core/test/testUtils";
+import { StringWriter, createTempDir, disposeTempDir, readText, writeProjectFiles } from "../../core/test/testUtils";
 import { CrapTypescriptVitestReporter } from "../src/index";
 
 const tempDirs: string[] = [];
@@ -16,7 +16,7 @@ afterEach(async () => {
 });
 
 describe("CrapTypescriptVitestReporter", () => {
-  it("prints the no-files message when no analyzable source files are selected", async () => {
+  it("prints a passed TOON report when no analyzable source files are selected", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -33,7 +33,8 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
-    expect(stdout.toString()).toContain("No TypeScript files to analyze.");
+    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
+    expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
     expect(process.exitCode).toBe(originalExitCode);
   });
@@ -126,8 +127,63 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
+    const junit = await readText(`${projectRoot}/custom-coverage/crap-typescript-junit.xml`);
+
+    expect(stdout.toString()).toContain("status: failed");
     expect(stdout.toString()).toContain("risky");
+    expect(junit).toContain('tests="1"');
+    expect(junit).toContain("<failure");
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
     expect(process.exitCode).toBe(1);
+  });
+
+  it("supports agent filtering and disabled JUnit output", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            }
+          },
+          fnMap: {},
+          branchMap: {},
+          s: {
+            "0": 1
+          },
+          f: {},
+          b: {}
+        }
+      })
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      format: "json",
+      agent: true,
+      junitReportPath: false,
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    expect(JSON.parse(stdout.toString())).toEqual({
+      status: "passed",
+      methods: []
+    });
+    await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();
+    expect(stderr.toString()).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

- add TOON, JSON, text, and JUnit CRAP report formatters with overall `status` and method-level details
- add `--format`, `--agent`, `--output`, and `--junit-report` CLI support
- update Jest and Vitest adapters to default to TOON stdout plus a JUnit XML artifact

## Validation

- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`

Closes #47