### PR TITLE
Add failures-only primary report filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ npx crap-typescript
 --test-runner <runner>       Force auto, vitest, or jest
 --format <format>            Emit toon, json, text, or junit (default: toon)
 --agent                      Emit only overall status and failed methods for toon, json, or text
+--failures-only[=true|false] Emit failed methods only in the primary report
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
 --threshold <number>         Override the CRAP threshold (`8.0` by default)
@@ -101,6 +102,7 @@ npx crap-typescript
 npx crap-typescript --changed
 npx crap-typescript --package-manager npm --test-runner vitest
 npx crap-typescript --format json --output reports/crap.json
+npx crap-typescript --failures-only --format json
 npx crap-typescript --agent --junit-report reports/crap-junit.xml
 npx crap-typescript --threshold 6
 npx crap-typescript src/sample.ts
@@ -113,9 +115,11 @@ The CLI defaults to TOON output for compact, agent-readable reports. `--format` 
 
 Primary reports expose overall `status` and the run-level `threshold`. Per-function entries use the shared fields `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. Method-level entries never repeat `threshold`.
 
+Use `--failures-only` to keep run-level metadata but emit only failed function entries in the primary report. `--failures-only=true` and `--failures-only=false` are accepted for explicit boolean configuration.
+
 `--agent` is a filtering mode, not a report format. It is available with `toon`, `json`, and `text`; it keeps the overall `status` and `threshold`, includes failed methods only, and omits method-level `status` because included method entries are implicitly failed.
 
-Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit output keeps the aggregate XML attributes required by CI parsers, writes `threshold` as a testsuite property, and puts method details on each testcase.
+Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit sidecars always contain the full method set, regardless of `--failures-only`. JUnit output keeps the aggregate XML attributes required by CI parsers, writes `threshold` as a testsuite property, and puts method details on each testcase.
 
 The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates. The warning recommends `8.0` for hard gates, targeting `6.0` during implementation, and using the `8.0` default when in doubt.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,6 +30,7 @@ npx crap-typescript packages/api packages/web
 --test-runner <runner>       Force auto, vitest, or jest
 --format <format>            Emit toon, json, text, or junit (default: toon)
 --agent                      Emit only overall status and failed methods for toon, json, or text
+--failures-only[=true|false] Emit failed methods only in the primary report
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
 --threshold <number>         Override the CRAP threshold (`8.0` by default)
@@ -37,7 +38,7 @@ npx crap-typescript packages/api packages/web
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
 
-The default `toon` format is compact and agent-readable. Primary reports include run-level `status` and `threshold`; method rows use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. `--agent` is a filtering mode, not a format: it keeps the overall `status` and `threshold`, includes failed method entries only, and omits method-level `status`.
+The default `toon` format is compact and agent-readable. Primary reports include run-level `status` and `threshold`; method rows use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. `--failures-only`, `--failures-only=true`, and `--failures-only=false` control whether the primary report includes only failed method entries. JUnit sidecar reports always include the full method set. `--agent` is a filtering mode, not a format: it keeps the overall `status` and `threshold`, includes failed method entries only, and omits method-level `status`.
 
 The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -11,8 +11,8 @@ const HELP_TEXT = `crap-typescript
 
 Usage:
   crap-typescript [--help]
-  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>] [--threshold <number>]
-  crap-typescript [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--output <path>] [--junit-report <path>] [--threshold <number>] <path ...>
+  crap-typescript [--changed] [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--failures-only[=true|false]] [--output <path>] [--junit-report <path>] [--threshold <number>]
+  crap-typescript [--package-manager <tool>] [--test-runner <runner>] [--format <format>] [--agent] [--failures-only[=true|false]] [--output <path>] [--junit-report <path>] [--threshold <number>] <path ...>
 
 Options:
   --help                     Print usage to stdout
@@ -21,6 +21,8 @@ Options:
   --test-runner <runner>     Force auto, vitest, or jest
   --format <format>          Emit toon, json, text, or junit (default: toon)
   --agent                    Emit only overall status and failed methods for toon, json, or text
+  --failures-only[=true|false]
+                             Emit failed methods only in the primary report
   --output <path>            Write the primary report to a file instead of stdout
   --junit-report <path>      Also write a full JUnit XML report for CI test-report UIs
   --threshold <number>       Override the CRAP threshold (default: 8.0)
