### PR TITLE
Add configurable CRAP thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ npx crap-typescript
 --agent                      Emit only overall status and failed methods for toon, json, or text
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
+--threshold <number>         Override the CRAP threshold (`8.0` by default)
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
@@ -101,6 +102,7 @@ npx crap-typescript --changed
 npx crap-typescript --package-manager npm --test-runner vitest
 npx crap-typescript --format json --output reports/crap.json
 npx crap-typescript --agent --junit-report reports/crap-junit.xml
+npx crap-typescript --threshold 6
 npx crap-typescript src/sample.ts
 npx crap-typescript packages/api packages/web
 ```
@@ -114,6 +116,8 @@ Primary reports expose overall `status` and the run-level `threshold`. Per-funct
 `--agent` is a filtering mode, not a report format. It is available with `toon`, `json`, and `text`; it keeps the overall `status` and `threshold`, includes failed methods only, and omits method-level `status` because included method entries are implicitly failed.
 
 Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit output keeps the aggregate XML attributes required by CI parsers, writes `threshold` as a testsuite property, and puts method details on each testcase.
+
+The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates. The warning recommends `8.0` for hard gates, targeting `6.0` during implementation, and using the `8.0` default when in doubt.
 
 ## Adapter Usage
 
@@ -129,7 +133,7 @@ export default withCrapTypescriptVitest({
 });
 ```
 
-The Vitest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The Vitest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
 
 Jest:
 
@@ -141,13 +145,13 @@ export default withCrapTypescriptJest({
 });
 ```
 
-The Jest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The Jest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
 
 ## Exit Codes
 
 - `0` success, threshold respected
 - `1` invalid CLI usage or execution failure
-- `2` CRAP threshold exceeded (`> 8.0`)
+- `2` CRAP threshold exceeded (`> configured threshold`)
 
 ## Release
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,6 +15,7 @@ npx crap-typescript
 npx crap-typescript --changed
 npx crap-typescript --format json --output reports/crap.json
 npx crap-typescript --agent --junit-report reports/crap-junit.xml
+npx crap-typescript --threshold 6
 npx crap-typescript src/sample.ts
 npx crap-typescript packages/api packages/web
 ```
@@ -31,17 +32,20 @@ npx crap-typescript packages/api packages/web
 --agent                      Emit only overall status and failed methods for toon, json, or text
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
+--threshold <number>         Override the CRAP threshold (`8.0` by default)
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
 
 The default `toon` format is compact and agent-readable. Primary reports include run-level `status` and `threshold`; method rows use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. `--agent` is a filtering mode, not a format: it keeps the overall `status` and `threshold`, includes failed method entries only, and omits method-level `status`.
 
+The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
+
 ## Exit Codes
 
 - `0` success, threshold respected
 - `1` invalid CLI usage or execution failure
-- `2` CRAP threshold exceeded (> 8.0)
+- `2` CRAP threshold exceeded (> configured threshold)
 
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.
 

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { CRAP_THRESHOLD } from "./constants.js";
+import { CRAP_THRESHOLD, thresholdWarning, validateThreshold } from "./constants.js";
 import { coverageForMethods } from "./coverageAttribution.js";
 import { ensureCoverageReport, expectedCoveragePath } from "./coverage.js";
 import type { FileCoverage } from "./coverageUnits.js";
