### PR TITLE
Hard-rename report destination and JUnit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ export default withCrapTypescriptVitest({
 });
 ```
 
-The Vitest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The Vitest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `output`, `junit`, `junitReport`, or `threshold` in the adapter options to customize reporting. Set `junit: false` to disable the JUnit artifact.
 
 Jest:
 
@@ -145,7 +145,7 @@ export default withCrapTypescriptJest({
 });
 ```
 
-The Jest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact.
+The Jest adapter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `output`, `junit`, `junitReport`, or `threshold` in the adapter options to customize reporting. Set `junit: false` to disable the JUnit artifact.
 
 ## Exit Codes
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -58,15 +58,16 @@ interface ParseState {
   format: ReportFormat;
   threshold: number;
   agent: boolean;
-  outputPath?: string;
-  junitReportPath?: string;
+  output?: string;
+  junit: boolean;
+  junitReport?: string;
   packageManagerSeen: boolean;
   testRunnerSeen: boolean;
   formatSeen: boolean;
   thresholdSeen: boolean;
   agentSeen: boolean;
-  outputPathSeen: boolean;
-  junitReportPathSeen: boolean;
+  outputSeen: boolean;
+  junitReportSeen: boolean;
   fileArgs: string[];
 }
 
@@ -112,15 +113,16 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = {
     return index + 1;
   },
   "--output": (state, args, index) => {
-    ensureOptionIsUnique(state.outputPathSeen, "--output");
-    state.outputPath = parsePathOption(args[index + 1], "--output");
-    state.outputPathSeen = true;
+    ensureOptionIsUnique(state.outputSeen, "--output");
+    state.output = parsePathOption(args[index + 1], "--output");
+    state.outputSeen = true;
     return index + 1;
   },
   "--junit-report": (state, args, index) => {
-    ensureOptionIsUnique(state.junitReportPathSeen, "--junit-report");
-    state.junitReportPath = parsePathOption(args[index + 1], "--junit-report");
-    state.junitReportPathSeen = true;
+    ensureOptionIsUnique(state.junitReportSeen, "--junit-report");
+    state.junit = true;
+    state.junitReport = parsePathOption(args[index + 1], "--junit-report");
+    state.junitReportSeen = true;
     return index + 1;
   }
 };
@@ -134,15 +136,16 @@ function createParseState(): ParseState {
     format: "toon",
     threshold: CRAP_THRESHOLD,
     agent: false,
-    outputPath: undefined,
-    junitReportPath: undefined,
+    output: undefined,
+    junit: false,
+    junitReport: undefined,
     packageManagerSeen: false,
     testRunnerSeen: false,
     formatSeen: false,
     thresholdSeen: false,
     agentSeen: false,
-    outputPathSeen: false,
-    junitReportPathSeen: false,
+    outputSeen: false,
+    junitReportSeen: false,
     fileArgs: []
   };
 }
@@ -172,8 +175,9 @@ function finalizeCliArguments(state: ParseState): CliArguments {
     format: state.format,
     threshold: state.threshold,
     agent: state.agent,
-    ...optionalPath("outputPath", state.outputPath),
-    ...optionalPath("junitReportPath", state.junitReportPath)
+    ...optionalPath("output", state.output),
+    junit: state.junit,
+    ...optionalPath("junitReport", state.junitReport)
   };
 }
 
@@ -199,7 +203,7 @@ function cliMode(state: ParseState): CliArguments["mode"] {
   return state.fileArgs.length > 0 ? "explicit" : "all";
 }
 
-function optionalPath<K extends "outputPath" | "junitReportPath">(key: K, value: string | undefined): Pick<CliArguments, K> | {} {
+function optionalPath<K extends "output" | "junitReport">(key: K, value: string | undefined): Pick<CliArguments, K> | {} {
   return value === undefined ? {} : { [key]: value } as Pick<CliArguments, K>;
 }
 
@@ -334,14 +338,14 @@ async function writeCliReports(
     agent: parsed.agent,
     threshold: result.threshold
   });
