### PR TITLE
Use XML builder for JUnit reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -948,6 +948,18 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
@@ -2510,6 +2522,42 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4101,6 +4149,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4599,6 +4662,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -5377,6 +5452,7 @@
       "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "fast-xml-parser": "^5.7.2",
         "typescript": "^6.0.2"
       },
       "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "fast-xml-parser": "^5.7.2",
     "typescript": "^6.0.2"
   }
 }

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -284,23 +284,25 @@ function createXmlBuilder(): XMLBuilder {
 
 function toJunitXml(report: AnalysisReport): XmlNode {
   const counts = countJunitMethodStatuses(report.methods);
-
-  return {
-    testsuite: {
-      "@_name": "crap-typescript",
-      "@_status": report.status,
-      "@_tests": report.methods.length,
-      "@_failures": counts.failures,
-      "@_skipped": counts.skipped,
-      "@_errors": 0,
-      properties: {
-        property: [
-          toXmlProperty("threshold", formatNumber(report.threshold))
-        ]
-      },
-      testcase: report.methods.map((method) => toJunitTestcaseXml(method, report.threshold))
+  const testsuite: XmlNode = {
+    "@_name": "crap-typescript",
+    "@_status": report.status,
+    "@_tests": report.methods.length,
+    "@_failures": counts.failures,
+    "@_skipped": counts.skipped,
+    "@_errors": 0,
+    properties: {
+      property: [
+        toXmlProperty("threshold", formatNumber(report.threshold))
+      ]
     }
   };
+
+  if (report.methods.length > 0) {
+    testsuite.testcase = report.methods.map((method) => toJunitTestcaseXml(method, report.threshold));
+  }
+
+  return { testsuite };
 }
 
 function countJunitMethodStatuses(methods: MethodReportEntry[]): JunitMethodCounts {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,3 +1,5 @@
+import { XMLBuilder } from "fast-xml-parser";
+
 import { CRAP_THRESHOLD } from "./constants";
 import { formatNumber } from "./utils";
 import type {
@@ -49,6 +51,7 @@ type ReportValue = string | number | null;
 type ReportFormatter = (report: SerializableReport, agent: boolean) => string;
 type MethodColumn = typeof METHOD_COLUMNS[number];
 type AgentMethodColumn = typeof AGENT_METHOD_COLUMNS[number];
+type XmlNode = Record<string, unknown>;
 
 const REPORT_FORMATTERS: Record<ReportFormat, ReportFormatter> = {
   toon: formatToonReport,
@@ -151,37 +154,7 @@ export function formatTextReport(report: SerializableReport, agent = false): str
 }
 
 export function formatJunitReport(report: AnalysisReport): string {
-  const failures = report.methods.filter((method) => method.status === "failed").length;
-  const skipped = report.methods.filter((method) => method.status === "skipped").length;
-  const lines = [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    `<testsuite name="crap-typescript" status="${report.status}" tests="${report.methods.length}" failures="${failures}" skipped="${skipped}" errors="0">`
-  ];
-  lines.push("  <properties>");
-  lines.push(`    <property name="threshold" value="${formatNumber(report.threshold)}" />`);
-  lines.push("  </properties>");
-
-  for (const method of report.methods) {
-    lines.push(
-      `  <testcase classname="${escapeXmlAttribute(method.src)}" name="${escapeXmlAttribute(method.func)}" file="${escapeXmlAttribute(method.src)}" line="${method.lineStart}">`
-    );
-    lines.push("    <properties>");
-    for (const [name, value] of methodProperties(method)) {
-      lines.push(`      <property name="${name}" value="${escapeXmlAttribute(value)}" />`);
-    }
-    lines.push("    </properties>");
-    if (method.status === "failed") {
-      const message = `CRAP score ${formatNullableNumber(method.crap)} exceeds threshold ${formatNumber(report.threshold)}`;
-      lines.push(`    <failure type="crap-threshold" message="${escapeXmlAttribute(message)}">${escapeXmlText(message)}</failure>`);
-    }
-    if (method.status === "skipped") {
-      lines.push('    <skipped message="CRAP score unavailable" />');
-    }
-    lines.push("  </testcase>");
-  }
-
-  lines.push("</testsuite>");
-  return `${lines.join("\n")}\n`;
+  return `${formatXmlDeclaration()}\n${createXmlBuilder().build(toJunitXml(report)).trimEnd()}\n`;
 }
 
 function toMethodReportEntry(metric: MethodMetrics): MethodReportEntry {
@@ -291,13 +264,75 @@ function methodProperties(method: MethodReportEntry): Array<[string, string]> {
   ];
 }
 
-function escapeXmlAttribute(value: string): string {
-  return escapeXmlText(value).replace(/"/g, "&quot;");
+function formatXmlDeclaration(): string {
+  return '<?xml version="1.0" encoding="UTF-8"?>';
 }
 
-function escapeXmlText(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+function createXmlBuilder(): XMLBuilder {
+  return new XMLBuilder({
+    attributeNamePrefix: "@_",
+    format: true,
+    ignoreAttributes: false,
+    suppressEmptyNode: true
+  });
+}
+
+function toJunitXml(report: AnalysisReport): XmlNode {
+  return {
+    testsuite: {
+      "@_name": "crap-typescript",
+      "@_status": report.status,
+      "@_tests": report.methods.length,
+      "@_failures": report.methods.filter((method) => method.status === "failed").length,
+      "@_skipped": report.methods.filter((method) => method.status === "skipped").length,
+      "@_errors": 0,
+      properties: {
+        property: [
+          toXmlProperty("threshold", formatNumber(report.threshold))
+        ]
+      },
+      testcase: report.methods.map((method) => toJunitTestcaseXml(method, report.threshold))
+    }
+  };
+}
+
+function toJunitTestcaseXml(method: MethodReportEntry, threshold: number): XmlNode {
+  return {
+    "@_classname": method.src,
+    "@_name": method.func,
+    "@_file": method.src,
+    "@_line": method.lineStart,
+    properties: {
+      property: methodProperties(method).map(([name, value]) => toXmlProperty(name, value))
+    },
+    ...junitStatusXml(method, threshold)
+  };
+}
+
+function toXmlProperty(name: string, value: string): XmlNode {
+  return {
+    "@_name": name,
+    "@_value": value
+  };
+}
+
+function junitStatusXml(method: MethodReportEntry, threshold: number): XmlNode {
+  if (method.status === "failed") {
+    const message = `CRAP score ${formatNullableNumber(method.crap)} exceeds threshold ${formatNumber(threshold)}`;
+    return {
+      failure: {
+        "@_type": "crap-threshold",
+        "@_message": message,
+        "#text": message
+      }
+    };
+  }
+  if (method.status === "skipped") {
+    return {
+      skipped: {
+        "@_message": "CRAP score unavailable"
+      }
+    };
+  }
+  return {};
 }

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -53,6 +53,11 @@ type MethodColumn = typeof METHOD_COLUMNS[number];
 type AgentMethodColumn = typeof AGENT_METHOD_COLUMNS[number];
 type XmlNode = Record<string, unknown>;
 
+interface JunitMethodCounts {
+  failures: number;
+  skipped: number;
+}
+
 const REPORT_FORMATTERS: Record<ReportFormat, ReportFormatter> = {
   toon: formatToonReport,
   json: (report) => `${JSON.stringify(report, null, 2)}\n`,
@@ -278,13 +283,15 @@ function createXmlBuilder(): XMLBuilder {
 }
 
 function toJunitXml(report: AnalysisReport): XmlNode {
+  const counts = countJunitMethodStatuses(report.methods);
+
   return {
     testsuite: {
       "@_name": "crap-typescript",
       "@_status": report.status,
       "@_tests": report.methods.length,
-      "@_failures": report.methods.filter((method) => method.status === "failed").length,
-      "@_skipped": report.methods.filter((method) => method.status === "skipped").length,
+      "@_failures": counts.failures,
+      "@_skipped": counts.skipped,
       "@_errors": 0,
       properties: {
         property: [
@@ -294,6 +301,18 @@ function toJunitXml(report: AnalysisReport): XmlNode {
       testcase: report.methods.map((method) => toJunitTestcaseXml(method, report.threshold))
     }
   };
+}
+
+function countJunitMethodStatuses(methods: MethodReportEntry[]): JunitMethodCounts {
+  const counts = { failures: 0, skipped: 0 };
+  for (const method of methods) {
+    if (method.status === "failed") {
+      counts.failures += 1;
+    } else if (method.status === "skipped") {
+      counts.skipped += 1;
+    }
+  }
+  return counts;
 }
 
 function toJunitTestcaseXml(method: MethodReportEntry, threshold: number): XmlNode {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -215,8 +215,8 @@ describe("report formatting", () => {
   it("formats JUnit XML with testcase properties and escaped values", () => {
     const output = formatJunitReport(buildAnalysisReport([
       metric({
-        displayName: "risky <value>",
-        relativePath: "src/special&file.ts",
+        displayName: "risky \"quoted\" <value>",
+        relativePath: "src/\"special\"&file.ts",
         complexity: 4,
         coverage: measured(0),
         statementCoverage: measured(0),
@@ -228,8 +228,8 @@ describe("report formatting", () => {
 
     expect(output).toContain('<testsuite name="crap-typescript" status="failed" tests="1" failures="1" skipped="0" errors="0">');
     expect(output).toContain('<property name="threshold" value="8.0"/>');
-    expect(output).toContain('name="risky &lt;value&gt;"');
-    expect(output).toContain('file="src/special&amp;file.ts"');
+    expect(output).toContain('name="risky &quot;quoted&quot; &lt;value&gt;"');
+    expect(output).toContain('file="src/&quot;special&quot;&amp;file.ts"');
     expect(output).toContain('<property name="crap" value="20.0"/>');
     expect(output).toContain('<property name="cov" value="0.0"/>');
     expect(output).toContain('<property name="covKind" value="stmt"/>');

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -227,14 +227,16 @@ describe("report formatting", () => {
     ]));
 
     expect(output).toContain('<testsuite name="crap-typescript" status="failed" tests="1" failures="1" skipped="0" errors="0">');
-    expect(output).toContain('<property name="threshold" value="8.0" />');
+    expect(output).toContain('<property name="threshold" value="8.0"/>');
     expect(output).toContain('name="risky &lt;value&gt;"');
     expect(output).toContain('file="src/special&amp;file.ts"');
-    expect(output).toContain('<property name="crap" value="20.0" />');
-    expect(output).toContain('<property name="cov" value="0.0" />');
-    expect(output).toContain('<property name="covKind" value="stmt" />');
+    expect(output).toContain('<property name="crap" value="20.0"/>');
+    expect(output).toContain('<property name="cov" value="0.0"/>');
+    expect(output).toContain('<property name="covKind" value="stmt"/>');
     expect(output.match(/property name="threshold"/g)).toHaveLength(1);
     expect(output).toContain("<failure");
+    expect(output.endsWith("\n")).toBe(true);
+    expect(output.endsWith("\n\n")).toBe(false);
   });
 
   it("formats unavailable JUnit numeric properties as empty values", () => {
@@ -249,8 +251,8 @@ describe("report formatting", () => {
       })
     ]));
 
-    expect(output).toContain('<property name="crap" value="" />');
-    expect(output).toContain('<property name="cov" value="" />');
+    expect(output).toContain('<property name="crap" value=""/>');
+    expect(output).toContain('<property name="cov" value=""/>');
     expect(output).toContain("<skipped");
   });
 });

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -255,4 +255,14 @@ describe("report formatting", () => {
     expect(output).toContain('<property name="cov" value=""/>');
     expect(output).toContain("<skipped");
   });
+
+  it("formats empty JUnit reports without testcase elements", () => {
+    const output = formatJunitReport(buildAnalysisReport([]));
+
+    expect(output).toContain('<testsuite name="crap-typescript" status="passed" tests="0" failures="0" skipped="0" errors="0">');
+    expect(output).toContain('<property name="threshold" value="8.0"/>');
+    expect(output).not.toContain("<testcase");
+    expect(output.endsWith("\n")).toBe(true);
+    expect(output.endsWith("\n\n")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add fast-xml-parser to the core package
- marshal JUnit XML through XMLBuilder instead of hand-built XML strings
- keep the existing JUnit attributes, status nodes, escaping behavior, and single trailing newline

Fixes #52

## Tests
- npm run build
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- npm pack --workspaces