@@ -21,22 +21,24 @@ import type {
 
 export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promise<AnalysisResult> {
   const context = createAnalyzeContext(options);
+  const runWarnings = emitThresholdWarning(context.stderr, context.threshold);
   const selectedFiles = await selectFiles(context.projectRoot, options.explicitPaths ?? [], options.changedOnly ?? false);
   if (selectedFiles.length === 0) {
-    return emptyAnalysisResult();
+    return emptyAnalysisResult(context.threshold, runWarnings);
   }
 
   const groupedByModule = await groupFilesByModule(context.projectRoot, selectedFiles);
   const moduleResults = await analyzeModules(groupedByModule, context);
   const metrics = moduleResults.flatMap((result) => result.metrics);
   const coverageCommands = moduleResults.flatMap((result) => result.coverageCommands);
-  const warnings = moduleResults.flatMap((result) => result.warnings);
+  const warnings = [...runWarnings, ...moduleResults.flatMap((result) => result.warnings)];
   const max = maxCrap(metrics);
 
   return {
     metrics,
     maxCrap: max,
-    thresholdExceeded: max > CRAP_THRESHOLD,
+    threshold: context.threshold,
+    thresholdExceeded: max > context.threshold,
     selectedFiles,
     coverageCommands,
     warnings
@@ -48,6 +50,7 @@ interface AnalyzeContext {
   coverageMode: NonNullable<AnalyzeProjectOptions["coverageMode"]>;
   packageManager: NonNullable<AnalyzeProjectOptions["packageManager"]>;
   testRunner: NonNullable<AnalyzeProjectOptions["testRunner"]>;
+  threshold: number;
   coverageReportPath: AnalyzeProjectOptions["coverageReportPath"];
   executor: NonNullable<AnalyzeProjectOptions["executor"]>;
   stderr: AnalyzeProjectOptions["stderr"];
@@ -76,20 +79,22 @@ function createAnalyzeContext(options: AnalyzeProjectOptions): AnalyzeContext {
     coverageMode: options.coverageMode ?? "auto",
     packageManager: options.packageManager ?? "auto",
     testRunner: options.testRunner ?? "auto",
+    threshold: validateThreshold(options.threshold ?? CRAP_THRESHOLD),
     coverageReportPath: options.coverageReportPath,
     executor: options.executor ?? new DefaultCommandExecutor(),
     stderr: options.stderr
   };
 }
 
-function emptyAnalysisResult(): AnalysisResult {
+function emptyAnalysisResult(threshold: number, warnings: string[]): AnalysisResult {
   return {
     metrics: [],
     maxCrap: 0,
+    threshold,
     thresholdExceeded: false,
     selectedFiles: [],
     coverageCommands: [],
-    warnings: []
+    warnings
   };
 }
 
@@ -272,4 +277,9 @@ function resolveFileCoverage(
 function emitWarning(stderr: AnalyzeProjectOptions["stderr"], warning: string): string {
   writeLine(stderr, warning);
   return warning;
+}
+
+function emitThresholdWarning(stderr: AnalyzeProjectOptions["stderr"], threshold: number): string[] {
+  const warning = thresholdWarning(threshold);
+  return warning === "" ? [] : [emitWarning(stderr, warning)];
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { CRAP_THRESHOLD } from "./constants.js";
+import { CRAP_THRESHOLD, validateThreshold } from "./constants.js";
 import { analyzeProject } from "./analyzeProject.js";
 import { formatAnalysisReport } from "./report.js";
 import { formatNumber, writeLine } from "./utils.js";
@@ -11,8 +11,8 @@ const HELP_TEXT = `crap-typescript
 
 Usage:
   crap-typescript [--help]
-  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>]
-  crap-typescript [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>] <path ...>
+  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>] [--threshold <number>]
+  crap-typescript [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>] [--threshold <number>] <path ...>
 
 Options:
   --help                     Print usage to stdout
@@ -23,6 +23,7 @@ Options:
   --agent                    Emit only overall status and failed methods for toon, json, or text
   --output <path>            Write the primary report to a file instead of stdout
   --junit-report <path>      Also write a full JUnit XML report for CI test-report UIs
+  --threshold <number>       Override the CRAP threshold (default: 8.0)
 
 Behavior:
   (no args)                  Analyze all TypeScript files under any nested src/ tree
@@ -55,12 +56,14 @@ interface ParseState {
   packageManager: PackageManagerSelection;
   testRunner: TestRunnerSelection;
   format: ReportFormat;
+  threshold: number;
   agent: boolean;
   outputPath?: string;
   junitReportPath?: string;
   packageManagerSeen: boolean;
   testRunnerSeen: boolean;
   formatSeen: boolean;
+  thresholdSeen: boolean;
   agentSeen: boolean;
   outputPathSeen: boolean;
   junitReportPathSeen: boolean;
@@ -102,6 +105,12 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = {
     state.formatSeen = true;
     return index + 1;
   },
+  "--threshold": (state, args, index) => {
+    ensureOptionIsUnique(state.thresholdSeen, "--threshold");
+    state.threshold = parseThreshold(args[index + 1]);
+    state.thresholdSeen = true;
+    return index + 1;
+  },
   "--output": (state, args, index) => {
     ensureOptionIsUnique(state.outputPathSeen, "--output");
     state.outputPath = parsePathOption(args[index + 1], "--output");
@@ -123,12 +132,14 @@ function createParseState(): ParseState {
     packageManager: "auto",
     testRunner: "auto",
     format: "toon",
+    threshold: CRAP_THRESHOLD,
     agent: false,
     outputPath: undefined,
     junitReportPath: undefined,
     packageManagerSeen: false,
     testRunnerSeen: false,
     formatSeen: false,
+    thresholdSeen: false,
     agentSeen: false,
     outputPathSeen: false,
     junitReportPathSeen: false,
@@ -159,6 +170,7 @@ function finalizeCliArguments(state: ParseState): CliArguments {
     packageManager: state.packageManager,
     testRunner: state.testRunner,
     format: state.format,
+    threshold: state.threshold,
     agent: state.agent,
     ...optionalPath("outputPath", state.outputPath),
     ...optionalPath("junitReportPath", state.junitReportPath)
@@ -221,6 +233,17 @@ function parseReportFormat(value: string | undefined): ReportFormat {
   throw new Error("--format requires one of: toon, json, text, junit");
 }
 
+function parseThreshold(value: string | undefined): number {
+  if (!value) {
+    throw new Error("--threshold requires a finite number greater than 0");
+  }
+  try {
+    return validateThreshold(Number(value));
+  } catch {
+    throw new Error("--threshold requires a finite number greater than 0");
+  }
+}
+
 function parsePathOption(value: string | undefined, option: string): string {
   if (!value) {
     throw new Error(`${option} requires a path`);
@@ -269,6 +292,7 @@ async function analyzeCliProject(
       changedOnly: parsed.mode === "changed",
       packageManager: parsed.packageManager,
       testRunner: parsed.testRunner,
+      threshold: parsed.threshold,
       stdout,
       stderr
     });
@@ -290,7 +314,7 @@ async function handleCliResult(
   }
 
   try {
-    await writeCliReports(result.metrics, parsed, projectRoot, stdout);
+    await writeCliReports(result, parsed, projectRoot, stdout);
   } catch (error) {
     writeLine(stderr, (error as Error).message);
     return 1;
@@ -300,14 +324,15 @@ async function handleCliResult(
 }
 
 async function writeCliReports(
-  metrics: Awaited<ReturnType<typeof analyzeProject>>["metrics"],
+  result: Awaited<ReturnType<typeof analyzeProject>>,
   parsed: CliArguments,
   projectRoot: string,
   stdout: Writer
 ): Promise<void> {
-  const primaryReport = formatAnalysisReport(metrics, {
+  const primaryReport = formatAnalysisReport(result.metrics, {
     format: parsed.format,
-    agent: parsed.agent
+    agent: parsed.agent,
+    threshold: result.threshold
   });
   if (parsed.outputPath) {
     await writeReportFile(projectRoot, parsed.outputPath, primaryReport);
@@ -316,7 +341,10 @@ async function writeCliReports(
   }
 
   if (parsed.junitReportPath) {
-    await writeReportFile(projectRoot, parsed.junitReportPath, formatAnalysisReport(metrics, { format: "junit" }));
+    await writeReportFile(projectRoot, parsed.junitReportPath, formatAnalysisReport(result.metrics, {
+      format: "junit",
+      threshold: result.threshold
+    }));
   }
 }
 
@@ -333,6 +361,6 @@ function writeCliThresholdStatus(
   if (!result.thresholdExceeded) {
     return 0;
   }
-  writeLine(stderr, `CRAP threshold exceeded: ${formatNumber(result.maxCrap)} > ${formatNumber(CRAP_THRESHOLD)}`);
+  writeLine(stderr, `CRAP threshold exceeded: ${formatNumber(result.maxCrap)} > ${formatNumber(result.threshold)}`);
   return 2;
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,6 +3,27 @@ export const COVERAGE_REPORT_RELATIVE_PATH = "coverage/coverage-final.json";
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No analyzable functions found.";
 
+export function validateThreshold(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("Threshold must be a finite number greater than 0");
+  }
+  return value;
+}
+
+export function thresholdWarning(value: number): string {
+  if (value < 4.0) {
+    return `Warning: CRAP threshold below 4.0 is likely too noisy. ${thresholdRecommendation()}`;
+  }
+  if (value > CRAP_THRESHOLD) {
+    return `Warning: CRAP threshold above 8.0 is too lenient even for hard gates. ${thresholdRecommendation()}`;
+  }
+  return "";
+}
+
+function thresholdRecommendation(): string {
+  return "Use 8.0 for hard gates, target 6.0 during implementation, and use the 8.0 default when in doubt.";
+}
+
 export const IGNORED_DIRECTORIES = new Set([
   ".git",
   "coverage",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,5 @@
 export const CRAP_THRESHOLD = 8.0;
+const TOO_LENIENT_THRESHOLD = 8.0;
 export const COVERAGE_REPORT_RELATIVE_PATH = "coverage/coverage-final.json";
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No analyzable functions found.";
@@ -14,8 +15,8 @@ export function thresholdWarning(value: number): string {
   if (value < 4.0) {
     return `Warning: CRAP threshold below 4.0 is likely too noisy. ${thresholdRecommendation()}`;
   }
-  if (value > CRAP_THRESHOLD) {
-    return `Warning: CRAP threshold above 8.0 is too lenient even for hard gates. ${thresholdRecommendation()}`;
+  if (value > TOO_LENIENT_THRESHOLD) {
+    return `Warning: CRAP threshold above ${TOO_LENIENT_THRESHOLD.toFixed(1)} is too lenient even for hard gates. ${thresholdRecommendation()}`;
   }
   return "";
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,14 @@ export {
   formatToonReport,
   sortMetrics
 } from "./report.js";
-export { CRAP_THRESHOLD, COVERAGE_REPORT_RELATIVE_PATH, NO_FILES_MESSAGE, NO_ANALYZABLE_FUNCTIONS_MESSAGE } from "./constants.js";
+export {
+  CRAP_THRESHOLD,
+  COVERAGE_REPORT_RELATIVE_PATH,
+  NO_FILES_MESSAGE,
+  NO_ANALYZABLE_FUNCTIONS_MESSAGE,
+  thresholdWarning,
+  validateThreshold
+} from "./constants.js";
 export type {
   AnalysisResult,
   AnalyzeProjectOptions,

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,7 +1,7 @@
 import { encode } from "@toon-format/toon";
 import { XMLBuilder } from "fast-xml-parser";
 
-import { CRAP_THRESHOLD } from "./constants.js";
+import { CRAP_THRESHOLD, validateThreshold } from "./constants.js";
 import { formatNumber } from "./utils.js";
 import type {
   CoverageKind,
@@ -45,6 +45,7 @@ export interface AgentAnalysisReport {
 export interface FormatAnalysisReportOptions {
   format: ReportFormat;
   agent?: boolean;
+  threshold?: number;
 }
 
 type SerializableReport = AnalysisReport | AgentAnalysisReport;
@@ -84,17 +85,18 @@ export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
   });
 }
 
-export function buildAnalysisReport(metrics: MethodMetrics[]): AnalysisReport {
-  const methods = sortMetrics(metrics).map(toMethodReportEntry);
+export function buildAnalysisReport(metrics: MethodMetrics[], threshold = CRAP_THRESHOLD): AnalysisReport {
+  threshold = validateThreshold(threshold);
+  const methods = sortMetrics(metrics).map((metric) => toMethodReportEntry(metric, threshold));
   return {
     status: methods.some((method) => method.status === "failed") ? "failed" : "passed",
-    threshold: CRAP_THRESHOLD,
+    threshold,
     methods
   };
 }
 
-export function buildAgentAnalysisReport(metrics: MethodMetrics[]): AgentAnalysisReport {
-  const report = buildAnalysisReport(metrics);
+export function buildAgentAnalysisReport(metrics: MethodMetrics[], threshold = CRAP_THRESHOLD): AgentAnalysisReport {
+  const report = buildAnalysisReport(metrics, threshold);
   return {
     status: report.status,
     threshold: report.threshold,
@@ -106,8 +108,9 @@ export function buildAgentAnalysisReport(metrics: MethodMetrics[]): AgentAnalysi
 
 export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAnalysisReportOptions): string {
   const agent = options.agent ?? false;
+  const threshold = options.threshold ?? CRAP_THRESHOLD;
   validateReportOptions(options.format, agent);
-  return REPORT_FORMATTERS[options.format](agent ? buildAgentAnalysisReport(metrics) : buildAnalysisReport(metrics), agent);
+  return REPORT_FORMATTERS[options.format](agent ? buildAgentAnalysisReport(metrics, threshold) : buildAnalysisReport(metrics, threshold), agent);
 }
 
 function validateReportOptions(format: ReportFormat, agent: boolean): void {
@@ -154,9 +157,9 @@ export function formatJunitReport(report: AnalysisReport): string {
   return `${formatXmlDeclaration()}\n${createXmlBuilder().build(toJunitXml(report)).trimEnd()}\n`;
 }
 
-function toMethodReportEntry(metric: MethodMetrics): MethodReportEntry {
+function toMethodReportEntry(metric: MethodMetrics, threshold: number): MethodReportEntry {
   return {
-    status: methodStatus(metric),
+    status: methodStatus(metric, threshold),
     crap: metric.crapScore,
     cc: metric.complexity,
     cov: metric.coveragePercent,
@@ -180,11 +183,11 @@ function omitMethodStatuses(report: AnalysisReport): AgentAnalysisReport {
   };
 }
 
-function methodStatus(metric: MethodMetrics): MethodReportStatus {
+function methodStatus(metric: MethodMetrics, threshold: number): MethodReportStatus {
   if (metric.crapScore === null) {
     return "skipped";
   }
-  return metric.crapScore > CRAP_THRESHOLD ? "failed" : "passed";
+  return metric.crapScore > threshold ? "failed" : "passed";
 }
 
 function coverageKind(metric: MethodMetrics): CoverageKind {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,6 +40,7 @@ export interface CliArguments {
   packageManager: PackageManagerSelection;
   testRunner: TestRunnerSelection;
   format: ReportFormat;
+  threshold: number;
   agent: boolean;
   outputPath?: string;
   junitReportPath?: string;
@@ -87,6 +88,7 @@ export interface AnalyzeProjectOptions {
   changedOnly?: boolean;
   packageManager?: PackageManagerSelection;
   testRunner?: TestRunnerSelection;
+  threshold?: number;
   coverageMode?: CoverageMode;
   coverageReportPath?: string;
   stdout?: Writer;
@@ -97,6 +99,7 @@ export interface AnalyzeProjectOptions {
 export interface AnalysisResult {
   metrics: MethodMetrics[];
   maxCrap: number;
+  threshold: number;
   thresholdExceeded: boolean;
   selectedFiles: string[];
   coverageCommands: CoverageCommand[];

--- a/packages/core/test/analysis.test.ts
+++ b/packages/core/test/analysis.test.ts
@@ -39,7 +39,36 @@ describe("analyzeProject", () => {
       { name: "upper", coverage: 100.0, crap: 1.0, coverageStatus: "measured", statementStatus: "measured", branchStatus: "structural_na" }
     ]);
     expect(result.maxCrap).toBeGreaterThan(CRAP_THRESHOLD);
+    expect(result.threshold).toBe(CRAP_THRESHOLD);
     expect(result.thresholdExceeded).toBe(true);
+  });
+
+  it("uses configured thresholds and emits Java-style threshold warnings", async () => {
+    const projectRoot = await copyFixture("workspace-project");
+    tempDirs.push(projectRoot);
+    const warnings: string[] = [];
+
+    const result = await analyzeProject({
+      projectRoot,
+      coverageMode: "existing-only",
+      threshold: 13,
+      stderr: {
+        write(chunk: string) {
+          warnings.push(chunk);
+        }
+      }
+    });
+
+    expect(result.threshold).toBe(13);
+    expect(result.thresholdExceeded).toBe(false);
+    expect(result.warnings).toEqual([
+      "Warning: CRAP threshold above 8.0 is too lenient even for hard gates. Use 8.0 for hard gates, target 6.0 during implementation, and use the 8.0 default when in doubt."
+    ]);
+    expect(warnings.join("")).toContain("CRAP threshold above 8.0 is too lenient");
+  });
+
+  it("rejects invalid configured thresholds", async () => {
+    await expect(analyzeProject({ threshold: 0 })).rejects.toThrow("Threshold must be a finite number greater than 0");
   });
 
   it("warns and reports N/A coverage when existing coverage is missing", async () => {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -30,6 +30,7 @@ describe("cli", () => {
       packageManager: "npm",
       testRunner: "vitest",
       format: "json",
+      threshold: 8,
       agent: true,
       outputPath: "reports/crap.json",
       junitReportPath: "reports/crap.xml"
@@ -48,6 +49,7 @@ describe("cli", () => {
       packageManager: "pnpm",
       testRunner: "jest",
       format: "toon",
+      threshold: 8,
       agent: false
     });
     expect(parseCliArguments(["--help", "--package-manager", "yarn"])).toEqual({
@@ -56,6 +58,7 @@ describe("cli", () => {
       packageManager: "yarn",
       testRunner: "auto",
       format: "toon",
+      threshold: 8,
       agent: false
     });
     expect(parseCliArguments(["--help", "--changed", "src/app.ts", "--agent", "--format", "junit"])).toEqual({
@@ -64,6 +67,7 @@ describe("cli", () => {
       packageManager: "auto",
       testRunner: "auto",
       format: "junit",
+      threshold: 8,
       agent: true
     });
   });
@@ -78,6 +82,9 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--format", "toon", "--format", "json"])).toThrow(
       "--format can only be provided once"
     );
+    expect(() => parseCliArguments(["--threshold", "6", "--threshold", "8"])).toThrow(
+      "--threshold can only be provided once"
+    );
     expect(() => parseCliArguments(["--agent", "--agent"])).toThrow("--agent can only be provided once");
     expect(() => parseCliArguments(["--output", "a", "--output", "b"])).toThrow("--output can only be provided once");
     expect(() => parseCliArguments(["--junit-report", "a", "--junit-report", "b"])).toThrow(
@@ -86,6 +93,7 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--package-manager"])).toThrow("--package-manager requires one of: auto, npm, pnpm, yarn");
     expect(() => parseCliArguments(["--test-runner"])).toThrow("--test-runner requires one of: auto, vitest, jest");
     expect(() => parseCliArguments(["--format"])).toThrow("--format requires one of: toon, json, text, junit");
+    expect(() => parseCliArguments(["--threshold"])).toThrow("--threshold requires a finite number greater than 0");
     expect(() => parseCliArguments(["--output"])).toThrow("--output requires a path");
     expect(() => parseCliArguments(["--junit-report"])).toThrow("--junit-report requires a path");
     expect(() => parseCliArguments(["--package-manager", "bun"])).toThrow(
@@ -97,7 +105,18 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--format", "agent"])).toThrow(
       "--format requires one of: toon, json, text, junit"
     );
+    expect(() => parseCliArguments(["--threshold", "0"])).toThrow("--threshold requires a finite number greater than 0");
+    expect(() => parseCliArguments(["--threshold", "-1"])).toThrow("--threshold requires a finite number greater than 0");
+    expect(() => parseCliArguments(["--threshold", "NaN"])).toThrow("--threshold requires a finite number greater than 0");
+    expect(() => parseCliArguments(["--threshold", "Infinity"])).toThrow("--threshold requires a finite number greater than 0");
     expect(() => parseCliArguments(["--unknown"])).toThrow("Unknown option: --unknown");
+  });
+
+  it("parses custom thresholds", () => {
+    expect(parseCliArguments(["--threshold", "6", "--changed"])).toMatchObject({
+      mode: "changed",
+      threshold: 6
+    });
   });
 
   it("prints help", async () => {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -144,6 +144,28 @@ describe("report formatting", () => {
     ]);
   });
 
+  it("uses configured thresholds for method status and report metadata", () => {
+    const parsed = JSON.parse(formatAnalysisReport([
+      metric({
+        displayName: "borderline",
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      })
+    ], { format: "json", threshold: 21 })) as {
+      status: string;
+      threshold: number;
+      methods: Array<{ status: string }>;
+    };
+
+    expect(parsed.status).toBe("passed");
+    expect(parsed.threshold).toBe(21);
+    expect(parsed.methods[0].status).toBe("passed");
+  });
+
   it("formats TOON reports and omits status from agent method entries", () => {
     const report = buildAgentAnalysisReport([
       metric(),

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -20,7 +20,7 @@ export default withCrapTypescriptJest({
 
 `withCrapTypescriptJest` wraps your Jest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
-The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact. The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
 The reporter is also available as a standalone export at `@barney-media/crap-typescript-jest/reporter` for direct configuration.
 

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -12,6 +12,7 @@ export interface CrapTypescriptJestOptions {
   paths?: string[];
   packageManager?: PackageManagerSelection;
   coverageReportPath?: string;
+  threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
   outputPath?: string;

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import {
   analyzeProject,
   COVERAGE_REPORT_RELATIVE_PATH,
-  CRAP_THRESHOLD,
   formatAnalysisReport
 } from "@barney-media/crap-typescript-core";
 import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
@@ -15,6 +14,7 @@ export interface CrapTypescriptJestOptions {
   paths?: string[];
   packageManager?: PackageManagerSelection;
   coverageReportPath?: string;
+  threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
   outputPath?: string;
@@ -29,6 +29,7 @@ interface ResolvedReporterOptions {
   changedOnly: boolean;
   packageManager: PackageManagerSelection;
   coverageReportPath: string;
+  threshold: number | undefined;
   format: ReportFormat;
   agent: boolean;
   outputPath: string | undefined;
@@ -66,6 +67,7 @@ export default class CrapTypescriptJestReporter {
         changedOnly: options.changedOnly,
         packageManager: options.packageManager,
         testRunner: "jest",
+        threshold: options.threshold,
         coverageMode: "existing-only",
         coverageReportPath: options.coverageReportPath,
         stdout: options.stdout,
@@ -74,7 +76,7 @@ export default class CrapTypescriptJestReporter {
 
       await writeReporterReports(result.metrics, options);
       if (result.thresholdExceeded) {
-        this.error = createThresholdExceededError(result.maxCrap);
+        this.error = createThresholdExceededError(result.maxCrap, result.threshold);
         options.stderr.write(`${this.error.message}\n`);
         process.exitCode = 1;
       }
@@ -117,8 +119,8 @@ function resolveReporterOptions(options: CrapTypescriptJestOptions): ResolvedRep
   };
 }
 
-function createThresholdExceededError(maxCrap: number): Error {
-  return new Error(`CRAP threshold exceeded: ${maxCrap.toFixed(1)} > ${CRAP_THRESHOLD.toFixed(1)}`);
+function createThresholdExceededError(maxCrap: number, threshold: number): Error {
+  return new Error(`CRAP threshold exceeded: ${maxCrap.toFixed(1)} > ${threshold.toFixed(1)}`);
 }
 
 function toError(error: unknown): Error {
@@ -135,6 +137,7 @@ function resolveAnalysisOptions(
     changedOnly: resolveChangedOnly(options),
     packageManager: resolvePackageManager(options),
     coverageReportPath,
+    threshold: options.threshold,
     format: resolveFormat(options),
     agent: resolveAgent(options),
     outputPath: options.outputPath,
@@ -191,7 +194,8 @@ async function writeReporterReports(
 ): Promise<void> {
   const primaryReport = formatAnalysisReport(metrics, {
     format: options.format,
-    agent: options.agent
+    agent: options.agent,
+    threshold: options.threshold
   });
   if (options.outputPath) {
     await writeReportFile(options.projectRoot, options.outputPath, primaryReport);
@@ -200,7 +204,10 @@ async function writeReporterReports(
   }
 
   if (options.junitReportPath !== false) {
-    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, { format: "junit" }));
+    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, {
+      format: "junit",
+      threshold: options.threshold
+    }));
   }
 }
 

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -95,6 +95,30 @@ describe("CrapTypescriptJestReporter", () => {
     expect(stderr.toString()).toBe("");
   });
 
+  it("honors custom thresholds and emits threshold warnings", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": "{}"
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptJestReporter(undefined, {
+      projectRoot,
+      threshold: 9,
+      stdout,
+      stderr
+    });
+
+    await callFinalize(reporter);
+
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 9.0\n");
+    expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('<property name="threshold" value="9.0"/>');
+    expect(stderr.toString()).toContain("CRAP threshold above 8.0 is too lenient");
+  });
+
   it("prints the CRAP report and stores the threshold error for an absolute coverage path", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -22,7 +22,7 @@ export default withCrapTypescriptVitest({
 
 `withCrapTypescriptVitest` wraps your Vitest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
-The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, or `junitReportPath` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact. The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { analyzeProject, CRAP_THRESHOLD, formatAnalysisReport } from "@barney-media/crap-typescript-core";
+import { analyzeProject, formatAnalysisReport } from "@barney-media/crap-typescript-core";
 import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
 
 type VitestReporterEntry = string | [string, unknown] | {
@@ -26,6 +26,7 @@ export interface CrapTypescriptVitestOptions {
   paths?: string[];
   packageManager?: PackageManagerSelection;
   coverageReportPath?: string;
+  threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
   outputPath?: string;
@@ -46,6 +47,7 @@ export class CrapTypescriptVitestReporter {
         changedOnly: options.changedOnly,
         packageManager: options.packageManager,
         testRunner: "vitest",
+        threshold: options.threshold,
         coverageMode: "existing-only",
         coverageReportPath: options.coverageReportPath,
         stdout: options.stdout,
@@ -54,7 +56,7 @@ export class CrapTypescriptVitestReporter {
 
       await writeReporterReports(result.metrics, options);
       if (result.thresholdExceeded) {
-        const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${CRAP_THRESHOLD.toFixed(1)}`;
+        const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${result.threshold.toFixed(1)}`;
         options.stderr.write(`${error}\n`);
         process.exitCode = 1;
       }
@@ -145,6 +147,7 @@ interface ResolvedReporterOptions {
   changedOnly: boolean;
   packageManager: PackageManagerSelection;
   coverageReportPath: string | undefined;
+  threshold: number | undefined;
   format: ReportFormat;
   agent: boolean;
   outputPath: string | undefined;
@@ -160,6 +163,7 @@ function resolveReporterOptions(options: CrapTypescriptVitestOptions): ResolvedR
     changedOnly: resolveChangedOnly(options),
     packageManager: resolvePackageManager(options),
     coverageReportPath: options.coverageReportPath,
+    threshold: options.threshold,
     format: resolveFormat(options),
     agent: resolveAgent(options),
     outputPath: options.outputPath,
@@ -205,7 +209,8 @@ async function writeReporterReports(
 ): Promise<void> {
   const primaryReport = formatAnalysisReport(metrics, {
     format: options.format,
-    agent: options.agent
+    agent: options.agent,
+    threshold: options.threshold
   });
   if (options.outputPath) {
     await writeReportFile(options.projectRoot, options.outputPath, primaryReport);
@@ -214,7 +219,10 @@ async function writeReporterReports(
   }
 
   if (options.junitReportPath !== false) {
-    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, { format: "junit" }));
+    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, {
+      format: "junit",
+      threshold: options.threshold
+    }));
   }
 }
 

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -62,6 +62,29 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(stderr.toString()).toBe("");
   });
 
+  it("honors custom thresholds and emits threshold warnings", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}'
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      threshold: 9,
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 9.0\n");
+    expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('<property name="threshold" value="9.0"/>');
+    expect(stderr.toString()).toContain("CRAP threshold above 8.0 is too lenient");
+  });
+
   it("prints the CRAP report and sets a failure exit code when the threshold is exceeded", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);

--- a/spec.md
+++ b/spec.md
@@ -27,7 +27,6 @@ This specification defines:
 
 This specification does not define:
 
-- configurable thresholds through the CLI
 - support for non-TypeScript source files
 - machine-readable report formats
 - adapters beyond Vitest and Jest
@@ -46,6 +45,7 @@ It shall also accept optional overrides:
 
 - `--package-manager auto|npm|pnpm|yarn`
 - `--test-runner auto|vitest|jest`
+- `--threshold <finite-positive-number>`
 
 Invalid argument parsing shall exit with usage error and print the usage text.
 
@@ -217,11 +217,15 @@ Functions with `N/A` CRAP shall appear after functions with numeric CRAP.
 
 ## 11. Threshold
 
-The CRAP threshold shall be `8.0`.
+The default CRAP threshold shall be `8.0`. A finite positive threshold may be configured.
 
-If the maximum numeric CRAP value is greater than `8.0`:
+If the configured threshold is below `4.0`, the tool shall print a warning that the threshold is likely too noisy and recommend `8.0` for hard gates, targeting `6.0` during implementation, and using the `8.0` default when in doubt.
 
-- the tool shall print `CRAP threshold exceeded: <max> > 8.0` to stderr
+If the configured threshold is above `8.0`, the tool shall print a warning that the threshold is too lenient even for hard gates and the same recommendation.
+
+If the maximum numeric CRAP value is greater than the configured threshold:
+
+- the tool shall print `CRAP threshold exceeded: <max> > <threshold>` to stderr
 - the tool shall exit with threshold-failure status
 
 If no numeric CRAP values exist, the maximum shall be treated as `0.0`.


### PR DESCRIPTION
Closes #56.

## Summary

- Add configurable threshold support to core analysis, CLI parsing, report formatting, and Jest/Vitest adapters.
- Validate thresholds as finite positive numbers and emit Java-style guidance warnings below 4.0 or above 8.0.
- Use the configured threshold consistently for report metadata, method status, threshold failures, adapter errors, and docs.

## Validation

- `npm ci`
- `npm run build`
- `npm test`
- `npm run crap-typescript-check`