### PR TITLE
Redefine agent as composite report shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ npx crap-typescript
 --package-manager <tool>     Force auto, npm, pnpm, or yarn
 --test-runner <runner>       Force auto, vitest, or jest
 --format <format>            Emit toon, json, text, or junit (default: toon)
---agent                      Emit only overall status and failed methods for toon, json, or text
+--agent                      Default primary output to toon, failures-only, omit-redundancy
 --failures-only[=true|false] Emit failed methods only in the primary report
 --omit-redundancy[=true|false] Omit redundant per-function status in the primary report
 --output <path>              Write the primary report to a file instead of stdout
@@ -121,7 +121,7 @@ Use `--failures-only` to keep run-level metadata but emit only failed function e
 
 Use `--omit-redundancy` to keep run-level metadata but omit per-function `status` in the primary report. With `--format junit`, it omits the custom testcase `status` property while preserving JUnit failure and skipped elements. The value can also be assigned explicitly with `--omit-redundancy=true` or `--omit-redundancy=false`.
 
-`--agent` is a filtering mode, not a report format. It is available with `toon`, `json`, and `text`; it keeps the overall `status` and `threshold`, includes failed methods only, and omits method-level `status` because included method entries are implicitly failed.
+`--agent` is a composite shortcut, not a report format. It defaults primary output to `--format toon`, `--failures-only=true`, and `--omit-redundancy=true`. Explicit `--format`, `--failures-only=false`, or `--omit-redundancy=false` options override those defaults.
 
 Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit sidecars always contain the full method set, regardless of `--failures-only` or `--omit-redundancy`. JUnit output keeps the aggregate XML attributes required by CI parsers, writes `threshold` as a testsuite property, and puts method details on each testcase.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,7 +29,7 @@ npx crap-typescript packages/api packages/web
 --package-manager <tool>     Force auto, npm, pnpm, or yarn
 --test-runner <runner>       Force auto, vitest, or jest
 --format <format>            Emit toon, json, text, or junit (default: toon)
---agent                      Emit only overall status and failed methods for toon, json, or text
+--agent                      Default primary output to toon, failures-only, omit-redundancy
 --failures-only[=true|false] Emit failed methods only in the primary report
 --omit-redundancy[=true|false] Omit redundant per-function status in the primary report
 --output <path>              Write the primary report to a file instead of stdout
