### PR TITLE
Change adapter default report format

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ npx crap-typescript packages/api packages/web
 
 The CLI defaults to TOON output for compact, agent-readable reports. `--format` can select `toon`, `json`, `text`, or `junit`.
 
-All report formats expose only one overall result value: `status`, either `passed` or `failed`. Per-function entries carry the details: method status, CRAP score, threshold, complexity, coverage percent, coverage kind, source path, and line range.
+Primary reports expose overall `status` and the run-level `threshold`. Per-function entries use the shared fields `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. Method-level entries never repeat `threshold`.
 
-`--agent` is a filtering mode, not a report format. It is available with `toon`, `json`, and `text`; it keeps the overall `status`, includes failed methods only, and omits method-level `status` because included method entries are implicitly failed.
+`--agent` is a filtering mode, not a report format. It is available with `toon`, `json`, and `text`; it keeps the overall `status` and `threshold`, includes failed methods only, and omits method-level `status` because included method entries are implicitly failed.
 
-Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit output keeps the aggregate XML attributes required by CI parsers and puts CRAP-specific details on each testcase.
+Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit output keeps the aggregate XML attributes required by CI parsers, writes `threshold` as a testsuite property, and puts method details on each testcase.
 
 ## Adapter Usage
 
@@ -129,7 +129,7 @@ module.exports = withCrapTypescriptVitest({
 });
 ```
 
-The Vitest adapter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `junitReportPath: false` to disable the JUnit artifact.
+The Vitest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
 
 Jest:
 
