### PR TITLE
Update Jest and Vitest defaults

### DIFF
--- a/packages/core/test/testUtils.ts
+++ b/packages/core/test/testUtils.ts
@@ -85,3 +85,84 @@ export function repoPath(...parts: string[]): string {
 export async function readText(filePath: string): Promise<string> {
   return readFile(filePath, "utf8");
 }
+
+export function mixedCoverageProjectFiles(): Record<string, string> {
+  return {
+    "src/sample.ts": `export function safe(value: number): number {
+  return value + 1;
+}
+
+export function risky(flagA: boolean, flagB: boolean): number {
+  if (flagA && flagB) {
+    return 1;
+  }
+  return 0;
+}
+`,
+    "coverage/coverage-final.json": JSON.stringify({
+      "src/sample.ts": {
+        path: "src/sample.ts",
+        statementMap: {
+          "0": {
+            start: { line: 2, column: 2 },
+            end: { line: 2, column: 19 }
+          },
+          "1": {
+            start: { line: 7, column: 4 },
+            end: { line: 7, column: 13 }
+          },
+          "2": {
+            start: { line: 9, column: 2 },
+            end: { line: 9, column: 11 }
+          }
+        },
+        fnMap: {},
+        branchMap: {
+          "0": {
+            line: 6,
+            type: "if",
+            loc: {
+              start: { line: 6, column: 2 },
+              end: { line: 8, column: 3 }
+            },
+            locations: [
+              {
+                start: { line: 6, column: 2 },
+                end: { line: 8, column: 3 }
+              },
+              {}
+            ]
+          },
+          "1": {
+            line: 6,
+            type: "binary-expr",
+            loc: {
+              start: { line: 6, column: 6 },
+              end: { line: 6, column: 31 }
+            },
+            locations: [
+              {
+                start: { line: 6, column: 6 },
+                end: { line: 6, column: 20 }
+              },
+              {
+                start: { line: 6, column: 24 },
+                end: { line: 6, column: 29 }
+              }
+            ]
+          }
+        },
+        s: {
+          "0": 1,
+          "1": 0,
+          "2": 0
+        },
+        f: {},
+        b: {
+          "0": [0, 0],
+          "1": [0, 0]
+        }
+      }
+    })
+  };
+}

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -15,6 +15,8 @@ export interface CrapTypescriptJestOptions {
   threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
   output?: string;
   junit?: boolean;
   junitReport?: string;
@@ -39,13 +41,7 @@ export function withCrapTypescriptJest(
   const coverageReportPath = options.coverageReportPath ?? buildCoverageReportPath(config.coverageDirectory as string | undefined);
   reporters.push([
     resolveReporterPath(),
-    {
-      ...options,
-      coverageReportPath,
-      junitReport: options.junitReport === undefined
-        ? buildJunitReportFromCoverage(coverageReportPath)
-        : options.junitReport
-    }
+    reporterOptions(options, coverageReportPath)
   ]);
 
   return {
@@ -93,6 +89,29 @@ function buildCoverageReportPath(coverageDirectory: string | undefined): string 
 
 function buildJunitReportFromCoverage(coverageReportPath: string): string {
   return `${path.dirname(coverageReportPath).replace(/\\/g, "/")}/crap-typescript-junit.xml`;
+}
+
+function reporterOptions(
+  options: CrapTypescriptJestOptions,
+  coverageReportPath: string
+): CrapTypescriptJestOptions {
+  return {
+    ...options,
+    coverageReportPath,
+    format: configuredFormat(options),
+    junit: options.junit ?? true,
+    junitReport: configuredJunitReport(options, coverageReportPath)
+  };
+}
+
+function configuredFormat(options: CrapTypescriptJestOptions): ReportFormat {
+  return options.format ?? (options.agent ? "toon" : "none");
+}
+
+function configuredJunitReport(options: CrapTypescriptJestOptions, coverageReportPath: string): string {
+  return options.junitReport === undefined
+    ? buildJunitReportFromCoverage(coverageReportPath)
+    : options.junitReport;
 }
 
 function resolveReporterPath(): string {

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -17,6 +17,8 @@ export interface CrapTypescriptJestOptions {
   threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
   output?: string;
   junit?: boolean;
   junitReport?: string;
@@ -33,6 +35,8 @@ interface ResolvedReporterOptions {
   threshold: number | undefined;
   format: ReportFormat;
   agent: boolean;
+  failuresOnly: boolean | undefined;
+  omitRedundancy: boolean | undefined;
   output: string | undefined;
   junit: boolean;
   junitReport: string;
@@ -142,6 +146,8 @@ function resolveAnalysisOptions(
     threshold: options.threshold,
     format: resolveFormat(options),
     agent: resolveAgent(options),
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy,
     output: options.output,
     junit: resolveJunit(options),
     junitReport: resolveJunitReport(options, coverageReportPath)
@@ -169,7 +175,7 @@ function resolveCoverageReportPathOption(options: CrapTypescriptJestOptions): st
 }
 
 function resolveFormat(options: CrapTypescriptJestOptions): ReportFormat {
-  return options.format ?? (options.agent ? "toon" : "text");
+  return options.format ?? (options.agent ? "toon" : "none");
 }
 
 function resolveAgent(options: CrapTypescriptJestOptions): boolean {
@@ -202,7 +208,9 @@ async function writeReporterReports(
   const primaryReport = formatAnalysisReport(metrics, {
     format: options.format,
     agent: options.agent,
-    threshold: options.threshold
+    threshold: options.threshold,
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy
   });
   if (options.output) {
     await writeReportFile(options.projectRoot, options.output, primaryReport);

--- a/packages/jest/test/config.test.ts
+++ b/packages/jest/test/config.test.ts
@@ -17,6 +17,8 @@ describe("withCrapTypescriptJest", () => {
     expect(reporterEntry[0].replace(/\\/g, "/")).toContain("/packages/jest/src/reporter");
     expect(reporterEntry[1]).toMatchObject({
       coverageReportPath: "coverage/coverage-final.json",
+      format: "none",
+      junit: true,
       junitReport: "coverage/crap-typescript-junit.xml"
     });
   });
@@ -36,6 +38,8 @@ describe("withCrapTypescriptJest", () => {
         expect.any(String),
         expect.objectContaining({
           coverageReportPath: "custom-coverage/coverage-final.json",
+          format: "none",
+          junit: true,
           junitReport: "custom-coverage/crap-typescript-junit.xml"
         })
       ]
@@ -60,6 +64,8 @@ describe("withCrapTypescriptJest", () => {
         expect.any(String),
         expect.objectContaining({
           coverageReportPath: "custom-coverage/coverage-final.json",
+          format: "none",
+          junit: true,
           junitReport: "custom-coverage/crap-typescript-junit.xml"
         })
       ]
@@ -68,6 +74,10 @@ describe("withCrapTypescriptJest", () => {
 
   it("passes renamed reporting options to the reporter", () => {
     const config = withCrapTypescriptJest({}, {
+      format: "json",
+      agent: true,
+      failuresOnly: true,
+      omitRedundancy: true,
       output: "reports/crap.txt",
       junit: false,
       junitReport: "reports/custom-junit.xml"
@@ -78,6 +88,10 @@ describe("withCrapTypescriptJest", () => {
       [
         expect.any(String),
         expect.objectContaining({
+          format: "json",
+          agent: true,
+          failuresOnly: true,
+          omitRedundancy: true,
           output: "reports/crap.txt",
           junit: false,
           junitReport: "reports/custom-junit.xml"
@@ -97,6 +111,8 @@ describe("withCrapTypescriptJest", () => {
         expect.any(String),
         expect.objectContaining({
           coverageReportPath: "custom-coverage/results/coverage-final.json",
+          format: "none",
+          junit: true,
           junitReport: "custom-coverage/results/crap-typescript-junit.xml"
         })
       ]

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -2,7 +2,14 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { StringWriter, createTempDir, disposeTempDir, readText, writeProjectFiles } from "../../core/test/testUtils";
+import {
+  StringWriter,
+  createTempDir,
+  disposeTempDir,
+  mixedCoverageProjectFiles,
+  readText,
+  writeProjectFiles
+} from "../../core/test/testUtils";
 import CrapTypescriptJestReporter from "../src/reporter";
 
 const tempDirs: string[] = [];
@@ -46,7 +53,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(finalize).toHaveBeenCalledTimes(1);
   });
 
-  it("prints a passed text report when no analyzable source files are selected", async () => {
+  it("emits no primary report by default and writes a full JUnit sidecar", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -64,7 +71,7 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\n");
+    expect(stdout.toString()).toBe("");
     expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
     expect(reporter.getLastError()).toBeUndefined();
@@ -95,7 +102,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(stderr.toString()).toBe("");
   });
 
-  it("writes renamed output and JUnit report options", async () => {
+  it("writes renamed output and JUnit report options with the default empty primary report", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -116,7 +123,7 @@ describe("CrapTypescriptJestReporter", () => {
     await callFinalize(reporter);
 
     expect(stdout.toString()).toBe("");
-    expect(await readText(`${projectRoot}/reports/crap.txt`)).toBe("status: passed\nthreshold: 8.0\n");
+    expect(await readText(`${projectRoot}/reports/crap.txt`)).toBe("");
     expect(await readText(`${projectRoot}/reports/custom-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
   });
@@ -134,6 +141,7 @@ describe("CrapTypescriptJestReporter", () => {
     const reporter = new CrapTypescriptJestReporter(undefined, {
       projectRoot,
       threshold: 9,
+      format: "text",
       stdout,
       stderr
     });
@@ -228,6 +236,7 @@ describe("CrapTypescriptJestReporter", () => {
       changedOnly: false,
       packageManager: "npm",
       coverageReportPath,
+      format: "text",
       stdout,
       stderr
     });
@@ -245,6 +254,52 @@ describe("CrapTypescriptJestReporter", () => {
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
     expect(reporter.getLastError()).toBeInstanceOf(Error);
     expect(reporter.getLastError()?.message).toContain("CRAP threshold exceeded");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("applies primary report controls without reducing the JUnit sidecar", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      ...mixedCoverageProjectFiles()
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptJestReporter(undefined, {
+      projectRoot,
+      paths: ["src"],
+      changedOnly: false,
+      packageManager: "npm",
+      format: "json",
+      failuresOnly: true,
+      omitRedundancy: true,
+      stdout,
+      stderr
+    });
+
+    await callFinalize(reporter);
+
+    const primary = JSON.parse(stdout.toString()) as {
+      status: string;
+      methods: Array<Record<string, unknown>>;
+    };
+    const junit = await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`);
+
+    expect(primary.status).toBe("failed");
+    expect(primary.methods).toEqual([
+      expect.objectContaining({
+        func: "risky"
+      })
+    ]);
+    expect(primary.methods[0]).not.toHaveProperty("status");
+    expect(junit).toContain('tests="2"');
+    expect(junit).toContain('name="safe"');
+    expect(junit).toContain('name="risky"');
+    expect(junit).toContain('<property name="status" value="passed"/>');
+    expect(junit).toContain('<property name="status" value="failed"/>');
+    expect(stderr.toString()).toContain("CRAP threshold exceeded");
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -29,6 +29,8 @@ export interface CrapTypescriptVitestOptions {
   threshold?: number;
   format?: ReportFormat;
   agent?: boolean;
+  failuresOnly?: boolean;
+  omitRedundancy?: boolean;
   output?: string;
   junit?: boolean;
   junitReport?: string;
@@ -77,13 +79,7 @@ export function withCrapTypescriptVitest(
   const coverageReporters = ensureReporterEntries(asArray(coverage.reporter), "json", "text");
   const reporters = ensureDefaultReporter(asArray(testConfig.reporters));
   const coverageReportPath = options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory);
-  reporters.push(new CrapTypescriptVitestReporter({
-    ...options,
-    coverageReportPath,
-    junitReport: options.junitReport === undefined
-      ? buildJunitReportFromCoverage(coverageReportPath)
-      : options.junitReport
-  }));
+  reporters.push(new CrapTypescriptVitestReporter(reporterOptions(options, coverageReportPath)));
 
   return {
     ...config,
@@ -135,6 +131,29 @@ function buildCoverageReportPath(reportsDirectory: string | undefined): string {
   return `${reportsDirectory ?? "coverage"}/coverage-final.json`;
 }
 
+function reporterOptions(
+  options: CrapTypescriptVitestOptions,
+  coverageReportPath: string
+): CrapTypescriptVitestOptions {
+  return {
+    ...options,
+    coverageReportPath,
+    format: configuredFormat(options),
+    junit: options.junit ?? true,
+    junitReport: configuredJunitReport(options, coverageReportPath)
+  };
+}
+
+function configuredFormat(options: CrapTypescriptVitestOptions): ReportFormat {
+  return options.format ?? (options.agent ? "toon" : "none");
+}
+
+function configuredJunitReport(options: CrapTypescriptVitestOptions, coverageReportPath: string): string {
+  return options.junitReport === undefined
+    ? buildJunitReportFromCoverage(coverageReportPath)
+    : options.junitReport;
+}
+
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
@@ -148,6 +167,8 @@ interface ResolvedReporterOptions {
   threshold: number | undefined;
   format: ReportFormat;
   agent: boolean;
+  failuresOnly: boolean | undefined;
+  omitRedundancy: boolean | undefined;
   output: string | undefined;
   junit: boolean;
   junitReport: string;
@@ -165,6 +186,8 @@ function resolveReporterOptions(options: CrapTypescriptVitestOptions): ResolvedR
     threshold: options.threshold,
     format: resolveFormat(options),
     agent: resolveAgent(options),
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy,
     output: options.output,
     junit: resolveJunit(options),
     junitReport: resolveJunitReport(options),
@@ -190,7 +213,7 @@ function resolvePackageManager(options: CrapTypescriptVitestOptions): PackageMan
 }
 
 function resolveFormat(options: CrapTypescriptVitestOptions): ReportFormat {
-  return options.format ?? (options.agent ? "toon" : "text");
+  return options.format ?? (options.agent ? "toon" : "none");
 }
 
 function resolveAgent(options: CrapTypescriptVitestOptions): boolean {
@@ -214,7 +237,9 @@ async function writeReporterReports(
   const primaryReport = formatAnalysisReport(metrics, {
     format: options.format,
     agent: options.agent,
-    threshold: options.threshold
+    threshold: options.threshold,
+    failuresOnly: options.failuresOnly,
+    omitRedundancy: options.omitRedundancy
   });
   if (options.output) {
     await writeReportFile(options.projectRoot, options.output, primaryReport);

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -213,7 +213,7 @@ function resolvePackageManager(options: CrapTypescriptVitestOptions): PackageMan
 }
 
 function resolveFormat(options: CrapTypescriptVitestOptions): ReportFormat {
-  return options.format ?? (options.agent ? "toon" : "none");
+  return configuredFormat(options);
 }
 
 function resolveAgent(options: CrapTypescriptVitestOptions): boolean {

--- a/packages/vitest/test/config.test.ts
+++ b/packages/vitest/test/config.test.ts
@@ -18,6 +18,8 @@ describe("withCrapTypescriptVitest", () => {
     expect(crapReporter).toBeInstanceOf(CrapTypescriptVitestReporter);
     expect(crapReporter).toMatchObject({
       options: expect.objectContaining({
+        format: "none",
+        junit: true,
         junitReport: "coverage/crap-typescript-junit.xml"
       })
     });
@@ -43,6 +45,8 @@ describe("withCrapTypescriptVitest", () => {
     expect(config.test?.coverage?.reportsDirectory).toBe("custom-coverage");
     expect(config.test?.reporters?.[1]).toMatchObject({
       options: expect.objectContaining({
+        format: "none",
+        junit: true,
         junitReport: "custom-coverage/crap-typescript-junit.xml"
       })
     });
@@ -50,6 +54,10 @@ describe("withCrapTypescriptVitest", () => {
 
   it("passes renamed reporting options to the reporter", () => {
     const config = withCrapTypescriptVitest({}, {
+      format: "json",
+      agent: true,
+      failuresOnly: true,
+      omitRedundancy: true,
       output: "reports/crap.txt",
       junit: false,
       junitReport: "reports/custom-junit.xml"
@@ -60,6 +68,10 @@ describe("withCrapTypescriptVitest", () => {
       expect.objectContaining({
         options: expect.objectContaining({
           output: "reports/crap.txt",
+          format: "json",
+          agent: true,
+          failuresOnly: true,
+          omitRedundancy: true,
           junit: false,
           junitReport: "reports/custom-junit.xml"
         })
@@ -77,6 +89,8 @@ describe("withCrapTypescriptVitest", () => {
       expect.objectContaining({
         options: expect.objectContaining({
           coverageReportPath: "custom-coverage/results/coverage-final.json",
+          format: "none",
+          junit: true,
           junitReport: "custom-coverage/results/crap-typescript-junit.xml"
         })
       })

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { StringWriter, createTempDir, disposeTempDir, readText, writeProjectFiles } from "../../core/test/testUtils";
+import {
+  StringWriter,
+  createTempDir,
+  disposeTempDir,
+  mixedCoverageProjectFiles,
+  readText,
+  writeProjectFiles
+} from "../../core/test/testUtils";
 import { CrapTypescriptVitestReporter } from "../src/index";
 
 const tempDirs: string[] = [];
@@ -16,7 +23,7 @@ afterEach(async () => {
 });
 
 describe("CrapTypescriptVitestReporter", () => {
-  it("prints a passed text report when no analyzable source files are selected", async () => {
+  it("emits no primary report by default and writes a full JUnit sidecar", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -33,7 +40,7 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8.0\n");
+    expect(stdout.toString()).toBe("");
     expect(await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
     expect(process.exitCode).toBe(originalExitCode);
@@ -62,7 +69,7 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(stderr.toString()).toBe("");
   });
 
-  it("writes renamed output and JUnit report options", async () => {
+  it("writes renamed output and JUnit report options with the default empty primary report", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -82,7 +89,7 @@ describe("CrapTypescriptVitestReporter", () => {
     await reporter.onFinishedReportCoverage();
 
     expect(stdout.toString()).toBe("");
-    expect(await readText(`${projectRoot}/reports/crap.txt`)).toBe("status: passed\nthreshold: 8.0\n");
+    expect(await readText(`${projectRoot}/reports/crap.txt`)).toBe("");
     expect(await readText(`${projectRoot}/reports/custom-junit.xml`)).toContain('status="passed"');
     expect(stderr.toString()).toBe("");
   });
@@ -100,6 +107,7 @@ describe("CrapTypescriptVitestReporter", () => {
     const reporter = new CrapTypescriptVitestReporter({
       projectRoot,
       threshold: 9,
+      format: "text",
       stdout,
       stderr
     });
@@ -193,6 +201,7 @@ describe("CrapTypescriptVitestReporter", () => {
       changedOnly: false,
       packageManager: "npm",
       coverageReportPath: "custom-coverage/coverage-final.json",
+      format: "text",
       stdout,
       stderr
     });
@@ -207,6 +216,52 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(stdout.toString()).toContain("risky");
     expect(junit).toContain('tests="1"');
     expect(junit).toContain("<failure");
+    expect(stderr.toString()).toContain("CRAP threshold exceeded");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("applies primary report controls without reducing the JUnit sidecar", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      ...mixedCoverageProjectFiles()
+    });
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      paths: ["src"],
+      changedOnly: false,
+      packageManager: "npm",
+      format: "json",
+      failuresOnly: true,
+      omitRedundancy: true,
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    const primary = JSON.parse(stdout.toString()) as {
+      status: string;
+      methods: Array<Record<string, unknown>>;
+    };
+    const junit = await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`);
+
+    expect(primary.status).toBe("failed");
+    expect(primary.methods).toEqual([
+      expect.objectContaining({
+        func: "risky"
+      })
+    ]);
+    expect(primary.methods[0]).not.toHaveProperty("status");
+    expect(junit).toContain('tests="2"');
+    expect(junit).toContain('name="safe"');
+    expect(junit).toContain('name="risky"');
+    expect(junit).toContain('<property name="status" value="passed"/>');
+    expect(junit).toContain('<property name="status" value="failed"/>');
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
     expect(process.exitCode).toBe(1);
   });


### PR DESCRIPTION
Closes #68.

## Summary
- default Jest and Vitest primary report format to `none`
- keep adapter JUnit sidecars enabled by default with the existing derived sidecar path
- expose and pass through `failuresOnly` and `omitRedundancy` for primary reports
- keep JUnit sidecars full and unaffected by primary report controls
- cover default-silent primary reports, empty primary output files, option pass-through, and full sidecars in adapter tests

## Validation
- `npm ci`
- `npm run build`
- `npm test`
- `npm run crap-typescript-check`