@@ -39,7 +39,7 @@ npx crap-typescript packages/api packages/web
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```
 
-The default `toon` format is compact and agent-readable. Primary reports include run-level `status` and `threshold`; method rows use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. `--failures-only`, `--failures-only=true`, and `--failures-only=false` control whether the primary report includes only failed method entries. `--omit-redundancy`, `--omit-redundancy=true`, and `--omit-redundancy=false` control whether primary report method rows omit `status`; with `--format junit`, they omit the custom testcase `status` property while preserving JUnit failure and skipped elements. JUnit sidecar reports always include the full method set and method status. `--agent` is a filtering mode, not a format: it keeps the overall `status` and `threshold`, includes failed method entries only, and omits method-level `status`.
+The default `toon` format is compact and agent-readable. Primary reports include run-level `status` and `threshold`; method rows use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. `--failures-only`, `--failures-only=true`, and `--failures-only=false` control whether the primary report includes only failed method entries. `--omit-redundancy`, `--omit-redundancy=true`, and `--omit-redundancy=false` control whether primary report method rows omit `status`; with `--format junit`, they omit the custom testcase `status` property while preserving JUnit failure and skipped elements. JUnit sidecar reports always include the full method set and method status. `--agent` is a composite shortcut, not a format: it defaults primary output to `--format toon`, `--failures-only=true`, and `--omit-redundancy=true`. Explicit `--format`, `--failures-only=false`, or `--omit-redundancy=false` options override those defaults.
 
 The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,7 +20,7 @@ console.log(report);
 
 Key exports: `analyzeProject`, `calculateCrapScore`, `formatAnalysisReport`, `formatReport`, `parseCoverageReport`, `parseFileMethods`.
 
-`formatAnalysisReport` supports `toon`, `json`, `text`, and `junit`. Primary reports expose run-level `status` and `threshold`; method-level entries use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. Pass `failuresOnly: true` to include failed method entries only. Pass `omitRedundancy: true` to omit method-level `status` while keeping run-level metadata; with `format: "junit"`, this omits the custom testcase `status` property while preserving JUnit failure and skipped elements. JUnit writes `threshold` as a testsuite property. Pass `agent: true` with `toon`, `json`, or `text` to include failed methods only and omit method-level `status`.
+`formatAnalysisReport` supports `toon`, `json`, `text`, and `junit`. Primary reports expose run-level `status` and `threshold`; method-level entries use `status`, `crap`, `cc`, `cov`, `covKind`, `func`, `src`, `lineStart`, and `lineEnd`. Pass `failuresOnly: true` to include failed method entries only. Pass `omitRedundancy: true` to omit method-level `status` while keeping run-level metadata; with `format: "junit"`, this omits the custom testcase `status` property while preserving JUnit failure and skipped elements. JUnit writes `threshold` as a testsuite property. Pass `agent: true` to default `failuresOnly` and `omitRedundancy` to `true`; explicit `failuresOnly: false` or `omitRedundancy: false` overrides those defaults.
 
 ## Formula
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -20,7 +20,7 @@ Options:
   --package-manager <tool>   Force auto, npm, pnpm, or yarn
   --test-runner <runner>     Force auto, vitest, or jest
   --format <format>          Emit toon, json, text, or junit (default: toon)
-  --agent                    Emit only overall status and failed methods for toon, json, or text
+  --agent                    Default primary output to --format toon --failures-only --omit-redundancy
   --failures-only[=true|false]
                              Emit failed methods only in the primary report
   --omit-redundancy[=true|false]
@@ -187,6 +187,7 @@ function ensureOptionIsUnique(seen: boolean, option: string): void {
 }
 
 function finalizeCliArguments(state: ParseState): CliArguments {
+  applyAgentDefaults(state);
   validateCliState(state);
 
   return {
@@ -205,15 +206,21 @@ function finalizeCliArguments(state: ParseState): CliArguments {
   };
 }
 
+function applyAgentDefaults(state: ParseState): void {
+  if (!state.agent) {
+    return;
+  }
+  state.format = state.formatSeen ? state.format : "toon";
+  state.failuresOnly = state.failuresOnlySeen ? state.failuresOnly : true;
+  state.omitRedundancy = state.omitRedundancySeen ? state.omitRedundancy : true;
+}
+
 function validateCliState(state: ParseState): void {
   if (state.help) {
     return;
   }
   if (state.changed && state.fileArgs.length > 0) {
     throw new Error("--changed cannot be combined with file arguments");
-  }
-  if (state.agent && state.format === "junit") {
-    throw new Error("--agent cannot be combined with --format junit");
   }
 }
 

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -115,16 +115,12 @@ export function buildAgentAnalysisReport(metrics: MethodMetrics[], threshold = C
 export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAnalysisReportOptions): string {
   const agent = options.agent ?? false;
   const threshold = options.threshold ?? CRAP_THRESHOLD;
-  const failuresOnly = options.failuresOnly ?? false;
-  const omitRedundancy = options.omitRedundancy ?? false;
-  validateReportOptions(options.format, agent);
-  const omitMethodStatus = agent || omitRedundancy;
-  const report = agent
-    ? buildAgentAnalysisReport(metrics, threshold)
-    : buildPrimaryAnalysisReport(metrics, threshold, failuresOnly, omitRedundancy, options.format);
+  const failuresOnly = options.failuresOnly ?? agent;
+  const omitRedundancy = options.omitRedundancy ?? agent;
+  const report = buildPrimaryAnalysisReport(metrics, threshold, failuresOnly, omitRedundancy, options.format);
   return REPORT_FORMATTERS[options.format](
     report,
-    omitMethodStatus
+    omitRedundancy
   );
 }
 
@@ -137,12 +133,6 @@ function buildPrimaryAnalysisReport(
 ): SerializableReport {
   const report = buildAnalysisReport(metrics, threshold, failuresOnly);
   return omitRedundancy && format !== "junit" ? omitMethodStatuses(report) : report;
-}
-
-function validateReportOptions(format: ReportFormat, agent: boolean): void {
-  if (agent && format === "junit") {
-    throw new Error("--agent cannot be combined with --format junit");
-  }
 }
 
 export function formatReport(metrics: MethodMetrics[]): string {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -34,7 +34,7 @@ describe("cli", () => {
       threshold: 8,
       agent: true,
       failuresOnly: false,
-      omitRedundancy: false,
+      omitRedundancy: true,
       output: "reports/crap.json",
       junit: true,
       junitReport: "reports/crap.xml"
@@ -43,7 +43,6 @@ describe("cli", () => {
 
   it("rejects invalid combinations", () => {
     expect(() => parseCliArguments(["--changed", "src/app.ts"])).toThrow("--changed cannot be combined");
-    expect(() => parseCliArguments(["--agent", "--format", "junit"])).toThrow("--agent cannot be combined");
   });
 
   it("parses explicit paths, help mode, and alternate package-manager and test-runner selections", () => {
@@ -79,8 +78,8 @@ describe("cli", () => {
       format: "junit",
       threshold: 8,
       agent: true,
-      failuresOnly: false,
-      omitRedundancy: false,
+      failuresOnly: true,
+      omitRedundancy: true,
       junit: false
     });
   });
@@ -164,6 +163,30 @@ describe("cli", () => {
       omitRedundancy: true
     });
     expect(parseCliArguments(["--omit-redundancy=false"])).toMatchObject({
+      omitRedundancy: false
+    });
+  });
+
+  it("applies agent composite defaults and explicit overrides", () => {
+    expect(parseCliArguments(["--agent"])).toMatchObject({
+      format: "toon",
+      agent: true,
+      failuresOnly: true,
+      omitRedundancy: true
+    });
+    expect(parseCliArguments(["--agent", "--format", "text"])).toMatchObject({
+      format: "text",
+      failuresOnly: true,
+      omitRedundancy: true
+    });
+    expect(parseCliArguments(["--format", "junit", "--agent"])).toMatchObject({
+      format: "junit",
+      failuresOnly: true,
+      omitRedundancy: true
+    });
+    expect(parseCliArguments(["--agent", "--failures-only=false", "--omit-redundancy=false"])).toMatchObject({
+      format: "toon",
+      failuresOnly: false,
       omitRedundancy: false
     });
   });
@@ -444,6 +467,34 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(junit).toContain('name="safe"');
     expect(junit).toContain('name="risky"');
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
+
+    const overrideStdout = new StringWriter();
+    const overrideStderr = new StringWriter();
+    const overrideExitCode = await runCli([
+      "--agent",
+      "--format",
+      "json",
+      "--failures-only=false",
+      "--omit-redundancy=false",
+      "--output",
+      "reports/full.json"
+    ], projectRoot, overrideStdout, overrideStderr);
+    const fullPrimary = JSON.parse(await readText(`${projectRoot}/reports/full.json`)) as {
+      methods: Array<Record<string, unknown>>;
+    };
+
+    expect(overrideExitCode).toBe(2);
+    expect(overrideStdout.toString()).toBe("");
+    expect(fullPrimary.methods).toHaveLength(2);
+    expect(fullPrimary.methods[0]).toMatchObject({
+      func: "risky",
+      status: "failed"
+    });
+    expect(fullPrimary.methods[1]).toMatchObject({
+      func: "safe",
+      status: "passed"
+    });
+    expect(overrideStderr.toString()).toContain("CRAP threshold exceeded");
   });
 
   it("filters failures-only primary reports and writes full JUnit sidecars", async () => {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -229,6 +229,70 @@ describe("report formatting", () => {
     });
   });
 
+  it("uses agent as failures-only plus omit-redundancy defaults", () => {
+    const parsed = JSON.parse(formatAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        startLine: 5,
+        endLine: 10,
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      })
+    ], { format: "json", agent: true })) as {
+      status: string;
+      threshold: number;
+      methods: Array<Record<string, unknown>>;
+    };
+
+    expect(parsed.status).toBe("failed");
+    expect(parsed.threshold).toBe(8);
+    expect(parsed.methods).toEqual([
+      expect.objectContaining({
+        func: "risky"
+      })
+    ]);
+    expect(parsed.methods[0]).not.toHaveProperty("status");
+  });
+
+  it("lets explicit report options override agent defaults", () => {
+    const parsed = JSON.parse(formatAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        startLine: 5,
+        endLine: 10,
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      })
+    ], {
+      format: "json",
+      agent: true,
+      failuresOnly: false,
+      omitRedundancy: false
+    })) as {
+      methods: Array<{ status: string; func: string }>;
+    };
+
+    expect(parsed.methods).toHaveLength(2);
+    expect(parsed.methods[0]).toMatchObject({
+      status: "failed",
+      func: "risky"
+    });
+    expect(parsed.methods[1]).toMatchObject({
+      status: "passed",
+      func: "safe"
+    });
+  });
+
   it("omits redundant method statuses from TOON reports", () => {
     const output = formatAnalysisReport([
       metric(),
@@ -289,6 +353,26 @@ describe("report formatting", () => {
 
     expect(output).toContain('<testsuite name="crap-typescript" status="failed" tests="1" failures="1" skipped="0" errors="0">');
     expect(output).toContain("<failure");
+    expect(output).not.toContain('<property name="status"');
+  });
+
+  it("allows agent defaults with primary JUnit reports", () => {
+    const output = formatAnalysisReport([
+      metric(),
+      metric({
+        displayName: "risky",
+        complexity: 4,
+        coverage: measured(0),
+        statementCoverage: measured(0),
+        branchCoverage: measured(0),
+        coveragePercent: 0,
+        crapScore: 20
+      })
+    ], { format: "junit", agent: true });
+
+    expect(output).toContain('tests="1"');
+    expect(output).toContain('name="risky"');
+    expect(output).not.toContain('name="safe"');
     expect(output).not.toContain('<property name="status"');
   });
 

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -169,7 +169,7 @@ function resolveCoverageReportPathOption(options: CrapTypescriptJestOptions): st
 }
 
 function resolveFormat(options: CrapTypescriptJestOptions): ReportFormat {
-  return options.format ?? "text";
+  return options.format ?? (options.agent ? "toon" : "text");
 }
 
 function resolveAgent(options: CrapTypescriptJestOptions): boolean {

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -248,7 +248,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("supports agent filtering and disabled JUnit output", async () => {
+  it("supports agent defaults and disabled JUnit output", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -281,7 +281,6 @@ describe("CrapTypescriptJestReporter", () => {
     const stderr = new StringWriter();
     const reporter = new CrapTypescriptJestReporter(undefined, {
       projectRoot,
-      format: "json",
       agent: true,
       junit: false,
       stdout,
@@ -290,11 +289,7 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
-    expect(JSON.parse(stdout.toString())).toEqual({
-      status: "passed",
-      threshold: 8,
-      methods: []
-    });
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
     await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();
     expect(stderr.toString()).toBe("");
     expect(reporter.getLastError()).toBeUndefined();

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -190,7 +190,7 @@ function resolvePackageManager(options: CrapTypescriptVitestOptions): PackageMan
 }
 
 function resolveFormat(options: CrapTypescriptVitestOptions): ReportFormat {
-  return options.format ?? "text";
+  return options.format ?? (options.agent ? "toon" : "text");
 }
 
 function resolveAgent(options: CrapTypescriptVitestOptions): boolean {

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -211,7 +211,7 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("supports agent filtering and disabled JUnit output", async () => {
+  it("supports agent defaults and disabled JUnit output", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -244,7 +244,6 @@ describe("CrapTypescriptVitestReporter", () => {
     const stderr = new StringWriter();
     const reporter = new CrapTypescriptVitestReporter({
       projectRoot,
-      format: "json",
       agent: true,
       junit: false,
       stdout,
@@ -253,20 +252,38 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
-    expect(JSON.parse(stdout.toString())).toEqual({
-      status: "passed",
-      threshold: 8,
-      methods: []
-    });
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
     await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();
     expect(stderr.toString()).toBe("");
   });
 
-  it("reports configuration errors without throwing", async () => {
+  it("allows agent with an explicit JUnit primary format", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
-      "package.json": '{"name":"fixture","private":true}'
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            }
+          },
+          fnMap: {},
+          branchMap: {},
+          s: {
+            "0": 1
+          },
+          f: {},
+          b: {}
+        }
+      })
     });
 
     const stdout = new StringWriter();
@@ -282,8 +299,9 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await expect(reporter.onFinishedReportCoverage()).resolves.toBeUndefined();
 
-    expect(stdout.toString()).toBe("");
-    expect(stderr.toString()).toContain("--agent cannot be combined with --format junit");
-    expect(process.exitCode).toBe(1);
+    expect(stdout.toString()).toContain('<testsuite name="crap-typescript" status="passed" tests="0" failures="0" skipped="0" errors="0">');
+    expect(stdout.toString()).not.toContain('<property name="status"');
+    expect(stderr.toString()).toBe("");
+    expect(process.exitCode).toBe(originalExitCode);
   });
 });

--- a/spec.md
+++ b/spec.md
@@ -223,6 +223,8 @@ When `--failures-only` is enabled, primary reports shall keep run-level metadata
 
 When `--omit-redundancy` is enabled, primary reports shall keep run-level metadata and omit only function-row status. If the primary report format is JUnit, the primary report shall omit custom testcase `status` properties while preserving JUnit failure and skipped elements. JUnit sidecar reports shall not be affected by this option and shall always contain the full function set, including custom testcase `status` properties.
 
+When `--agent` is enabled, primary reports shall default to `--format toon`, `--failures-only=true`, and `--omit-redundancy=true`. Explicit `--format`, `--failures-only=false`, or `--omit-redundancy=false` values shall override those defaults. JUnit sidecar reports shall not be affected by this option.
+
 ## 11. Threshold
 
 The default CRAP threshold shall be `8.0`. A finite positive threshold may be configured.


### PR DESCRIPTION
Closes #64.

## Summary
- make `agent` default primary output to `format=toon`, `failuresOnly=true`, and `omitRedundancy=true`
- allow explicit `format`, `failuresOnly=false`, and `omitRedundancy=false` values to override agent defaults
- apply agent default format behavior to Jest and Vitest adapters when `agent: true`
- update tests and docs for the new composite behavior

## Validation
- `npm ci`
- `npm run build`
- `npm test`
- `npm run crap-typescript-check`