### PR TITLE
Use official TOON encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Use `--junit-report <path>` to write a full JUnit XML artifact alongside the pri
 Vitest:
 
 ```js
-const { withCrapTypescriptVitest } = require("@barney-media/crap-typescript-vitest");
+import { withCrapTypescriptVitest } from "@barney-media/crap-typescript-vitest";
 
-module.exports = withCrapTypescriptVitest({
+export default withCrapTypescriptVitest({
   test: {
     include: ["test/**/*.test.ts"]
   }
@@ -134,9 +134,9 @@ The Vitest adapter prints text output by default and writes `coverage/crap-types
 Jest:
 
 ```js
-const { withCrapTypescriptJest } = require("@barney-media/crap-typescript-jest");
+import { withCrapTypescriptJest } from "@barney-media/crap-typescript-jest";
 
-module.exports = withCrapTypescriptJest({
+export default withCrapTypescriptJest({
   testEnvironment: "node"
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,6 +1285,12 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@toon-format/toon": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.1.0.tgz",
+      "integrity": "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5452,6 +5458,7 @@
       "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@toon-format/toon": "^2.1.0",
         "fast-xml-parser": "^5.7.2",
         "typescript": "^6.0.2"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   "bugs": {
     "url": "https://github.com/fabian-barney/crap-typescript/issues"
   },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
   "bugs": {
     "url": "https://github.com/fabian-barney/crap-typescript/issues"
   },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -40,6 +41,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@toon-format/toon": "^2.1.0",
     "fast-xml-parser": "^5.7.2",
     "typescript": "^6.0.2"
   }

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -1,15 +1,15 @@
 import path from "node:path";
 
-import { CRAP_THRESHOLD } from "./constants";
-import { coverageForMethods } from "./coverageAttribution";
-import { ensureCoverageReport, expectedCoveragePath } from "./coverage";
-import type { FileCoverage } from "./coverageUnits";
-import { calculateCrapScore, maxCrap } from "./crapScore";
-import { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots } from "./fileSelection";
-import { parseCoverageReport } from "./istanbul";
-import { resolveModuleRoot } from "./moduleResolution";
-import { parseFileMethods } from "./parser";
-import { DefaultCommandExecutor, normalizePathForMatch, toRelativePath, writeLine } from "./utils";
+import { CRAP_THRESHOLD } from "./constants.js";
+import { coverageForMethods } from "./coverageAttribution.js";
+import { ensureCoverageReport, expectedCoveragePath } from "./coverage.js";
+import type { FileCoverage } from "./coverageUnits.js";
+import { calculateCrapScore, maxCrap } from "./crapScore.js";
+import { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots } from "./fileSelection.js";
+import { parseCoverageReport } from "./istanbul.js";
+import { resolveModuleRoot } from "./moduleResolution.js";
+import { parseFileMethods } from "./parser.js";
+import { DefaultCommandExecutor, normalizePathForMatch, toRelativePath, writeLine } from "./utils.js";
 import type {
   AnalysisResult,
   AnalyzeProjectOptions,
@@ -17,7 +17,7 @@ import type {
   CoverageUnknownReason,
   MethodDescriptor,
   MethodMetrics
-} from "./types";
+} from "./types.js";
 
 export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promise<AnalysisResult> {
   const context = createAnalyzeContext(options);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,11 +1,11 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { CRAP_THRESHOLD } from "./constants";
-import { analyzeProject } from "./analyzeProject";
-import { formatAnalysisReport } from "./report";
-import { formatNumber, writeLine } from "./utils";
-import type { CliArguments, PackageManagerSelection, ReportFormat, TestRunnerSelection, Writer } from "./types";
+import { CRAP_THRESHOLD } from "./constants.js";
+import { analyzeProject } from "./analyzeProject.js";
+import { formatAnalysisReport } from "./report.js";
+import { formatNumber, writeLine } from "./utils.js";
+import type { CliArguments, PackageManagerSelection, ReportFormat, TestRunnerSelection, Writer } from "./types.js";
 
 const HELP_TEXT = `crap-typescript
 