@@ -58,6 +60,7 @@ interface ParseState {
   format: ReportFormat;
   threshold: number;
   agent: boolean;
+  failuresOnly: boolean;
   output?: string;
   junit: boolean;
   junitReport?: string;
@@ -66,6 +69,7 @@ interface ParseState {
   formatSeen: boolean;
   thresholdSeen: boolean;
   agentSeen: boolean;
+  failuresOnlySeen: boolean;
   outputSeen: boolean;
   junitReportSeen: boolean;
   fileArgs: string[];
@@ -136,6 +140,7 @@ function createParseState(): ParseState {
     format: "toon",
     threshold: CRAP_THRESHOLD,
     agent: false,
+    failuresOnly: false,
     output: undefined,
     junit: false,
     junitReport: undefined,
@@ -144,6 +149,7 @@ function createParseState(): ParseState {
     formatSeen: false,
     thresholdSeen: false,
     agentSeen: false,
+    failuresOnlySeen: false,
     outputSeen: false,
     junitReportSeen: false,
     fileArgs: []
@@ -151,6 +157,12 @@ function createParseState(): ParseState {
 }
 
 function consumeOption(state: ParseState, args: string[], index: number): number {
+  const [option, value] = splitInlineBooleanOption(args[index]);
+  if (option === "--failures-only") {
+    parseFailuresOnly(state, value);
+    return index;
+  }
+
   const handler = OPTION_HANDLERS[args[index]];
   if (!handler) {
     throw new Error(`Unknown option: ${args[index]}`);
@@ -175,6 +187,7 @@ function finalizeCliArguments(state: ParseState): CliArguments {
     format: state.format,
     threshold: state.threshold,
     agent: state.agent,
+    failuresOnly: state.failuresOnly,
     ...optionalPath("output", state.output),
     junit: state.junit,
     ...optionalPath("junitReport", state.junitReport)
@@ -246,6 +259,30 @@ function parseThreshold(value: string | undefined): number {
   } catch {
     throw new Error("--threshold requires a finite number greater than 0");
   }
+}
+
+function splitInlineBooleanOption(arg: string): [string, string | undefined] {
+  const [option, ...values] = arg.split("=");
+  return [option, values.length === 0 ? undefined : values.join("=")];
+}
+
+function parseFailuresOnly(state: ParseState, value: string | undefined): void {
+  ensureOptionIsUnique(state.failuresOnlySeen, "--failures-only");
+  state.failuresOnly = parseBooleanOption(value, "--failures-only");
+  state.failuresOnlySeen = true;
+}
+
+function parseBooleanOption(value: string | undefined, option: string): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  throw new Error(`${option} requires true or false when a value is provided`);
 }
 
 function parsePathOption(value: string | undefined, option: string): string {
@@ -336,7 +373,8 @@ async function writeCliReports(
   const primaryReport = formatAnalysisReport(result.metrics, {
     format: parsed.format,
     agent: parsed.agent,
-    threshold: result.threshold
+    threshold: result.threshold,
+    failuresOnly: parsed.failuresOnly
   });
   if (parsed.output) {
     await writeReportFile(projectRoot, parsed.output, primaryReport);

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -46,6 +46,7 @@ export interface FormatAnalysisReportOptions {
   format: ReportFormat;
   agent?: boolean;
   threshold?: number;
+  failuresOnly?: boolean;
 }
 
 type SerializableReport = AnalysisReport | AgentAnalysisReport;
@@ -85,13 +86,17 @@ export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
   });
 }
 
-export function buildAnalysisReport(metrics: MethodMetrics[], threshold = CRAP_THRESHOLD): AnalysisReport {
+export function buildAnalysisReport(
+  metrics: MethodMetrics[],
+  threshold = CRAP_THRESHOLD,
+  failuresOnly = false
+): AnalysisReport {
   threshold = validateThreshold(threshold);
-  const methods = sortMetrics(metrics).map((metric) => toMethodReportEntry(metric, threshold));
+  const allMethods = sortMetrics(metrics).map((metric) => toMethodReportEntry(metric, threshold));
   return {
-    status: methods.some((method) => method.status === "failed") ? "failed" : "passed",
+    status: allMethods.some((method) => method.status === "failed") ? "failed" : "passed",
     threshold,
-    methods
+    methods: failuresOnly ? allMethods.filter((method) => method.status === "failed") : allMethods
   };
 }
 
@@ -109,8 +114,12 @@ export function buildAgentAnalysisReport(metrics: MethodMetrics[], threshold = C
 export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAnalysisReportOptions): string {
   const agent = options.agent ?? false;
   const threshold = options.threshold ?? CRAP_THRESHOLD;
+  const failuresOnly = options.failuresOnly ?? false;
   validateReportOptions(options.format, agent);
-  return REPORT_FORMATTERS[options.format](agent ? buildAgentAnalysisReport(metrics, threshold) : buildAnalysisReport(metrics, threshold), agent);
+  return REPORT_FORMATTERS[options.format](
+    agent ? buildAgentAnalysisReport(metrics, threshold) : buildAnalysisReport(metrics, threshold, failuresOnly),
+    agent
+  );
 }
 
 function validateReportOptions(format: ReportFormat, agent: boolean): void {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,6 +42,7 @@ export interface CliArguments {
   format: ReportFormat;
   threshold: number;
   agent: boolean;
+  failuresOnly: boolean;
   output?: string;
   junit: boolean;
   junitReport?: string;

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -20,6 +20,7 @@ describe("cli", () => {
       "--format",
       "json",
       "--agent",
+      "--failures-only=false",
       "--output",
       "reports/crap.json",
       "--junit-report",
@@ -32,6 +33,7 @@ describe("cli", () => {
       format: "json",
       threshold: 8,
       agent: true,
+      failuresOnly: false,
       output: "reports/crap.json",
       junit: true,
       junitReport: "reports/crap.xml"
@@ -52,6 +54,7 @@ describe("cli", () => {
       format: "toon",
       threshold: 8,
       agent: false,
+      failuresOnly: false,
       junit: false
     });
     expect(parseCliArguments(["--help", "--package-manager", "yarn"])).toEqual({
@@ -62,6 +65,7 @@ describe("cli", () => {
       format: "toon",
       threshold: 8,
       agent: false,
+      failuresOnly: false,
       junit: false
     });
     expect(parseCliArguments(["--help", "--changed", "src/app.ts", "--agent", "--format", "junit"])).toEqual({
@@ -72,6 +76,7 @@ describe("cli", () => {
       format: "junit",
       threshold: 8,
       agent: true,
+      failuresOnly: false,
       junit: false
     });
   });
@@ -90,6 +95,9 @@ describe("cli", () => {
       "--threshold can only be provided once"
     );
     expect(() => parseCliArguments(["--agent", "--agent"])).toThrow("--agent can only be provided once");
+    expect(() => parseCliArguments(["--failures-only", "--failures-only=false"])).toThrow(
+      "--failures-only can only be provided once"
+    );
     expect(() => parseCliArguments(["--output", "a", "--output", "b"])).toThrow("--output can only be provided once");
     expect(() => parseCliArguments(["--junit-report", "a", "--junit-report", "b"])).toThrow(
       "--junit-report can only be provided once"
@@ -113,6 +121,9 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--threshold", "-1"])).toThrow("--threshold requires a finite number greater than 0");
     expect(() => parseCliArguments(["--threshold", "NaN"])).toThrow("--threshold requires a finite number greater than 0");
     expect(() => parseCliArguments(["--threshold", "Infinity"])).toThrow("--threshold requires a finite number greater than 0");
+    expect(() => parseCliArguments(["--failures-only=maybe"])).toThrow(
+      "--failures-only requires true or false when a value is provided"
+    );
     expect(() => parseCliArguments(["--unknown"])).toThrow("Unknown option: --unknown");
   });
 
@@ -120,6 +131,18 @@ describe("cli", () => {
     expect(parseCliArguments(["--threshold", "6", "--changed"])).toMatchObject({
       mode: "changed",
       threshold: 6
+    });
+  });
+
+  it("parses failures-only boolean syntax", () => {
+    expect(parseCliArguments(["--failures-only"])).toMatchObject({
+      failuresOnly: true
+    });
+    expect(parseCliArguments(["--failures-only=true"])).toMatchObject({
+      failuresOnly: true
+    });
+    expect(parseCliArguments(["--failures-only=false"])).toMatchObject({
+      failuresOnly: false
     });
   });
 
@@ -395,6 +418,123 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(primary.methods[0].func).toBe("risky");
     expect(primary.methods[0]).not.toHaveProperty("status");
     expect(primary.methods[0]).not.toHaveProperty("threshold");
+    expect(junit).toContain('tests="2"');
+    expect(junit).toContain('name="safe"');
+    expect(junit).toContain('name="risky"');
+    expect(stderr.toString()).toContain("CRAP threshold exceeded");
+  });
+
+  it("filters failures-only primary reports and writes full JUnit sidecars", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+
+export function risky(flagA: boolean, flagB: boolean): number {
+  if (flagA && flagB) {
+    return 1;
+  }
+  return 0;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            },
+            "1": {
+              start: { line: 7, column: 4 },
+              end: { line: 7, column: 13 }
+            },
+            "2": {
+              start: { line: 9, column: 2 },
+              end: { line: 9, column: 11 }
+            }
+          },
+          fnMap: {},
+          branchMap: {
+            "0": {
+              line: 6,
+              type: "if",
+              loc: {
+                start: { line: 6, column: 2 },
+                end: { line: 8, column: 3 }
+              },
+              locations: [
+                {
+                  start: { line: 6, column: 2 },
+                  end: { line: 8, column: 3 }
+                },
+                {}
+              ]
+            },
+            "1": {
+              line: 6,
+              type: "binary-expr",
+              loc: {
+                start: { line: 6, column: 6 },
+                end: { line: 6, column: 31 }
+              },
+              locations: [
+                {
+                  start: { line: 6, column: 6 },
+                  end: { line: 6, column: 20 }
+                },
+                {
+                  start: { line: 6, column: 24 },
+                  end: { line: 6, column: 29 }
+                }
+              ]
+            }
+          },
+          s: {
+            "0": 1,
+            "1": 0,
+            "2": 0
+          },
+          f: {},
+          b: {
+            "0": [0, 0],
+            "1": [0, 0]
+          }
+        }
+      })
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const exitCode = await runCli([
+      "--failures-only",
+      "--format",
+      "json",
+      "--output",
+      "reports/crap.json",
+      "--junit-report",
+      "reports/crap.xml"
+    ], projectRoot, stdout, stderr);
+
+    const primary = JSON.parse(await readText(`${projectRoot}/reports/crap.json`)) as {
+      status: string;
+      threshold: number;
+      methods: Array<Record<string, unknown>>;
+    };
+    const junit = await readText(`${projectRoot}/reports/crap.xml`);
+
+    expect(exitCode).toBe(2);
+    expect(stdout.toString()).toBe("");
+    expect(primary.status).toBe("failed");
+    expect(primary.threshold).toBe(8);
+    expect(primary.methods).toHaveLength(1);
+    expect(primary.methods[0]).toMatchObject({
+      status: "failed",
+      func: "risky"
+    });
     expect(junit).toContain('tests="2"');
     expect(junit).toContain('name="safe"');
     expect(junit).toContain('name="risky"');

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -166,6 +166,36 @@ describe("report formatting", () => {
     expect(parsed.methods[0].status).toBe("passed");
   });
 
+  it("filters primary reports to failed methods without changing run metadata", () => {
+    const parsed = JSON.parse(formatAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        startLine: 5,
+        endLine: 10,
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      })
+    ], { format: "json", failuresOnly: true })) as {
+      status: string;
+      threshold: number;
+      methods: Array<{ status: string; func: string }>;
+    };
+
+    expect(parsed.status).toBe("failed");
+    expect(parsed.threshold).toBe(8);
+    expect(parsed.methods).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        func: "risky"
+      })
+    ]);
+  });
+
   it("formats TOON reports and omits status from agent method entries", () => {
     const report = buildAgentAnalysisReport([
       metric(),

--- a/spec.md
+++ b/spec.md
@@ -46,6 +46,8 @@ It shall also accept optional overrides:
 - `--package-manager auto|npm|pnpm|yarn`
 - `--test-runner auto|vitest|jest`
 - `--threshold <finite-positive-number>`
+- `--failures-only`
+- `--failures-only=true|false`
 
 Invalid argument parsing shall exit with usage error and print the usage text.
 
@@ -214,6 +216,8 @@ The tool shall print a tabular report containing, at minimum:
 The report shall be sorted by CRAP descending.
 
 Functions with `N/A` CRAP shall appear after functions with numeric CRAP.
+
+When `--failures-only` is enabled, primary reports shall keep run-level metadata and emit only function rows whose status is failed. JUnit sidecar reports shall not be affected by this option and shall always contain the full function set.
 
 ## 11. Threshold
 


### PR DESCRIPTION
Closes #60.

## Summary
- add `failuresOnly` to core report formatting and CLI parsing
- support `--failures-only`, `--failures-only=true`, and `--failures-only=false`
- keep JUnit sidecar output full while filtering only the primary report
- document the new option and sidecar behavior

## Validation
- `npm ci`
- `npm run build`
- `npm test`
- `npm run crap-typescript-check`