### PR TITLE
Fix coverage fallback semantics

### DIFF
--- a/packages/core/src/coverageNormalization.ts
+++ b/packages/core/src/coverageNormalization.ts
@@ -61,12 +61,20 @@ function toBranchCoverageMetric(
 }
 
 function combineCoverageMetrics(statementCoverage: CoverageMetric, branchCoverage: CoverageMetric): CoverageMetric {
-  if (statementCoverage.status === "unknown") {
-    return unknownCoverageMetric(statementCoverage.unknownReason!);
+  if (statementCoverage.status === "unknown" && branchCoverage.status === "unknown") {
+    return unknownCoverageMetric(statementCoverage.unknownReason ?? branchCoverage.unknownReason!);
   }
-  if (branchCoverage.status === "unknown") {
-    return unknownCoverageMetric(branchCoverage.unknownReason!);
+  return combinedKnownCoverage(statementCoverage, branchCoverage);
+}
+
+function combinedKnownCoverage(statementCoverage: CoverageMetric, branchCoverage: CoverageMetric): CoverageMetric {
+  const measuredPercents = [statementCoverage, branchCoverage]
+    .filter((metric) => metric.status === "measured")
+    .map((metric) => metric.percent!);
+  if (measuredPercents.length > 0) {
+    return measuredCoverageMetric(Math.min(...measuredPercents));
   }
+
   if (statementCoverage.status === "structural_na" && branchCoverage.status === "structural_na") {
     return {
       percent: 100,
@@ -74,7 +82,8 @@ function combineCoverageMetrics(statementCoverage: CoverageMetric, branchCoverag
       unknownReason: null
     };
   }
-  return measuredCoverageMetric(Math.min(statementCoverage.percent ?? 100, branchCoverage.percent ?? 100));
+
+  return unknownCoverageMetric(statementCoverage.unknownReason ?? branchCoverage.unknownReason!);
 }
 
 function measuredCoverageMetric(percent: number): CoverageMetric {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -5,7 +5,6 @@ import { CRAP_THRESHOLD, validateThreshold } from "./constants.js";
 import { formatNumber } from "./utils.js";
 import type {
   CoverageKind,
-  CoverageMetric,
   MethodMetrics,
   MethodReportStatus,
   ReportFormat,
@@ -213,19 +212,19 @@ function methodStatus(metric: MethodMetrics, threshold: number): MethodReportSta
 }
 
 function coverageKind(metric: MethodMetrics): CoverageKind {
-  if (metric.statementCoverage.status === "unknown") {
+  if (metric.coverage.status === "unknown") {
+    return "N/A";
+  }
+  if (metric.statementCoverage.status === "measured" && metric.branchCoverage.status === "measured") {
+    return metric.branchCoverage.percent! < metric.statementCoverage.percent! ? "branch" : "stmt";
+  }
+  if (metric.statementCoverage.status === "measured") {
     return "stmt";
   }
-  if (metric.branchCoverage.status === "unknown") {
+  if (metric.branchCoverage.status === "measured") {
     return "branch";
   }
-  const statementPercent = effectivePercent(metric.statementCoverage);
-  const branchPercent = effectivePercent(metric.branchCoverage);
-  return branchPercent < statementPercent ? "branch" : "stmt";
-}
-
-function effectivePercent(metric: CoverageMetric): number {
-  return metric.percent ?? 100;
+  return "stmt";
 }
 
 function formatNullableNumber(value: number | null): string {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,7 @@ export type CoverageMode = "auto" | "existing-only";
 export type ReportFormat = "toon" | "json" | "text" | "junit" | "none";
 export type ReportStatus = "passed" | "failed";
 export type MethodReportStatus = ReportStatus | "skipped";
-export type CoverageKind = "stmt" | "branch";
+export type CoverageKind = "stmt" | "branch" | "N/A";
 export type CoverageStatus = "measured" | "structural_na" | "unknown";
 export type CoverageUnknownReason =
   | "missing_report"

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -306,7 +306,7 @@ export function enumDeclOnly(): void {
     });
   });
 
-  it("keeps coverage unknown when branch syntax exists but no branch counters can be attributed", async () => {
+  it("uses measured statement coverage when branch counters cannot be attributed", async () => {
     const projectRoot = await createTempDir("crap-coverage-");
     tempDirs.push(projectRoot);
     await writeProjectFiles(projectRoot, {
@@ -351,9 +351,44 @@ export function enumDeclOnly(): void {
 
     expect(coverageForMethods(methods, [...coverageReport.values()][0]).map(summarizeMethodCoverage)).toEqual([
       {
-        coverage: { percent: null, status: "unknown", reason: "branch_unattributed" },
+        coverage: { percent: 100.0, status: "measured", reason: null },
         statement: { percent: 100.0, status: "measured", reason: null },
         branch: { percent: null, status: "unknown", reason: "branch_unattributed" }
+      }
+    ]);
+  });
+
+  it("uses measured branch coverage when statement counters cannot be attributed", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/sample.ts": `export function branchy(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}
+`
+    });
+
+    const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
+    expect(
+      coverageForMethods(methods, {
+        statements: [],
+        branches: [
+          {
+            span: { startLine: 2, startColumn: 2, endLine: 4, endColumn: 3 },
+            hits: [1, 0]
+          }
+        ],
+        functions: []
+      }).map(summarizeMethodCoverage)
+    ).toEqual([
+      {
+        coverage: { percent: 50.0, status: "measured", reason: null },
+        statement: { percent: null, status: "unknown", reason: "statement_unattributed" },
+        branch: { percent: 50.0, status: "measured", reason: null }
       }
     ]);
   });

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -101,12 +101,12 @@ describe("report formatting", () => {
       {
         status: "skipped",
         func: "unknownCoverage",
-        covKind: "stmt"
+        covKind: "N/A"
       }
     ]);
   });
 
-  it("chooses branch coverage when branch coverage blocks the score", () => {
+  it("reports N/A coverage kind when score coverage is unavailable", () => {
     const report = buildAnalysisReport([
       metric({
         coverage: unknown("branch_unattributed"),
@@ -119,6 +119,40 @@ describe("report formatting", () => {
 
     expect(report.methods[0]).toMatchObject({
       status: "skipped",
+      covKind: "N/A"
+    });
+  });
+
+  it("reports statement coverage kind when it is the only measured component", () => {
+    const report = buildAnalysisReport([
+      metric({
+        coverage: measured(75),
+        statementCoverage: measured(75),
+        branchCoverage: unknown("branch_unattributed"),
+        coveragePercent: 75,
+        crapScore: 1.0625
+      })
+    ]);
+
+    expect(report.methods[0]).toMatchObject({
+      status: "passed",
+      covKind: "stmt"
+    });
+  });
+
+  it("reports branch coverage kind when it is the only measured component", () => {
+    const report = buildAnalysisReport([
+      metric({
+        coverage: measured(50),
+        statementCoverage: unknown("statement_unattributed"),
+        branchCoverage: measured(50),
+        coveragePercent: 50,
+        crapScore: 1.125
+      })
+    ]);
+
+    expect(report.methods[0]).toMatchObject({
+      status: "passed",
       covKind: "branch"
     });
   });
@@ -445,7 +479,7 @@ describe("report formatting", () => {
 
     expect(output).toBe(`${encode(report)}\n`);
     expect(output).toContain('failed,20,4,0,stmt,"risky \\"quoted\\", value","src/a,b.ts",1,3');
-    expect(output).toContain("skipped,null,1,null,stmt,missingCoverage");
+    expect(output).toContain("skipped,null,1,null,N/A,missingCoverage");
   });
 
   it("formats text reports with aligned method columns", () => {


### PR DESCRIPTION
Closes #77

## Summary
- use the worst measured TypeScript coverage component when only one of statement or branch coverage is available
- report `covKind: N/A` only when score coverage is unavailable
- add focused coverage and report tests for measured/unknown fallback cases

## Validation
- `npx vitest run packages/core/test/coverage.test.ts packages/core/test/report.test.ts`
- `npm run build`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`