-  if (parsed.outputPath) {
-    await writeReportFile(projectRoot, parsed.outputPath, primaryReport);
+  if (parsed.output) {
+    await writeReportFile(projectRoot, parsed.output, primaryReport);
   } else {
     stdout.write(primaryReport);
   }
 
-  if (parsed.junitReportPath) {
-    await writeReportFile(projectRoot, parsed.junitReportPath, formatAnalysisReport(result.metrics, {
+  if (parsed.junit && parsed.junitReport) {
+    await writeReportFile(projectRoot, parsed.junitReport, formatAnalysisReport(result.metrics, {
       format: "junit",
       threshold: result.threshold
     }));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,8 +42,9 @@ export interface CliArguments {
   format: ReportFormat;
   threshold: number;
   agent: boolean;
-  outputPath?: string;
-  junitReportPath?: string;
+  output?: string;
+  junit: boolean;
+  junitReport?: string;
 }
 
 export interface MethodDescriptor {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -32,8 +32,9 @@ describe("cli", () => {
       format: "json",
       threshold: 8,
       agent: true,
-      outputPath: "reports/crap.json",
-      junitReportPath: "reports/crap.xml"
+      output: "reports/crap.json",
+      junit: true,
+      junitReport: "reports/crap.xml"
     });
   });
 
@@ -50,7 +51,8 @@ describe("cli", () => {
       testRunner: "jest",
       format: "toon",
       threshold: 8,
-      agent: false
+      agent: false,
+      junit: false
     });
     expect(parseCliArguments(["--help", "--package-manager", "yarn"])).toEqual({
       mode: "help",
@@ -59,7 +61,8 @@ describe("cli", () => {
       testRunner: "auto",
       format: "toon",
       threshold: 8,
-      agent: false
+      agent: false,
+      junit: false
     });
     expect(parseCliArguments(["--help", "--changed", "src/app.ts", "--agent", "--format", "junit"])).toEqual({
       mode: "help",
@@ -68,7 +71,8 @@ describe("cli", () => {
       testRunner: "auto",
       format: "junit",
       threshold: 8,
-      agent: true
+      agent: true,
+      junit: false
     });
   });
 

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -20,7 +20,7 @@ export default withCrapTypescriptJest({
 
 `withCrapTypescriptJest` wraps your Jest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
-The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact. The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
+The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `output`, `junit`, `junitReport`, or `threshold` in the adapter options to customize reporting. Set `junit: false` to disable the JUnit artifact. The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
 The reporter is also available as a standalone export at `@barney-media/crap-typescript-jest/reporter` for direct configuration.
 

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -36,13 +36,14 @@ export function withCrapTypescriptJest(
   const reporters = ensureDefaultReporter(
     asArray<JestReporterEntry>(config.reporters as JestReporterEntry[] | undefined)
   );
+  const coverageReportPath = options.coverageReportPath ?? buildCoverageReportPath(config.coverageDirectory as string | undefined);
   reporters.push([
     resolveReporterPath(),
     {
       ...options,
-      coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(config.coverageDirectory as string | undefined),
+      coverageReportPath,
       junitReport: options.junitReport === undefined
-        ? buildDefaultJunitReport(config.coverageDirectory as string | undefined)
+        ? buildJunitReportFromCoverage(coverageReportPath)
         : options.junitReport
     }
   ]);
@@ -90,8 +91,8 @@ function buildCoverageReportPath(coverageDirectory: string | undefined): string 
   return `${coverageDirectory ?? "coverage"}/coverage-final.json`;
 }
 
-function buildDefaultJunitReport(coverageDirectory: string | undefined): string {
-  return `${coverageDirectory ?? "coverage"}/crap-typescript-junit.xml`;
+function buildJunitReportFromCoverage(coverageReportPath: string): string {
+  return `${path.dirname(coverageReportPath).replace(/\\/g, "/")}/crap-typescript-junit.xml`;
 }
 
 function resolveReporterPath(): string {

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -15,8 +15,9 @@ export interface CrapTypescriptJestOptions {
   threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
-  outputPath?: string;
-  junitReportPath?: string | false;
+  output?: string;
+  junit?: boolean;
+  junitReport?: string;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -40,9 +41,9 @@ export function withCrapTypescriptJest(
     {
       ...options,
       coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(config.coverageDirectory as string | undefined),
-      junitReportPath: options.junitReportPath === undefined
-        ? buildJunitReportPath(config.coverageDirectory as string | undefined)
-        : options.junitReportPath
+      junitReport: options.junitReport === undefined
+        ? buildDefaultJunitReport(config.coverageDirectory as string | undefined)
+        : options.junitReport
     }
   ]);
 
@@ -89,7 +90,7 @@ function buildCoverageReportPath(coverageDirectory: string | undefined): string 
   return `${coverageDirectory ?? "coverage"}/coverage-final.json`;
 }
 
-function buildJunitReportPath(coverageDirectory: string | undefined): string {
+function buildDefaultJunitReport(coverageDirectory: string | undefined): string {
   return `${coverageDirectory ?? "coverage"}/crap-typescript-junit.xml`;
 }
 

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -17,8 +17,9 @@ export interface CrapTypescriptJestOptions {
   threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
-  outputPath?: string;
-  junitReportPath?: string | false;
+  output?: string;
+  junit?: boolean;
+  junitReport?: string;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -32,8 +33,9 @@ interface ResolvedReporterOptions {
   threshold: number | undefined;
   format: ReportFormat;
   agent: boolean;
-  outputPath: string | undefined;
-  junitReportPath: string | false;
+  output: string | undefined;
+  junit: boolean;
+  junitReport: string;
   stdout: Writer;
   stderr: Writer;
 }
@@ -140,8 +142,9 @@ function resolveAnalysisOptions(
     threshold: options.threshold,
     format: resolveFormat(options),
     agent: resolveAgent(options),
-    outputPath: options.outputPath,
-    junitReportPath: resolveJunitReportPath(options, coverageReportPath)
+    output: options.output,
+    junit: resolveJunit(options),
+    junitReport: resolveJunitReport(options, coverageReportPath)
   };
 }
 
@@ -173,10 +176,14 @@ function resolveAgent(options: CrapTypescriptJestOptions): boolean {
   return options.agent ?? false;
 }
 
-function resolveJunitReportPath(options: CrapTypescriptJestOptions, coverageReportPath: string): string | false {
-  return options.junitReportPath === undefined
-    ? buildJunitReportPathFromCoveragePath(coverageReportPath)
-    : options.junitReportPath;
+function resolveJunit(options: CrapTypescriptJestOptions): boolean {
+  return options.junit ?? true;
+}
+
+function resolveJunitReport(options: CrapTypescriptJestOptions, coverageReportPath: string): string {
+  return options.junitReport === undefined
+    ? buildJunitReportFromCoverage(coverageReportPath)
+    : options.junitReport;
 }
 
 function resolveOutputWriters(
@@ -197,14 +204,14 @@ async function writeReporterReports(
     agent: options.agent,
     threshold: options.threshold
   });
-  if (options.outputPath) {
-    await writeReportFile(options.projectRoot, options.outputPath, primaryReport);
+  if (options.output) {
+    await writeReportFile(options.projectRoot, options.output, primaryReport);
   } else {
     options.stdout.write(primaryReport);
   }
 
-  if (options.junitReportPath !== false) {
-    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, {
+  if (options.junit) {
+    await writeReportFile(options.projectRoot, options.junitReport, formatAnalysisReport(metrics, {
       format: "junit",
       threshold: options.threshold
     }));
@@ -217,6 +224,6 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
   await writeFile(absolutePath, content);
 }
 
-function buildJunitReportPathFromCoveragePath(coverageReportPath: string): string {
+function buildJunitReportFromCoverage(coverageReportPath: string): string {
   return path.join(path.dirname(coverageReportPath), "crap-typescript-junit.xml");
 }

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -225,5 +225,5 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
 }
 
 function buildJunitReportFromCoverage(coverageReportPath: string): string {
-  return path.join(path.dirname(coverageReportPath), "crap-typescript-junit.xml");
+  return `${path.dirname(coverageReportPath).replace(/\\/g, "/")}/crap-typescript-junit.xml`;
 }

--- a/packages/jest/test/config.test.ts
+++ b/packages/jest/test/config.test.ts
@@ -11,13 +11,13 @@ describe("withCrapTypescriptJest", () => {
     expect(config.coverageReporters).toEqual(["json", "text"]);
 
     const reporters = config.reporters as unknown[];
-    const reporterEntry = reporters[1] as [string, { coverageReportPath: string; junitReportPath: string }];
+    const reporterEntry = reporters[1] as [string, { coverageReportPath: string; junitReport: string }];
     expect(reporters[0]).toBe("default");
     expect(Array.isArray(reporterEntry)).toBe(true);
     expect(reporterEntry[0].replace(/\\/g, "/")).toContain("/packages/jest/src/reporter");
     expect(reporterEntry[1]).toMatchObject({
       coverageReportPath: "coverage/coverage-final.json",
-      junitReportPath: "coverage/crap-typescript-junit.xml"
+      junitReport: "coverage/crap-typescript-junit.xml"
     });
   });
 
@@ -36,7 +36,7 @@ describe("withCrapTypescriptJest", () => {
         expect.any(String),
         expect.objectContaining({
           coverageReportPath: "custom-coverage/coverage-final.json",
-          junitReportPath: "custom-coverage/crap-typescript-junit.xml"
+          junitReport: "custom-coverage/crap-typescript-junit.xml"
         })
       ]
     ]);
@@ -60,7 +60,27 @@ describe("withCrapTypescriptJest", () => {
         expect.any(String),
         expect.objectContaining({
           coverageReportPath: "custom-coverage/coverage-final.json",
-          junitReportPath: "custom-coverage/crap-typescript-junit.xml"
+          junitReport: "custom-coverage/crap-typescript-junit.xml"
+        })
+      ]
+    ]);
+  });
+
+  it("passes renamed reporting options to the reporter", () => {
+    const config = withCrapTypescriptJest({}, {
+      output: "reports/crap.txt",
+      junit: false,
+      junitReport: "reports/custom-junit.xml"
+    });
+
+    expect(config.reporters).toEqual([
+      "default",
+      [
+        expect.any(String),
+        expect.objectContaining({
+          output: "reports/crap.txt",
+          junit: false,
+          junitReport: "reports/custom-junit.xml"
         })
       ]
     ]);

--- a/packages/jest/test/config.test.ts
+++ b/packages/jest/test/config.test.ts
@@ -85,4 +85,21 @@ describe("withCrapTypescriptJest", () => {
       ]
     ]);
   });
+
+  it("derives the default JUnit report from an overridden coverage report", () => {
+    const config = withCrapTypescriptJest({}, {
+      coverageReportPath: "custom-coverage/results/coverage-final.json"
+    });
+
+    expect(config.reporters).toEqual([
+      "default",
+      [
+        expect.any(String),
+        expect.objectContaining({
+          coverageReportPath: "custom-coverage/results/coverage-final.json",
+          junitReport: "custom-coverage/results/crap-typescript-junit.xml"
+        })
+      ]
+    ]);
+  });
 });

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -84,7 +84,7 @@ describe("CrapTypescriptJestReporter", () => {
     const reporter = new CrapTypescriptJestReporter(undefined, {
       projectRoot,
       format: "toon",
-      junitReportPath: false,
+      junit: false,
       stdout,
       stderr
     });
@@ -92,6 +92,32 @@ describe("CrapTypescriptJestReporter", () => {
     await callFinalize(reporter);
 
     expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(stderr.toString()).toBe("");
+  });
+
+  it("writes renamed output and JUnit report options", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": "{}"
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptJestReporter(undefined, {
+      projectRoot,
+      output: "reports/crap.txt",
+      junitReport: "reports/custom-junit.xml",
+      stdout,
+      stderr
+    });
+
+    await callFinalize(reporter);
+
+    expect(stdout.toString()).toBe("");
+    expect(await readText(`${projectRoot}/reports/crap.txt`)).toBe("status: passed\nthreshold: 8.0\n");
+    expect(await readText(`${projectRoot}/reports/custom-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
   });
 
@@ -257,7 +283,7 @@ describe("CrapTypescriptJestReporter", () => {
       projectRoot,
       format: "json",
       agent: true,
-      junitReportPath: false,
+      junit: false,
       stdout,
       stderr
     });

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -22,7 +22,7 @@ export default withCrapTypescriptVitest({
 
 `withCrapTypescriptVitest` wraps your Vitest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
-The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `outputPath`, `junitReportPath`, or `threshold` in the adapter options to customize reporting. Set `junitReportPath: false` to disable the JUnit artifact. The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
+The reporter prints text output by default and writes `coverage/crap-typescript-junit.xml` for CI test-report UIs. Pass `format`, `agent`, `output`, `junit`, `junitReport`, or `threshold` in the adapter options to customize reporting. Set `junit: false` to disable the JUnit artifact. The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -29,8 +29,9 @@ export interface CrapTypescriptVitestOptions {
   threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
-  outputPath?: string;
-  junitReportPath?: string | false;
+  output?: string;
+  junit?: boolean;
+  junitReport?: string;
   stdout?: Writer;
   stderr?: Writer;
 }
@@ -78,9 +79,9 @@ export function withCrapTypescriptVitest(
   reporters.push(new CrapTypescriptVitestReporter({
     ...options,
     coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory),
-    junitReportPath: options.junitReportPath === undefined
-      ? buildJunitReportPath(coverage.reportsDirectory)
-      : options.junitReportPath
+    junitReport: options.junitReport === undefined
+      ? buildDefaultJunitReport(coverage.reportsDirectory)
+      : options.junitReport
   }));
 
   return {
@@ -133,7 +134,7 @@ function buildCoverageReportPath(reportsDirectory: string | undefined): string {
   return `${reportsDirectory ?? "coverage"}/coverage-final.json`;
 }
 
-function buildJunitReportPath(reportsDirectory: string | undefined): string {
+function buildDefaultJunitReport(reportsDirectory: string | undefined): string {
   return `${reportsDirectory ?? "coverage"}/crap-typescript-junit.xml`;
 }
 
@@ -150,8 +151,9 @@ interface ResolvedReporterOptions {
   threshold: number | undefined;
   format: ReportFormat;
   agent: boolean;
-  outputPath: string | undefined;
-  junitReportPath: string | false;
+  output: string | undefined;
+  junit: boolean;
+  junitReport: string;
   stdout: Writer;
   stderr: Writer;
 }
@@ -166,8 +168,9 @@ function resolveReporterOptions(options: CrapTypescriptVitestOptions): ResolvedR
     threshold: options.threshold,
     format: resolveFormat(options),
     agent: resolveAgent(options),
-    outputPath: options.outputPath,
-    junitReportPath: resolveJunitReportPath(options),
+    output: options.output,
+    junit: resolveJunit(options),
+    junitReport: resolveJunitReport(options),
     stdout: options.stdout ?? process.stdout,
     stderr: options.stderr ?? process.stderr
   };
@@ -197,10 +200,14 @@ function resolveAgent(options: CrapTypescriptVitestOptions): boolean {
   return options.agent ?? false;
 }
 
-function resolveJunitReportPath(options: CrapTypescriptVitestOptions): string | false {
-  return options.junitReportPath === undefined
-    ? buildJunitReportPathFromCoveragePath(options.coverageReportPath)
-    : options.junitReportPath;
+function resolveJunit(options: CrapTypescriptVitestOptions): boolean {
+  return options.junit ?? true;
+}
+
+function resolveJunitReport(options: CrapTypescriptVitestOptions): string {
+  return options.junitReport === undefined
+    ? buildJunitReportFromCoverage(options.coverageReportPath)
+    : options.junitReport;
 }
 
 async function writeReporterReports(
@@ -212,14 +219,14 @@ async function writeReporterReports(
     agent: options.agent,
     threshold: options.threshold
   });
-  if (options.outputPath) {
-    await writeReportFile(options.projectRoot, options.outputPath, primaryReport);
+  if (options.output) {
+    await writeReportFile(options.projectRoot, options.output, primaryReport);
   } else {
     options.stdout.write(primaryReport);
   }
 
-  if (options.junitReportPath !== false) {
-    await writeReportFile(options.projectRoot, options.junitReportPath, formatAnalysisReport(metrics, {
+  if (options.junit) {
+    await writeReportFile(options.projectRoot, options.junitReport, formatAnalysisReport(metrics, {
       format: "junit",
       threshold: options.threshold
     }));
@@ -232,6 +239,6 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
   await writeFile(absolutePath, content);
 }
 
-function buildJunitReportPathFromCoveragePath(coverageReportPath: string | undefined): string {
+function buildJunitReportFromCoverage(coverageReportPath: string | undefined): string {
   return path.join(path.dirname(coverageReportPath ?? "coverage/coverage-final.json"), "crap-typescript-junit.xml");
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -76,11 +76,12 @@ export function withCrapTypescriptVitest(
   const coverage = testConfig.coverage ?? {};
   const coverageReporters = ensureReporterEntries(asArray(coverage.reporter), "json", "text");
   const reporters = ensureDefaultReporter(asArray(testConfig.reporters));
+  const coverageReportPath = options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory);
   reporters.push(new CrapTypescriptVitestReporter({
     ...options,
-    coverageReportPath: options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory),
+    coverageReportPath,
     junitReport: options.junitReport === undefined
-      ? buildDefaultJunitReport(coverage.reportsDirectory)
+      ? buildJunitReportFromCoverage(coverageReportPath)
       : options.junitReport
   }));
 
@@ -132,10 +133,6 @@ function ensureDefaultReporter(existing: VitestReporterEntry[]): VitestReporterE
 
 function buildCoverageReportPath(reportsDirectory: string | undefined): string {
   return `${reportsDirectory ?? "coverage"}/coverage-final.json`;
-}
-
-function buildDefaultJunitReport(reportsDirectory: string | undefined): string {
-  return `${reportsDirectory ?? "coverage"}/crap-typescript-junit.xml`;
 }
 
 function toError(error: unknown): Error {
@@ -240,5 +237,5 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
 }
 
 function buildJunitReportFromCoverage(coverageReportPath: string | undefined): string {
-  return path.join(path.dirname(coverageReportPath ?? "coverage/coverage-final.json"), "crap-typescript-junit.xml");
+  return `${path.dirname(coverageReportPath ?? "coverage/coverage-final.json").replace(/\\/g, "/")}/crap-typescript-junit.xml`;
 }

--- a/packages/vitest/test/config.test.ts
+++ b/packages/vitest/test/config.test.ts
@@ -18,7 +18,7 @@ describe("withCrapTypescriptVitest", () => {
     expect(crapReporter).toBeInstanceOf(CrapTypescriptVitestReporter);
     expect(crapReporter).toMatchObject({
       options: expect.objectContaining({
-        junitReportPath: "coverage/crap-typescript-junit.xml"
+        junitReport: "coverage/crap-typescript-junit.xml"
       })
     });
     expect(coverageReporters).toEqual(["json", "text"]);
@@ -43,8 +43,27 @@ describe("withCrapTypescriptVitest", () => {
     expect(config.test?.coverage?.reportsDirectory).toBe("custom-coverage");
     expect(config.test?.reporters?.[1]).toMatchObject({
       options: expect.objectContaining({
-        junitReportPath: "custom-coverage/crap-typescript-junit.xml"
+        junitReport: "custom-coverage/crap-typescript-junit.xml"
       })
     });
+  });
+
+  it("passes renamed reporting options to the reporter", () => {
+    const config = withCrapTypescriptVitest({}, {
+      output: "reports/crap.txt",
+      junit: false,
+      junitReport: "reports/custom-junit.xml"
+    });
+
+    expect(config.test?.reporters).toEqual([
+      "default",
+      expect.objectContaining({
+        options: expect.objectContaining({
+          output: "reports/crap.txt",
+          junit: false,
+          junitReport: "reports/custom-junit.xml"
+        })
+      })
+    ]);
   });
 });

--- a/packages/vitest/test/config.test.ts
+++ b/packages/vitest/test/config.test.ts
@@ -66,4 +66,20 @@ describe("withCrapTypescriptVitest", () => {
       })
     ]);
   });
+
+  it("derives the default JUnit report from an overridden coverage report", () => {
+    const config = withCrapTypescriptVitest({}, {
+      coverageReportPath: "custom-coverage/results/coverage-final.json"
+    });
+
+    expect(config.test?.reporters).toEqual([
+      "default",
+      expect.objectContaining({
+        options: expect.objectContaining({
+          coverageReportPath: "custom-coverage/results/coverage-final.json",
+          junitReport: "custom-coverage/results/crap-typescript-junit.xml"
+        })
+      })
+    ]);
+  });
 });

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -51,7 +51,7 @@ describe("CrapTypescriptVitestReporter", () => {
     const reporter = new CrapTypescriptVitestReporter({
       projectRoot,
       format: "toon",
-      junitReportPath: false,
+      junit: false,
       stdout,
       stderr
     });
@@ -61,6 +61,32 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
+
+  it("writes renamed output and JUnit report options", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}'
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      output: "reports/crap.txt",
+      junitReport: "reports/custom-junit.xml",
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    expect(stdout.toString()).toBe("");
+    expect(await readText(`${projectRoot}/reports/crap.txt`)).toBe("status: passed\nthreshold: 8.0\n");
+    expect(await readText(`${projectRoot}/reports/custom-junit.xml`)).toContain('status="passed"');
+    expect(stderr.toString()).toBe("");
+  });
+
 
   it("honors custom thresholds and emits threshold warnings", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
@@ -220,7 +246,7 @@ describe("CrapTypescriptVitestReporter", () => {
       projectRoot,
       format: "json",
       agent: true,
-      junitReportPath: false,
+      junit: false,
       stdout,
       stderr
     });
@@ -249,7 +275,7 @@ describe("CrapTypescriptVitestReporter", () => {
       projectRoot,
       format: "junit",
       agent: true,
-      junitReportPath: false,
+      junit: false,
       stdout,
       stderr
     });


### PR DESCRIPTION
Closes #58.

## Summary

- Rename exported CLI argument fields from `outputPath`/`junitReportPath` to `output`/`junit`/`junitReport` while keeping the `--output` and `--junit-report` flags unchanged.
- Rename Jest and Vitest public adapter options to `output`, `junit`, and `junitReport` without compatibility aliases.
- Keep adapter JUnit sidecars enabled by default and use `junit: false` as the explicit disable switch.

## Validation

- `npm ci`
- `npm run build`
- `npm test`
- `npm run crap-typescript-check`