@@ -141,7 +141,7 @@ module.exports = withCrapTypescriptJest({
 });
 ```
 
-The Jest adapter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `junitReportPath: false` to disable the JUnit artifact.
+The Jest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
 
 ## Exit Codes
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,7 +35,7 @@ npx crap-typescript packages/api packages/web
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
 
-The default `toon` format is compact and agent-readable. `--agent` is a filtering mode, not a format: it keeps the overall `status`, includes failed method entries only, and omits method-level `status`.
+The default `toon` format is compact and agent-readable. Primary reports include run-level `status` and `threshold`; method rows use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. `--agent` is a filtering mode, not a format: it keeps the overall `status` and `threshold`, includes failed method entries only, and omits method-level `status`.
 
 ## Exit Codes
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,7 +20,7 @@ console.log(report);
 
 Key exports: `analyzeProject`, `calculateCrapScore`, `formatAnalysisReport`, `formatReport`, `parseCoverageReport`, `parseFileMethods`.
 
-`formatAnalysisReport` supports `toon`, `json`, `text`, and `junit`. The root report has only overall `status`; method-level entries contain CRAP score, threshold, complexity, coverage percent, coverage kind, source path, and line range. Pass `agent: true` with `toon`, `json`, or `text` to include failed methods only.
+`formatAnalysisReport` supports `toon`, `json`, `text`, and `junit`. Primary reports expose run-level `status` and `threshold`; method-level entries use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. JUnit writes `threshold` as a testsuite property. Pass `agent: true` with `toon`, `json`, or `text` to include failed methods only and omit method-level `status`.
 
 ## Formula
 

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -9,31 +9,33 @@ import type {
   ReportStatus
 } from "./types";
 
-const TEXT_HEADERS = ["Status", "Function", "CC", "Coverage Kind", "Coverage", "CRAP", "Threshold", "Location"];
-const AGENT_TEXT_HEADERS = ["Function", "CC", "Coverage Kind", "Coverage", "CRAP", "Threshold", "Location"];
+const METHOD_COLUMNS = ["status", "crap", "cc", "cov", "covKind", "func", "src", "lineStart", "lineEnd"] as const;
+const AGENT_METHOD_COLUMNS = ["crap", "cc", "cov", "covKind", "func", "src", "lineStart", "lineEnd"] as const;
+const RIGHT_ALIGNED_TEXT_COLUMNS = new Set<MethodColumn>(["crap", "cc", "cov", "lineStart", "lineEnd"]);
 
 export interface MethodReportEntry {
   status: MethodReportStatus;
-  name: string;
-  sourcePath: string;
-  startLine: number;
-  endLine: number;
-  complexity: number;
-  coverageKind: CoverageKind;
-  coveragePercent: number | null;
-  crapScore: number | null;
-  threshold: number;
+  crap: number | null;
+  cc: number;
+  cov: number | null;
+  covKind: CoverageKind;
+  func: string;
+  src: string;
+  lineStart: number;
+  lineEnd: number;
 }
 
 export type AgentMethodReportEntry = Omit<MethodReportEntry, "status">;
 
 export interface AnalysisReport {
   status: ReportStatus;
+  threshold: number;
   methods: MethodReportEntry[];
 }
 
 export interface AgentAnalysisReport {
   status: ReportStatus;
+  threshold: number;
   methods: AgentMethodReportEntry[];
 }
 
@@ -45,6 +47,8 @@ export interface FormatAnalysisReportOptions {
 type SerializableReport = AnalysisReport | AgentAnalysisReport;
 type ReportValue = string | number | null;
 type ReportFormatter = (report: SerializableReport, agent: boolean) => string;
+type MethodColumn = typeof METHOD_COLUMNS[number];
+type AgentMethodColumn = typeof AGENT_METHOD_COLUMNS[number];
 
 const REPORT_FORMATTERS: Record<ReportFormat, ReportFormatter> = {
   toon: formatToonReport,
@@ -75,6 +79,7 @@ export function buildAnalysisReport(metrics: MethodMetrics[]): AnalysisReport {
   const methods = sortMetrics(metrics).map(toMethodReportEntry);
   return {
     status: methods.some((method) => method.status === "failed") ? "failed" : "passed",
+    threshold: CRAP_THRESHOLD,
     methods
   };
 }
@@ -83,6 +88,7 @@ export function buildAgentAnalysisReport(metrics: MethodMetrics[]): AgentAnalysi
   const report = buildAnalysisReport(metrics);
   return {
     status: report.status,
+    threshold: report.threshold,
     methods: report.methods
       .filter((method) => method.status === "failed")
       .map(({ status: _status, ...method }) => method)
@@ -106,11 +112,9 @@ export function formatReport(metrics: MethodMetrics[]): string {
 }
 
 export function formatToonReport(report: SerializableReport, agent = false): string {
-  const lines = [`status: ${report.status}`];
+  const lines = [`status: ${report.status}`, `threshold: ${formatNumber(report.threshold)}`];
   const includeStatus = !agent && reportHasMethodStatus(report);
-  const columns = includeStatus
-    ? ["status", "name", "sourcePath", "startLine", "endLine", "complexity", "coverageKind", "coveragePercent", "crapScore", "threshold"]
-    : ["name", "sourcePath", "startLine", "endLine", "complexity", "coverageKind", "coveragePercent", "crapScore", "threshold"];
+  const columns = includeStatus ? METHOD_COLUMNS : AGENT_METHOD_COLUMNS;
 
   if (report.methods.length === 0) {
     return agent ? `${lines.join("\n")}\n` : `${[...lines, "methods[0]:"].join("\n")}\n`;
@@ -124,32 +128,26 @@ export function formatToonReport(report: SerializableReport, agent = false): str
 }
 
 export function formatTextReport(report: SerializableReport, agent = false): string {
+  const summary = [`status: ${report.status}`, `threshold: ${formatNumber(report.threshold)}`];
   if (report.methods.length === 0) {
-    return `Status: ${report.status}\n`;
+    return `${summary.join("\n")}\n`;
   }
 
   const includeStatus = !agent && reportHasMethodStatus(report);
-  const headers = includeStatus ? TEXT_HEADERS : AGENT_TEXT_HEADERS;
-  const rows = report.methods.map((method) => {
-    const values = [
-      method.name,
-      String(method.complexity),
-      method.coverageKind,
-      formatNullablePercent(method.coveragePercent),
-      formatNullableNumber(method.crapScore),
-      formatNumber(method.threshold),
-      `${method.sourcePath}:${method.startLine}-${method.endLine}`
-    ];
-    return includeStatus && "status" in method ? [method.status, ...values] : values;
-  });
-  const widths = headers.map((header, index) =>
-    rows.reduce((max, row) => Math.max(max, row[index].length), header.length)
+  const columns = includeStatus ? METHOD_COLUMNS : AGENT_METHOD_COLUMNS;
+  const rows = includeStatus
+    ? report.methods.map((method) => METHOD_COLUMNS.map((column) => formatTextValue(column, method[column])))
+    : (report as AgentAnalysisReport).methods.map((method) =>
+      AGENT_METHOD_COLUMNS.map((column) => formatTextValue(column, method[column]))
+    );
+  const widths = columns.map((column, index) =>
+    rows.reduce((max, row) => Math.max(max, row[index].length), column.length)
   );
-  const headerLine = headers.map((header, index) => header.padEnd(widths[index])).join("  ");
-  const separator = widths.map((width) => "-".repeat(width)).join("  ");
-  const body = rows.map((row) => row.map((value, index) => value.padEnd(widths[index])).join("  "));
+  const headerLine = formatTextRow([...columns], widths, columns);
+  const separator = formatTextSeparator(widths);
+  const body = rows.map((row) => formatTextRow(row, widths, columns));
 
-  return [`Status: ${report.status}`, "", headerLine, separator, ...body].join("\n") + "\n";
+  return [...summary, "", headerLine, separator, ...body].join("\n") + "\n";
 }
 
 export function formatJunitReport(report: AnalysisReport): string {
@@ -159,10 +157,13 @@ export function formatJunitReport(report: AnalysisReport): string {
     '<?xml version="1.0" encoding="UTF-8"?>',
     `<testsuite name="crap-typescript" status="${report.status}" tests="${report.methods.length}" failures="${failures}" skipped="${skipped}" errors="0">`
   ];
+  lines.push("  <properties>");
+  lines.push(`    <property name="threshold" value="${formatNumber(report.threshold)}" />`);
+  lines.push("  </properties>");
 
   for (const method of report.methods) {
     lines.push(
-      `  <testcase classname="${escapeXmlAttribute(method.sourcePath)}" name="${escapeXmlAttribute(method.name)}" file="${escapeXmlAttribute(method.sourcePath)}" line="${method.startLine}">`
+      `  <testcase classname="${escapeXmlAttribute(method.src)}" name="${escapeXmlAttribute(method.func)}" file="${escapeXmlAttribute(method.src)}" line="${method.lineStart}">`
     );
     lines.push("    <properties>");
     for (const [name, value] of methodProperties(method)) {
@@ -170,7 +171,7 @@ export function formatJunitReport(report: AnalysisReport): string {
     }
     lines.push("    </properties>");
     if (method.status === "failed") {
-      const message = `CRAP score ${formatNullableNumber(method.crapScore)} exceeds threshold ${formatNumber(method.threshold)}`;
+      const message = `CRAP score ${formatNullableNumber(method.crap)} exceeds threshold ${formatNumber(report.threshold)}`;
       lines.push(`    <failure type="crap-threshold" message="${escapeXmlAttribute(message)}">${escapeXmlText(message)}</failure>`);
     }
     if (method.status === "skipped") {
@@ -186,15 +187,14 @@ export function formatJunitReport(report: AnalysisReport): string {
 function toMethodReportEntry(metric: MethodMetrics): MethodReportEntry {
   return {
     status: methodStatus(metric),
-    name: metric.displayName,
-    sourcePath: metric.relativePath,
-    startLine: metric.startLine,
-    endLine: metric.endLine,
-    complexity: metric.complexity,
-    coverageKind: coverageKind(metric),
-    coveragePercent: metric.coveragePercent,
-    crapScore: metric.crapScore,
-    threshold: CRAP_THRESHOLD
+    crap: metric.crapScore,
+    cc: metric.complexity,
+    cov: metric.coveragePercent,
+    covKind: coverageKind(metric),
+    func: metric.displayName,
+    src: metric.relativePath,
+    lineStart: metric.startLine,
+    lineEnd: metric.endLine
   };
 }
 
@@ -230,13 +230,17 @@ function formatToonValue(value: ReportValue): string {
     return "null";
   }
   if (typeof value === "number") {
-    return Number.isInteger(value) ? String(value) : formatNumber(value);
+    return formatToonNumber(value);
   }
-  return /^[A-Za-z0-9_.:/#@$-]+$/.test(value) ? value : JSON.stringify(value);
+  return formatToonString(value);
 }
 
-function formatNullablePercent(value: number | null): string {
-  return value === null ? "N/A" : `${formatNumber(value)}%`;
+function formatToonNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : formatNumber(value);
+}
+
+function formatToonString(value: string): string {
+  return /^[A-Za-z0-9_.:/#@$-]+$/.test(value) ? value : JSON.stringify(value);
 }
 
 function formatNullableNumber(value: number | null): string {
@@ -247,18 +251,43 @@ function formatJunitNullableNumber(value: number | null): string {
   return value === null ? "" : formatNumber(value);
 }
 
+function formatTextValue(column: MethodColumn | AgentMethodColumn, value: ReportValue): string {
+  if (column === "cov") {
+    return value === null ? "N/A" : `${formatNumber(value as number)}%`;
+  }
+  if (column === "crap") {
+    return formatNullableNumber(value as number | null);
+  }
+  return value === null ? "N/A" : String(value);
+}
+
+function formatTextRow(
+  values: string[],
+  widths: number[],
+  columns: readonly (MethodColumn | AgentMethodColumn)[] = METHOD_COLUMNS
+): string {
+  return `| ${values.map((value, index) => formatTextCell(value, widths[index], columns[index])).join(" | ")} |`;
+}
+
+function formatTextCell(value: string, width: number, column: MethodColumn | AgentMethodColumn): string {
+  return RIGHT_ALIGNED_TEXT_COLUMNS.has(column as MethodColumn) ? value.padStart(width) : value.padEnd(width);
+}
+
+function formatTextSeparator(widths: number[]): string {
+  return `| ${widths.map((width) => "-".repeat(width)).join(" | ")} |`;
+}
+
 function methodProperties(method: MethodReportEntry): Array<[string, string]> {
   return [
     ["status", method.status],
-    ["score", formatJunitNullableNumber(method.crapScore)],
-    ["threshold", formatNumber(method.threshold)],
-    ["complexity", String(method.complexity)],
-    ["coveragePercent", formatJunitNullableNumber(method.coveragePercent)],
-    ["coverageKind", method.coverageKind],
-    ["sourcePath", method.sourcePath],
-    ["startLine", String(method.startLine)],
-    ["endLine", String(method.endLine)],
-    ["lineRange", `${method.startLine}-${method.endLine}`]
+    ["crap", formatJunitNullableNumber(method.crap)],
+    ["cc", String(method.cc)],
+    ["cov", formatJunitNullableNumber(method.cov)],
+    ["covKind", method.covKind],
+    ["func", method.func],
+    ["src", method.src],
+    ["lineStart", String(method.lineStart)],
+    ["lineEnd", String(method.lineEnd)]
   ];
 }
 

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -211,9 +211,55 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toContain("status: failed");
-    expect(stdout.toString()).toContain("methods[2]{status,name,sourcePath,startLine,endLine,complexity,coverageKind,coveragePercent,crapScore,threshold}:");
+    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("methods[2]{status,crap,cc,cov,covKind,func,src,lineStart,lineEnd}:");
     expect(stdout.toString()).toContain("risky");
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
+  });
+
+  it("prints the revised text table when requested", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            }
+          },
+          fnMap: {},
+          branchMap: {},
+          s: {
+            "0": 1
+          },
+          f: {},
+          b: {}
+        }
+      })
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const exitCode = await runCli(["--format", "text"], projectRoot, stdout, stderr);
+    const tableLines = stdout.toString().split("\n").filter((line) => line.startsWith("|"));
+    const pipePositions = tableLines.map((line) =>
+      [...line].flatMap((char, index) => char === "|" ? [index] : [])
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.toString()).toContain("status: passed");
+    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(tableLines[0]).toBe("| status | crap | cc |    cov | covKind | func | src           | lineStart | lineEnd |");
+    expect(new Set(pipePositions.map((positions) => positions.join(","))).size).toBe(1);
+    expect(stderr.toString()).toBe("");
   });
 
   it("filters primary reports in agent mode and writes full JUnit before threshold failure", async () => {
@@ -313,6 +359,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     const primary = JSON.parse(await readText(`${projectRoot}/reports/crap.json`)) as {
       status: string;
+      threshold: number;
       methods: Array<Record<string, unknown>>;
     };
     const junit = await readText(`${projectRoot}/reports/crap.xml`);
@@ -320,9 +367,11 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toBe("");
     expect(primary.status).toBe("failed");
+    expect(primary.threshold).toBe(8);
     expect(primary.methods).toHaveLength(1);
-    expect(primary.methods[0].name).toBe("risky");
+    expect(primary.methods[0].func).toBe("risky");
     expect(primary.methods[0]).not.toHaveProperty("status");
+    expect(primary.methods[0]).not.toHaveProperty("threshold");
     expect(junit).toContain('tests="2"');
     expect(junit).toContain('name="safe"');
     expect(junit).toContain('name="risky"');
@@ -390,6 +439,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("status: passed");
+    expect(stdout.toString()).toContain("threshold: 8.0");
     expect(stdout.toString()).toContain("safe");
     expect(stderr.toString()).toBe("");
   });
@@ -406,7 +456,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 
@@ -424,7 +474,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -85,21 +85,22 @@ describe("report formatting", () => {
     ]);
 
     expect(report.status).toBe("failed");
+    expect(report.threshold).toBe(8);
     expect(report.methods).toMatchObject([
       {
         status: "failed",
-        name: "risky",
-        coverageKind: "branch"
+        func: "risky",
+        covKind: "branch"
       },
       {
         status: "passed",
-        name: "safe",
-        coverageKind: "stmt"
+        func: "safe",
+        covKind: "stmt"
       },
       {
         status: "skipped",
-        name: "unknownCoverage",
-        coverageKind: "stmt"
+        func: "unknownCoverage",
+        covKind: "stmt"
       }
     ]);
   });
@@ -117,21 +118,28 @@ describe("report formatting", () => {
 
     expect(report.methods[0]).toMatchObject({
       status: "skipped",
-      coverageKind: "branch"
+      covKind: "branch"
     });
   });
 
   it("formats JSON without global aggregate fields", () => {
     const parsed = JSON.parse(formatAnalysisReport([metric()], { format: "json" })) as Record<string, unknown>;
 
-    expect(Object.keys(parsed)).toEqual(["status", "methods"]);
+    expect(Object.keys(parsed)).toEqual(["status", "threshold", "methods"]);
     expect(parsed.status).toBe("passed");
+    expect(parsed.threshold).toBe(8);
     expect(parsed.methods).toEqual([
-      expect.objectContaining({
+      {
         status: "passed",
-        name: "safe",
-        threshold: 8
-      })
+        crap: 1,
+        cc: 1,
+        cov: 100,
+        covKind: "stmt",
+        func: "safe",
+        src: "src/sample.ts",
+        lineStart: 1,
+        lineEnd: 3
+      }
     ]);
   });
 
@@ -139,7 +147,7 @@ describe("report formatting", () => {
     const output = formatAnalysisReport([
       metric(),
       metric({
-        displayName: "risky",
+        displayName: "risky value",
         complexity: 4,
         coverage: measured(0),
         statementCoverage: measured(0),
@@ -150,23 +158,58 @@ describe("report formatting", () => {
     ], { format: "toon", agent: true });
 
     expect(output).toContain("status: failed");
-    expect(output).toContain("methods[1]{name,sourcePath,startLine,endLine,complexity,coverageKind,coveragePercent,crapScore,threshold}:");
-    expect(output).toContain("risky");
+    expect(output).toContain("threshold: 8.0");
+    expect(output).toContain("methods[1]{crap,cc,cov,covKind,func,src,lineStart,lineEnd}:");
+    expect(output).toContain("\"risky value\"");
     expect(output).not.toContain("safe");
-    expect(output).not.toContain("failed,risky");
+    expect(output).not.toContain("failed,\"risky value\"");
   });
 
-  it("formats text reports with only method-level details", () => {
-    const output = formatTextReport(buildAnalysisReport([metric()]));
+  it("formats unavailable TOON values as null", () => {
+    const output = formatToonReport(buildAnalysisReport([
+      metric({
+        displayName: "missingCoverage",
+        coverage: unknown("missing_report"),
+        statementCoverage: unknown("missing_report"),
+        branchCoverage: unknown("missing_report"),
+        coveragePercent: null,
+        crapScore: null
+      })
+    ]));
 
-    expect(output).toContain("Status: passed");
-    expect(output).toContain("Function");
+    expect(output).toContain("skipped,null,1,null,stmt,missingCoverage");
+  });
+
+  it("formats text reports with aligned method columns", () => {
+    const output = formatTextReport(buildAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        startLine: 15,
+        endLine: 120,
+        complexity: 12,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 120
+      })
+    ]));
+    const tableLines = output.split("\n").filter((line) => line.startsWith("|"));
+    const pipePositions = tableLines.map((line) =>
+      [...line].flatMap((char, index) => char === "|" ? [index] : [])
+    );
+
+    expect(output).toContain("status: failed");
+    expect(output).toContain("threshold: 8.0");
+    expect(tableLines[0]).toBe("| status |  crap | cc |    cov | covKind | func  | src           | lineStart | lineEnd |");
+    expect(new Set(pipePositions.map((positions) => positions.join(","))).size).toBe(1);
     expect(output).toContain("safe");
     expect(output).not.toContain("Summary");
   });
 
   it("formats empty agent reports as status only", () => {
-    expect(formatToonReport(buildAgentAnalysisReport([]), true)).toBe("status: passed\n");
+    expect(formatToonReport(buildAgentAnalysisReport([]), true)).toBe("status: passed\nthreshold: 8.0\n");
   });
 
   it("formats JUnit XML with testcase properties and escaped values", () => {
@@ -184,11 +227,13 @@ describe("report formatting", () => {
     ]));
 
     expect(output).toContain('<testsuite name="crap-typescript" status="failed" tests="1" failures="1" skipped="0" errors="0">');
+    expect(output).toContain('<property name="threshold" value="8.0" />');
     expect(output).toContain('name="risky &lt;value&gt;"');
     expect(output).toContain('file="src/special&amp;file.ts"');
-    expect(output).toContain('<property name="score" value="20.0" />');
-    expect(output).toContain('<property name="coveragePercent" value="0.0" />');
-    expect(output).toContain('<property name="coverageKind" value="stmt" />');
+    expect(output).toContain('<property name="crap" value="20.0" />');
+    expect(output).toContain('<property name="cov" value="0.0" />');
+    expect(output).toContain('<property name="covKind" value="stmt" />');
+    expect(output.match(/property name="threshold"/g)).toHaveLength(1);
     expect(output).toContain("<failure");
   });
 
@@ -204,8 +249,8 @@ describe("report formatting", () => {
       })
     ]));
 
-    expect(output).toContain('<property name="score" value="" />');
-    expect(output).toContain('<property name="coveragePercent" value="" />');
+    expect(output).toContain('<property name="crap" value="" />');
+    expect(output).toContain('<property name="cov" value="" />');
     expect(output).toContain("<skipped");
   });
 });

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -20,7 +20,7 @@ module.exports = withCrapTypescriptJest({
 
 `withCrapTypescriptJest` wraps your Jest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
-The reporter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
 
 The reporter is also available as a standalone export at `@barney-media/crap-typescript-jest/reporter` for direct configuration.
 

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -163,7 +163,7 @@ function resolveCoverageReportPathOption(options: CrapTypescriptJestOptions): st
 }
 
 function resolveFormat(options: CrapTypescriptJestOptions): ReportFormat {
-  return options.format ?? "toon";
+  return options.format ?? "text";
 }
 
 function resolveAgent(options: CrapTypescriptJestOptions): boolean {

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -46,7 +46,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(finalize).toHaveBeenCalledTimes(1);
   });
 
-  it("prints a passed TOON report when no analyzable source files are selected", async () => {
+  it("prints a passed text report when no analyzable source files are selected", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -64,11 +64,35 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
-    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\n");
     expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
     expect(reporter.getLastError()).toBeUndefined();
     expect(process.exitCode).toBe(originalExitCode);
+  });
+
+  it("supports explicit TOON output", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": "{}"
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptJestReporter(undefined, {
+      projectRoot,
+      format: "toon",
+      junitReportPath: false,
+      stdout,
+      stderr
+    });
+
+    await callFinalize(reporter);
+
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
+    expect(stderr.toString()).toBe("");
   });
 
   it("prints the CRAP report and stores the threshold error for an absolute coverage path", async () => {
@@ -163,6 +187,8 @@ describe("CrapTypescriptJestReporter", () => {
     const junit = await readText(`${projectRoot}/custom-coverage/crap-typescript-junit.xml`);
 
     expect(stdout.toString()).toContain("status: failed");
+    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("| status |");
     expect(stdout.toString()).toContain("risky");
     expect(junit).toContain('tests="1"');
     expect(junit).toContain("<failure");
@@ -216,6 +242,7 @@ describe("CrapTypescriptJestReporter", () => {
 
     expect(JSON.parse(stdout.toString())).toEqual({
       status: "passed",
+      threshold: 8,
       methods: []
     });
     await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -22,7 +22,7 @@ module.exports = withCrapTypescriptVitest({
 
 `withCrapTypescriptVitest` wraps your Vitest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
-The reporter prints TOON output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
 
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -186,7 +186,7 @@ function resolvePackageManager(options: CrapTypescriptVitestOptions): PackageMan
 }
 
 function resolveFormat(options: CrapTypescriptVitestOptions): ReportFormat {
-  return options.format ?? "toon";
+  return options.format ?? "text";
 }
 
 function resolveAgent(options: CrapTypescriptVitestOptions): boolean {

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -16,7 +16,7 @@ afterEach(async () => {
 });
 
 describe("CrapTypescriptVitestReporter", () => {
-  it("prints a passed TOON report when no analyzable source files are selected", async () => {
+  it("prints a passed text report when no analyzable source files are selected", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -33,10 +33,33 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
-    expect(stdout.toString()).toBe("status: passed\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\n");
     expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
     expect(process.exitCode).toBe(originalExitCode);
+  });
+
+  it("supports explicit TOON output", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}'
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      format: "toon",
+      junitReportPath: false,
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
+    expect(stderr.toString()).toBe("");
   });
 
   it("prints the CRAP report and sets a failure exit code when the threshold is exceeded", async () => {
@@ -130,6 +153,8 @@ describe("CrapTypescriptVitestReporter", () => {
     const junit = await readText(`${projectRoot}/custom-coverage/crap-typescript-junit.xml`);
 
     expect(stdout.toString()).toContain("status: failed");
+    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("| status |");
     expect(stdout.toString()).toContain("risky");
     expect(junit).toContain('tests="1"');
     expect(junit).toContain("<failure");
@@ -181,6 +206,7 @@ describe("CrapTypescriptVitestReporter", () => {
 
     expect(JSON.parse(stdout.toString())).toEqual({
       status: "passed",
+      threshold: 8,
       methods: []
     });
     await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();


### PR DESCRIPTION
## Summary

- switch Jest and Vitest adapter default stdout reports to `text` while keeping the CLI default as `toon`
- move `threshold` to report-level output and use abbreviated method fields across report formats
- improve text report table width calculation so headers, cells, and delimiters align

## Validation

- `npm run build`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`

Closes #49