--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
 
-import { COVERAGE_REPORT_RELATIVE_PATH } from "./constants";
-import { locateCoverageReport, resolvePackageManager, resolveTestRunner } from "./moduleResolution";
-import { isAbsolutePath } from "./utils";
-import type { CommandExecutor, CoverageMode, CoverageCommand, PackageManager, TestRunner } from "./types";
+import { COVERAGE_REPORT_RELATIVE_PATH } from "./constants.js";
+import { locateCoverageReport, resolvePackageManager, resolveTestRunner } from "./moduleResolution.js";
+import { isAbsolutePath } from "./utils.js";
+import type { CommandExecutor, CoverageMode, CoverageCommand, PackageManager, TestRunner } from "./types.js";
 
 export async function ensureCoverageReport(
   projectRoot: string,

--- a/packages/core/src/coverageAttribution.ts
+++ b/packages/core/src/coverageAttribution.ts
@@ -1,7 +1,7 @@
-import type { CoverageUnknownReason, MethodDescriptor, SourceSpan } from "./types";
-import { computeMethodCoverage, unavailableMethodCoverage } from "./coverageNormalization";
-import type { FileCoverage, FunctionCoverageUnit } from "./coverageUnits";
-import type { MethodCoverage } from "./coverageNormalization";
+import type { CoverageUnknownReason, MethodDescriptor, SourceSpan } from "./types.js";
+import { computeMethodCoverage, unavailableMethodCoverage } from "./coverageNormalization.js";
+import type { FileCoverage, FunctionCoverageUnit } from "./coverageUnits.js";
+import type { MethodCoverage } from "./coverageNormalization.js";
 
 const MAX_COLUMN = Number.MAX_SAFE_INTEGER;
 

--- a/packages/core/src/coverageNormalization.ts
+++ b/packages/core/src/coverageNormalization.ts
@@ -1,5 +1,5 @@
-import type { CoverageMetric, CoverageUnknownReason, MethodDescriptor } from "./types";
-import type { BranchCoverageUnit, StatementCoverageUnit } from "./coverageUnits";
+import type { CoverageMetric, CoverageUnknownReason, MethodDescriptor } from "./types.js";
+import type { BranchCoverageUnit, StatementCoverageUnit } from "./coverageUnits.js";
 
 export interface MethodCoverage {
   coverage: CoverageMetric;

--- a/packages/core/src/coverageUnits.ts
+++ b/packages/core/src/coverageUnits.ts
@@ -1,4 +1,4 @@
-import type { SourceSpan } from "./types";
+import type { SourceSpan } from "./types.js";
 
 export interface StatementCoverageUnit {
   span: SourceSpan;

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -1,8 +1,8 @@
 import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
-import { IGNORED_DIRECTORIES } from "./constants";
-import { runCommand, toRelativePath } from "./utils";
+import { IGNORED_DIRECTORIES } from "./constants.js";
+import { runCommand, toRelativePath } from "./utils.js";
 
 const ANALYZABLE_EXTENSIONS = [".ts", ".tsx"];
 const TEST_FILE_MARKERS = [".test.", ".spec."];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,10 @@
-export { analyzeProject } from "./analyzeProject";
-export { runCli, parseCliArguments, usage } from "./cli";
-export { calculateCrapScore, maxCrap } from "./crapScore";
-export { buildCoverageCommand } from "./coverage";
-export { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots, isAnalyzableFile } from "./fileSelection";
-export { coverageForMethods, parseCoverageReport } from "./istanbul";
-export { parseFileMethods } from "./parser";
+export { analyzeProject } from "./analyzeProject.js";
+export { runCli, parseCliArguments, usage } from "./cli.js";
+export { calculateCrapScore, maxCrap } from "./crapScore.js";
+export { buildCoverageCommand } from "./coverage.js";
+export { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots, isAnalyzableFile } from "./fileSelection.js";
+export { coverageForMethods, parseCoverageReport } from "./istanbul.js";
+export { parseFileMethods } from "./parser.js";
 export {
   buildAgentAnalysisReport,
   buildAnalysisReport,
@@ -14,8 +14,8 @@ export {
   formatTextReport,
   formatToonReport,
   sortMetrics
-} from "./report";
-export { CRAP_THRESHOLD, COVERAGE_REPORT_RELATIVE_PATH, NO_FILES_MESSAGE, NO_ANALYZABLE_FUNCTIONS_MESSAGE } from "./constants";
+} from "./report.js";
+export { CRAP_THRESHOLD, COVERAGE_REPORT_RELATIVE_PATH, NO_FILES_MESSAGE, NO_ANALYZABLE_FUNCTIONS_MESSAGE } from "./constants.js";
 export type {
   AnalysisResult,
   AnalyzeProjectOptions,
@@ -37,4 +37,4 @@ export type {
   TestRunner,
   TestRunnerSelection,
   Writer
-} from "./types";
+} from "./types.js";

--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { isAbsolutePath, normalizePathForMatch } from "./utils";
-import type { SourceSpan } from "./types";
+import { isAbsolutePath, normalizePathForMatch } from "./utils.js";
+import type { SourceSpan } from "./types.js";
 import type {
   BranchCoverageUnit,
   CoveragePosition,
@@ -10,13 +10,13 @@ import type {
   FunctionCoverageUnit,
   FunctionSpanSource,
   StatementCoverageUnit
-} from "./coverageUnits";
+} from "./coverageUnits.js";
 
 const MAX_COLUMN = Number.MAX_SAFE_INTEGER;
 
-export { coverageForMethods } from "./coverageAttribution";
-export type { MethodCoverage } from "./coverageNormalization";
-export type { FileCoverage } from "./coverageUnits";
+export { coverageForMethods } from "./coverageAttribution.js";
+export type { MethodCoverage } from "./coverageNormalization.js";
+export type { FileCoverage } from "./coverageUnits.js";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -1,9 +1,9 @@
 import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { COVERAGE_REPORT_RELATIVE_PATH } from "./constants";
-import { isAbsolutePath } from "./utils";
-import type { PackageManager, PackageManagerSelection, TestRunner, TestRunnerSelection } from "./types";
+import { COVERAGE_REPORT_RELATIVE_PATH } from "./constants.js";
+import { isAbsolutePath } from "./utils.js";
+import type { PackageManager, PackageManagerSelection, TestRunner, TestRunnerSelection } from "./types.js";
 
 export interface CoverageSource {
   reportPath: string;

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import ts from "typescript";
 
-import { resolveScriptKind } from "./utils";
-import type { MethodDescriptor, SourceSpan } from "./types";
+import { resolveScriptKind } from "./utils.js";
+import type { MethodDescriptor, SourceSpan } from "./types.js";
 
 const COMPLEXITY_INCREMENT_KINDS = new Set([
   ts.SyntaxKind.IfStatement,

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,7 +1,8 @@
+import { encode } from "@toon-format/toon";
 import { XMLBuilder } from "fast-xml-parser";
 
-import { CRAP_THRESHOLD } from "./constants";
-import { formatNumber } from "./utils";
+import { CRAP_THRESHOLD } from "./constants.js";
+import { formatNumber } from "./utils.js";
 import type {
   CoverageKind,
   CoverageMetric,
@@ -9,7 +10,7 @@ import type {
   MethodReportStatus,
   ReportFormat,
   ReportStatus
-} from "./types";
+} from "./types.js";
 
 const METHOD_COLUMNS = ["status", "crap", "cc", "cov", "covKind", "func", "src", "lineStart", "lineEnd"] as const;
 const AGENT_METHOD_COLUMNS = ["crap", "cc", "cov", "covKind", "func", "src", "lineStart", "lineEnd"] as const;
@@ -120,19 +121,10 @@ export function formatReport(metrics: MethodMetrics[]): string {
 }
 
 export function formatToonReport(report: SerializableReport, agent = false): string {
-  const lines = [`status: ${report.status}`, `threshold: ${formatNumber(report.threshold)}`];
-  const includeStatus = !agent && reportHasMethodStatus(report);
-  const columns = includeStatus ? METHOD_COLUMNS : AGENT_METHOD_COLUMNS;
-
-  if (report.methods.length === 0) {
-    return agent ? `${lines.join("\n")}\n` : `${[...lines, "methods[0]:"].join("\n")}\n`;
-  }
-
-  lines.push(`methods[${report.methods.length}]{${columns.join(",")}}:`);
-  for (const method of report.methods) {
-    lines.push(`  ${columns.map((column) => formatToonValue(method[column as keyof typeof method] as ReportValue)).join(",")}`);
-  }
-  return `${lines.join("\n")}\n`;
+  const toonReport = agent && reportHasMethodStatus(report)
+    ? omitMethodStatuses(report)
+    : report;
+  return `${encode(toonReport)}\n`;
 }
 
 export function formatTextReport(report: SerializableReport, agent = false): string {
@@ -180,6 +172,14 @@ function reportHasMethodStatus(report: SerializableReport): report is AnalysisRe
   return report.methods.every((method) => "status" in method);
 }
 
+function omitMethodStatuses(report: AnalysisReport): AgentAnalysisReport {
+  return {
+    status: report.status,
+    threshold: report.threshold,
+    methods: report.methods.map(({ status: _status, ...method }) => method)
+  };
+}
+
 function methodStatus(metric: MethodMetrics): MethodReportStatus {
   if (metric.crapScore === null) {
     return "skipped";
@@ -201,24 +201,6 @@ function coverageKind(metric: MethodMetrics): CoverageKind {
 
 function effectivePercent(metric: CoverageMetric): number {
   return metric.percent ?? 100;
-}
-
-function formatToonValue(value: ReportValue): string {
-  if (value === null) {
-    return "null";
-  }
-  if (typeof value === "number") {
-    return formatToonNumber(value);
-  }
-  return formatToonString(value);
-}
-
-function formatToonNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : formatNumber(value);
-}
-
-function formatToonString(value: string): string {
-  return /^[A-Za-z0-9_.:/#@$-]+$/.test(value) ? value : JSON.stringify(value);
 }
 
 function formatNullableNumber(value: number | null): string {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -169,7 +169,7 @@ function toMethodReportEntry(metric: MethodMetrics): MethodReportEntry {
 }
 
 function reportHasMethodStatus(report: SerializableReport): report is AnalysisReport {
-  return report.methods.every((method) => "status" in method);
+  return report.methods.length > 0 && report.methods.every((method) => "status" in method);
 }
 
 function omitMethodStatuses(report: AnalysisReport): AgentAnalysisReport {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { spawn } from "node:child_process";
 
-import type { CoverageCommand, Writer } from "./types";
+import type { CoverageCommand, Writer } from "./types.js";
 
 export function writeLine(writer: Writer | undefined, message: string): void {
   writer?.write(`${message}\n`);

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -211,7 +211,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toContain("status: failed");
-    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("threshold: 8");
     expect(stdout.toString()).toContain("methods[2]{status,crap,cc,cov,covKind,func,src,lineStart,lineEnd}:");
     expect(stdout.toString()).toContain("risky");
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
@@ -256,7 +256,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("status: passed");
-    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("threshold: 8");
     expect(tableLines[0]).toBe("| status | crap | cc |    cov | covKind | func | src           | lineStart | lineEnd |");
     expect(new Set(pipePositions.map((positions) => positions.join(","))).size).toBe(1);
     expect(stderr.toString()).toBe("");
@@ -439,7 +439,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("status: passed");
-    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("threshold: 8");
     expect(stdout.toString()).toContain("safe");
     expect(stderr.toString()).toBe("");
   });
@@ -456,7 +456,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 
@@ -474,7 +474,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { encode } from "@toon-format/toon";
 
 import {
   buildAgentAnalysisReport,
@@ -144,7 +145,7 @@ describe("report formatting", () => {
   });
 
   it("formats TOON reports and omits status from agent method entries", () => {
-    const output = formatAnalysisReport([
+    const report = buildAgentAnalysisReport([
       metric(),
       metric({
         displayName: "risky value",
@@ -155,18 +156,30 @@ describe("report formatting", () => {
         coveragePercent: 0,
         crapScore: 20
       })
-    ], { format: "toon", agent: true });
+    ]);
+    const output = formatToonReport(report, true);
 
+    expect(output).toBe(`${encode(report)}\n`);
     expect(output).toContain("status: failed");
-    expect(output).toContain("threshold: 8.0");
+    expect(output).toContain("threshold: 8");
     expect(output).toContain("methods[1]{crap,cc,cov,covKind,func,src,lineStart,lineEnd}:");
-    expect(output).toContain("\"risky value\"");
+    expect(output).toContain("risky value");
     expect(output).not.toContain("safe");
-    expect(output).not.toContain("failed,\"risky value\"");
+    expect(output).not.toContain("status,crap");
   });
 
-  it("formats unavailable TOON values as null", () => {
-    const output = formatToonReport(buildAnalysisReport([
+  it("formats full TOON reports with quoted strings and null values through the official encoder", () => {
+    const report = buildAnalysisReport([
+      metric({
+        displayName: "risky \"quoted\", value",
+        relativePath: "src/a,b.ts",
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      }),
       metric({
         displayName: "missingCoverage",
         coverage: unknown("missing_report"),
@@ -175,8 +188,11 @@ describe("report formatting", () => {
         coveragePercent: null,
         crapScore: null
       })
-    ]));
+    ]);
+    const output = formatToonReport(report);
 
+    expect(output).toBe(`${encode(report)}\n`);
+    expect(output).toContain('failed,20,4,0,stmt,"risky \\"quoted\\", value","src/a,b.ts",1,3');
     expect(output).toContain("skipped,null,1,null,stmt,missingCoverage");
   });
 
@@ -208,8 +224,13 @@ describe("report formatting", () => {
     expect(output).not.toContain("Summary");
   });
 
-  it("formats empty agent reports as status only", () => {
-    expect(formatToonReport(buildAgentAnalysisReport([]), true)).toBe("status: passed\nthreshold: 8.0\n");
+  it("formats empty TOON method lists through the official encoder", () => {
+    const report = buildAnalysisReport([]);
+    const agentReport = buildAgentAnalysisReport([]);
+
+    expect(formatToonReport(report)).toBe(`${encode(report)}\n`);
+    expect(formatToonReport(agentReport, true)).toBe(`${encode(agentReport)}\n`);
+    expect(formatToonReport(report)).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
   });
 
   it("formats JUnit XML with testcase properties and escaped values", () => {

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -11,9 +11,9 @@ npm install --save-dev @barney-media/crap-typescript-jest
 ## Setup
 
 ```js
-const { withCrapTypescriptJest } = require("@barney-media/crap-typescript-jest");
+import { withCrapTypescriptJest } from "@barney-media/crap-typescript-jest";
 
-module.exports = withCrapTypescriptJest({
+export default withCrapTypescriptJest({
   testEnvironment: "node"
 });
 ```

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -21,6 +21,7 @@
   "bugs": {
     "url": "https://github.com/fabian-barney/crap-typescript/issues"
   },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,9 +1,10 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
 
-import CrapTypescriptJestReporter from "./reporter";
+import CrapTypescriptJestReporter from "./reporter.js";
 
 export interface CrapTypescriptJestOptions {
   projectRoot?: string;
@@ -92,17 +93,14 @@ function buildJunitReportPath(coverageDirectory: string | undefined): string {
 }
 
 function resolveReporterPath(): string {
-  try {
-    return require.resolve("./reporter");
-  } catch {
-    const candidates = [
-      path.join(__dirname, "reporter.js"),
-      path.join(__dirname, "reporter.ts")
-    ];
-    const resolved = candidates.find((candidate) => existsSync(candidate));
-    if (resolved) {
-      return resolved;
-    }
-    throw new Error("Unable to resolve the crap-typescript Jest reporter module.");
+  const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(moduleDirectory, "reporter.js"),
+    path.join(moduleDirectory, "reporter.ts")
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (resolved) {
+    return resolved;
   }
+  throw new Error("Unable to resolve the crap-typescript Jest reporter module.");
 }

--- a/packages/jest/test/integration.test.ts
+++ b/packages/jest/test/integration.test.ts
@@ -1,5 +1,6 @@
 import { access } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -15,13 +16,16 @@ describe("crap-typescript-jest", () => {
   it("writes Istanbul JSON coverage and fails the run when the CRAP threshold is exceeded", async () => {
     const projectRoot = await copyFixture("jest-project");
     tempDirs.push(projectRoot);
-    const adapterPath = repoPath("packages", "jest", "dist", "index.js").replace(/\\/g, "/");
+    const adapterUrl = pathToFileURL(repoPath("packages", "jest", "dist", "index.js")).href;
     const repoRootPath = process.cwd().replace(/\\/g, "/");
     await writeProjectFiles(projectRoot, {
-      "jest.config.cjs": `const { withCrapTypescriptJest } = require(${JSON.stringify(adapterPath)});
+      "jest.config.mjs": `import { createRequire } from "node:module";
+import { withCrapTypescriptJest } from ${JSON.stringify(adapterUrl)};
+
+const require = createRequire(import.meta.url);
 const tsJestPath = require.resolve("ts-jest", { paths: [${JSON.stringify(repoRootPath)}] });
 
-module.exports = withCrapTypescriptJest(
+export default withCrapTypescriptJest(
   {
     testEnvironment: "node",
     testMatch: ["<rootDir>/test/**/*.test.js"],
@@ -39,7 +43,7 @@ module.exports = withCrapTypescriptJest(
 
     const result = await runProcess(
       process.execPath,
-      [repoPath("node_modules", "jest", "bin", "jest.js"), "--config", "jest.config.cjs", "--runInBand"],
+      [repoPath("node_modules", "jest", "bin", "jest.js"), "--config", "jest.config.mjs", "--runInBand"],
       projectRoot
     );
 
@@ -51,13 +55,16 @@ module.exports = withCrapTypescriptJest(
   it("honors custom coverage output directories when enforcing the CRAP threshold", async () => {
     const projectRoot = await copyFixture("jest-project");
     tempDirs.push(projectRoot);
-    const adapterPath = repoPath("packages", "jest", "dist", "index.js").replace(/\\/g, "/");
+    const adapterUrl = pathToFileURL(repoPath("packages", "jest", "dist", "index.js")).href;
     const repoRootPath = process.cwd().replace(/\\/g, "/");
     await writeProjectFiles(projectRoot, {
-      "jest.config.cjs": `const { withCrapTypescriptJest } = require(${JSON.stringify(adapterPath)});
+      "jest.config.mjs": `import { createRequire } from "node:module";
+import { withCrapTypescriptJest } from ${JSON.stringify(adapterUrl)};
+
+const require = createRequire(import.meta.url);
 const tsJestPath = require.resolve("ts-jest", { paths: [${JSON.stringify(repoRootPath)}] });
 
-module.exports = withCrapTypescriptJest(
+export default withCrapTypescriptJest(
   {
     testEnvironment: "node",
     testMatch: ["<rootDir>/test/**/*.test.js"],
@@ -76,7 +83,7 @@ module.exports = withCrapTypescriptJest(
 
     const result = await runProcess(
       process.execPath,
-      [repoPath("node_modules", "jest", "bin", "jest.js"), "--config", "jest.config.cjs", "--runInBand"],
+      [repoPath("node_modules", "jest", "bin", "jest.js"), "--config", "jest.config.mjs", "--runInBand"],
       projectRoot
     );
 

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -91,7 +91,7 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -11,9 +11,9 @@ npm install --save-dev @barney-media/crap-typescript-vitest
 ## Setup
 
 ```js
-const { withCrapTypescriptVitest } = require("@barney-media/crap-typescript-vitest");
+import { withCrapTypescriptVitest } from "@barney-media/crap-typescript-vitest";
 
-module.exports = withCrapTypescriptVitest({
+export default withCrapTypescriptVitest({
   test: {
     include: ["test/**/*.test.ts"]
   }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -21,6 +21,7 @@
   "bugs": {
     "url": "https://github.com/fabian-barney/crap-typescript/issues"
   },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/vitest/test/integration.test.ts
+++ b/packages/vitest/test/integration.test.ts
@@ -1,5 +1,6 @@
 import { access } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -15,11 +16,11 @@ describe("crap-typescript-vitest", () => {
   it("writes Istanbul JSON coverage and fails the run when the CRAP threshold is exceeded", async () => {
     const projectRoot = await copyFixture("vitest-project");
     tempDirs.push(projectRoot);
-    const adapterPath = repoPath("packages", "vitest", "dist", "index.js").replace(/\\/g, "/");
+    const adapterUrl = pathToFileURL(repoPath("packages", "vitest", "dist", "index.js")).href;
     await writeProjectFiles(projectRoot, {
-      "vitest.config.cjs": `const { withCrapTypescriptVitest } = require(${JSON.stringify(adapterPath)});
+      "vitest.config.mjs": `import { withCrapTypescriptVitest } from ${JSON.stringify(adapterUrl)};
 
-module.exports = withCrapTypescriptVitest(
+export default withCrapTypescriptVitest(
   {
     test: {
       include: ["test/**/*.test.ts"]
@@ -34,7 +35,7 @@ module.exports = withCrapTypescriptVitest(
 
     const result = await runProcess(
       process.execPath,
-      [repoPath("node_modules", "vitest", "vitest.mjs"), "run", "--config", "vitest.config.cjs"],
+      [repoPath("node_modules", "vitest", "vitest.mjs"), "run", "--config", "vitest.config.mjs"],
       projectRoot
     );
 
@@ -46,11 +47,11 @@ module.exports = withCrapTypescriptVitest(
   it("honors custom coverage output directories when enforcing the CRAP threshold", async () => {
     const projectRoot = await copyFixture("vitest-project");
     tempDirs.push(projectRoot);
-    const adapterPath = repoPath("packages", "vitest", "dist", "index.js").replace(/\\/g, "/");
+    const adapterUrl = pathToFileURL(repoPath("packages", "vitest", "dist", "index.js")).href;
     await writeProjectFiles(projectRoot, {
-      "vitest.config.cjs": `const { withCrapTypescriptVitest } = require(${JSON.stringify(adapterPath)});
+      "vitest.config.mjs": `import { withCrapTypescriptVitest } from ${JSON.stringify(adapterUrl)};
 
-module.exports = withCrapTypescriptVitest(
+export default withCrapTypescriptVitest(
   {
     test: {
       include: ["test/**/*.test.ts"],
@@ -68,7 +69,7 @@ module.exports = withCrapTypescriptVitest(
 
     const result = await runProcess(
       process.execPath,
-      [repoPath("node_modules", "vitest", "vitest.mjs"), "run", "--config", "vitest.config.cjs"],
+      [repoPath("node_modules", "vitest", "vitest.mjs"), "run", "--config", "vitest.config.mjs"],
       projectRoot
     );
 

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -58,7 +58,7 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 


### PR DESCRIPTION
## Summary
- add @toon-format/toon and use its encode function for TOON report serialization
- publish packages as ESM modules and update relative imports for Node ESM resolution
- update Vitest/Jest adapter docs and integration fixtures to use ESM configs

Fixes #51

## Tests
- npm run build
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- npm pack --workspaces