### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - No unreleased changes.
 
+## [0.3.0] - 2026-05-10
+
+### Added
+
+- Added configurable CRAP thresholds across the CLI, core formatter, and Jest and Vitest adapters, including warning guidance for unusually strict or lenient values.
+- Added TOON and JUnit report formatting, full JUnit sidecar generation for CI consumers, and the `--failures-only`, `--omit-redundancy`, `--format none`, and `--agent` primary-report controls.
+- Added the repository `cognitive-typescript` gate and CI enforcement for published package sources.
+
+### Changed
+
+- Changed the Jest and Vitest adapters to default their primary report to `none`, emit a full JUnit sidecar by default, and derive the sidecar path from the configured coverage report location.
+- Renamed the public report option surface to the current `format`, `output`, `junit`, and `junitReport` naming across the CLI and adapters.
+- Declared the published packages as ESM via `type: "module"` and switched report serialization to the official TOON encoder and XML builder implementations.
+- Expanded the README, package READMEs, and specification to document the current CLI, core, and adapter reporting behavior.
+
+### Fixed
+
+- Fixed `--help` option validation and release-notes rendering.
+- Fixed empty JUnit report generation and report-method status handling in formatted outputs.
+- Aligned threshold warning boundaries with the documented threshold guidance.
+
+## [0.2.3] - 2026-04-27
+
+### Fixed
+
+- Updated `postcss` from 8.5.8 to 8.5.12.
+
 ## [0.2.2] - 2026-04-10
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ All changes in this repository are expected to be issue-linked.
 ## Workflow
 
 1. Create or confirm the GitHub issue first.
-2. Create a branch named `<issue-number>-<slug>`.
+2. Create a branch named `codex/<issue-number>-<slug>`.
 3. Reference the issue number in every commit message.
 4. Open a pull request that closes the issue.
 5. Keep the pull request green, reply to review comments, and resolve threads only after the fix or an explicit invalidation response.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crap-typescript-parent",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crap-typescript-parent",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5502,10 +5502,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/crap-typescript",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.2"
+        "@barney-media/crap-typescript-core": "^0.3.0"
       },
       "bin": {
         "crap-typescript": "dist/bin.js"
@@ -5516,7 +5516,7 @@
     },
     "packages/core": {
       "name": "@barney-media/crap-typescript-core",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@toon-format/toon": "^2.1.0",
@@ -5529,10 +5529,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/crap-typescript-jest",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.2"
+        "@barney-media/crap-typescript-core": "^0.3.0"
       },
       "engines": {
         "node": ">=18"
@@ -5543,10 +5543,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/crap-typescript-vitest",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.2.2"
+        "@barney-media/crap-typescript-core": "^0.3.0"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crap-typescript-parent",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "CRAP metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "CLI for CRAP metric analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,6 +45,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.2.2"
+    "@barney-media/crap-typescript-core": "^0.3.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-core",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Core CRAP metric analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-jest",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Jest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,7 +45,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.2.2"
+    "@barney-media/crap-typescript-core": "^0.3.0"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-vitest",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Vitest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -41,7 +41,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.2.2"
+    "@barney-media/crap-typescript-core": "^0.3.0"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- prepare the `0.3.0` release across the workspace packages
- rebuild `CHANGELOG.md` from the full diff since `v0.2.3` and restore the missing `0.2.3` entry
- update contributor workflow docs to the current branch naming convention

## Validation
- `node ./scripts/verify-release-version.mjs v0.3.0`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`