### PR TITLE
Fix #80 report path validation

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { CRAP_THRESHOLD, validateThreshold } from "./constants.js";
 import { analyzeProject } from "./analyzeProject.js";
 import { formatAnalysisReport } from "./report.js";
+import { validateReportPathTargets } from "./reportPaths.js";
 import { formatNumber, writeLine } from "./utils.js";
 import type { CliArguments, PackageManagerSelection, ReportFormat, TestRunnerSelection, Writer } from "./types.js";
 
@@ -336,6 +337,13 @@ export async function runCli(
     return 0;
   }
 
+  try {
+    await validateCliReportPaths(parsed, projectRoot);
+  } catch (error) {
+    writeLine(stderr, (error as Error).message);
+    return 1;
+  }
+
   return handleCliResult(await analyzeCliProject(parsed, projectRoot, stdout, stderr), parsed, projectRoot, stdout, stderr);
 }
 
@@ -418,6 +426,13 @@ async function writeCliReports(
       threshold: result.threshold
     }));
   }
+}
+
+async function validateCliReportPaths(parsed: CliArguments, projectRoot: string): Promise<void> {
+  await validateReportPathTargets(projectRoot, [
+    { label: "--output", path: parsed.output },
+    { label: "--junit-report", path: parsed.junit ? parsed.junitReport : undefined }
+  ]);
 }
 
 async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {
   formatToonReport,
   sortMetrics
 } from "./report.js";
+export { validateReportPathTargets } from "./reportPaths.js";
 export type {
   AgentAnalysisReport,
   AgentMethodReportEntry,
@@ -22,6 +23,7 @@ export type {
   FormatAnalysisReportOptions,
   MethodReportEntry
 } from "./report.js";
+export type { ReportPathTarget } from "./reportPaths.js";
 export {
   CRAP_THRESHOLD,
   COVERAGE_REPORT_RELATIVE_PATH,

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -1,0 +1,104 @@
+import { lstat, realpath } from "node:fs/promises";
+import path from "node:path";
+
+export interface ReportPathTarget {
+  label: string;
+  path: string | undefined;
+}
+
+interface ResolvedReportPathTarget {
+  label: string;
+  path: string;
+  absolutePath: string;
+  collisionPath: string;
+}
+
+export async function validateReportPathTargets(
+  projectRoot: string,
+  targets: ReportPathTarget[]
+): Promise<void> {
+  const resolvedTargets = await Promise.all(
+    targets
+      .filter((target): target is { label: string; path: string } => target.path !== undefined)
+      .map((target) => resolveReportPathTarget(projectRoot, target))
+  );
+
+  for (let leftIndex = 0; leftIndex < resolvedTargets.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < resolvedTargets.length; rightIndex += 1) {
+      ensureDistinctReportPaths(resolvedTargets[leftIndex], resolvedTargets[rightIndex]);
+    }
+  }
+}
+
+async function resolveReportPathTarget(
+  projectRoot: string,
+  target: { label: string; path: string }
+): Promise<ResolvedReportPathTarget> {
+  const absolutePath = path.resolve(projectRoot, target.path);
+  if (isFilesystemRoot(absolutePath)) {
+    throw new Error(`${target.label} must target a report file, not a filesystem root`);
+  }
+
+  const stats = await lstatIfExists(absolutePath);
+  if (stats?.isDirectory()) {
+    throw new Error(`${target.label} must target a report file, not an existing directory`);
+  }
+
+  return {
+    label: target.label,
+    path: target.path,
+    absolutePath,
+    collisionPath: normalizeReportPathForCollision(await canonicalizeReportPath(absolutePath))
+  };
+}
+
+async function lstatIfExists(filePath: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+  try {
+    return await lstat(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function canonicalizeReportPath(filePath: string): Promise<string> {
+  try {
+    return await realpath(filePath);
+  } catch {
+    return path.join(await canonicalizeExistingParent(path.dirname(filePath)), path.basename(filePath));
+  }
+}
+
+async function canonicalizeExistingParent(directoryPath: string): Promise<string> {
+  try {
+    return await realpath(directoryPath);
+  } catch {
+    const parent = path.dirname(directoryPath);
+    if (parent === directoryPath) {
+      return directoryPath;
+    }
+    return path.join(await canonicalizeExistingParent(parent), path.basename(directoryPath));
+  }
+}
+
+function normalizeReportPathForCollision(filePath: string): string {
+  const normalized = path.normalize(filePath);
+  return isCaseInsensitivePlatform() ? normalized.toLowerCase() : normalized;
+}
+
+function isCaseInsensitivePlatform(): boolean {
+  return process.platform === "win32" || process.platform === "darwin";
+}
+
+function isFilesystemRoot(filePath: string): boolean {
+  const parsed = path.parse(filePath);
+  return path.resolve(filePath) === parsed.root;
+}
+
+function ensureDistinctReportPaths(left: ResolvedReportPathTarget, right: ResolvedReportPathTarget): void {
+  if (left.collisionPath !== right.collisionPath) {
+    return;
+  }
+  throw new Error(
+    `${left.label} and ${right.label} must target different report files: ${left.path} and ${right.path}`
+  );
+}

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -20,11 +20,9 @@ export async function validateReportPathTargets(
   const reportTargets = targets.filter((target): target is { label: string; path: string } => (
     target.path !== undefined
   ));
-  const caseInsensitiveFilesystem = reportTargets.length > 1
-    ? await isCaseInsensitiveFilesystem(projectRoot)
-    : false;
+  const shouldCheckCaseCollisions = reportTargets.length > 1;
   const resolvedTargets = await Promise.all(
-    reportTargets.map((target) => resolveReportPathTarget(projectRoot, target, caseInsensitiveFilesystem))
+    reportTargets.map((target) => resolveReportPathTarget(projectRoot, target, shouldCheckCaseCollisions))
   );
 
   for (let leftIndex = 0; leftIndex < resolvedTargets.length; leftIndex += 1) {
@@ -37,7 +35,7 @@ export async function validateReportPathTargets(
 async function resolveReportPathTarget(
   projectRoot: string,
   target: { label: string; path: string },
-  caseInsensitiveFilesystem: boolean
+  shouldCheckCaseCollisions: boolean
 ): Promise<ResolvedReportPathTarget> {
   const absolutePath = path.resolve(projectRoot, target.path);
   if (isFilesystemRoot(absolutePath)) {
@@ -49,11 +47,16 @@ async function resolveReportPathTarget(
     throw new Error(`${target.label} must target a report file, not an existing directory`);
   }
 
+  const canonicalPath = await canonicalizeReportPath(absolutePath);
+  const caseInsensitiveFilesystem = shouldCheckCaseCollisions
+    ? await isCaseInsensitiveFilesystem(await nearestExistingParent(path.dirname(absolutePath)))
+    : false;
+
   return {
     label: target.label,
     path: target.path,
     absolutePath,
-    collisionPath: normalizeReportPathForCollision(await canonicalizeReportPath(absolutePath), caseInsensitiveFilesystem)
+    collisionPath: normalizeReportPathForCollision(canonicalPath, caseInsensitiveFilesystem)
   };
 }
 
@@ -104,6 +107,18 @@ async function canonicalizeExistingParent(directoryPath: string): Promise<string
     }
     return path.join(await canonicalizeExistingParent(parent), path.basename(directoryPath));
   }
+}
+
+async function nearestExistingParent(directoryPath: string): Promise<string> {
+  const stats = await statIfExists(directoryPath);
+  if (stats?.isDirectory()) {
+    return realpath(directoryPath);
+  }
+  const parent = path.dirname(directoryPath);
+  if (parent === directoryPath) {
+    return directoryPath;
+  }
+  return nearestExistingParent(parent);
 }
 
 function normalizeReportPathForCollision(filePath: string, caseInsensitiveFilesystem: boolean): string {

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -1,4 +1,4 @@
-import { lstat, realpath } from "node:fs/promises";
+import { access, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 export interface ReportPathTarget {
@@ -17,10 +17,14 @@ export async function validateReportPathTargets(
   projectRoot: string,
   targets: ReportPathTarget[]
 ): Promise<void> {
+  const reportTargets = targets.filter((target): target is { label: string; path: string } => (
+    target.path !== undefined
+  ));
+  const caseInsensitiveFilesystem = reportTargets.length > 1
+    ? await isCaseInsensitiveFilesystem(projectRoot)
+    : false;
   const resolvedTargets = await Promise.all(
-    targets
-      .filter((target): target is { label: string; path: string } => target.path !== undefined)
-      .map((target) => resolveReportPathTarget(projectRoot, target))
+    reportTargets.map((target) => resolveReportPathTarget(projectRoot, target, caseInsensitiveFilesystem))
   );
 
   for (let leftIndex = 0; leftIndex < resolvedTargets.length; leftIndex += 1) {
@@ -32,14 +36,15 @@ export async function validateReportPathTargets(
 
 async function resolveReportPathTarget(
   projectRoot: string,
-  target: { label: string; path: string }
+  target: { label: string; path: string },
+  caseInsensitiveFilesystem: boolean
 ): Promise<ResolvedReportPathTarget> {
   const absolutePath = path.resolve(projectRoot, target.path);
   if (isFilesystemRoot(absolutePath)) {
     throw new Error(`${target.label} must target a report file, not a filesystem root`);
   }
 
-  const stats = await lstatIfExists(absolutePath);
+  const stats = await statIfExists(absolutePath);
   if (stats?.isDirectory()) {
     throw new Error(`${target.label} must target a report file, not an existing directory`);
   }
@@ -48,13 +53,13 @@ async function resolveReportPathTarget(
     label: target.label,
     path: target.path,
     absolutePath,
-    collisionPath: normalizeReportPathForCollision(await canonicalizeReportPath(absolutePath))
+    collisionPath: normalizeReportPathForCollision(await canonicalizeReportPath(absolutePath), caseInsensitiveFilesystem)
   };
 }
 
-async function lstatIfExists(filePath: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+async function statIfExists(filePath: string): Promise<Awaited<ReturnType<typeof stat>> | undefined> {
   try {
-    return await lstat(filePath);
+    return await stat(filePath);
   } catch (error) {
     if (isMissingPathError(error)) {
       return undefined;
@@ -101,13 +106,35 @@ async function canonicalizeExistingParent(directoryPath: string): Promise<string
   }
 }
 
-function normalizeReportPathForCollision(filePath: string): string {
+function normalizeReportPathForCollision(filePath: string, caseInsensitiveFilesystem: boolean): string {
   const normalized = path.normalize(filePath);
-  return isCaseInsensitivePlatform() ? normalized.toLowerCase() : normalized;
+  return caseInsensitiveFilesystem ? normalized.toLowerCase() : normalized;
 }
 
-function isCaseInsensitivePlatform(): boolean {
-  return process.platform === "win32";
+async function isCaseInsensitiveFilesystem(projectRoot: string): Promise<boolean> {
+  const probeDirectory = await createCaseProbeDirectory(projectRoot);
+  if (probeDirectory === undefined) {
+    return process.platform === "win32";
+  }
+
+  try {
+    const probeFile = path.join(probeDirectory, "crap-typescript-case-probe");
+    await writeFile(probeFile, "");
+    await access(path.join(probeDirectory, "CRAP-TYPESCRIPT-CASE-PROBE"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await rm(probeDirectory, { force: true, recursive: true });
+  }
+}
+
+async function createCaseProbeDirectory(projectRoot: string): Promise<string | undefined> {
+  try {
+    return await mkdtemp(path.join(projectRoot, ".crap-typescript-case-"));
+  } catch {
+    return undefined;
+  }
 }
 
 function isFilesystemRoot(filePath: string): boolean {

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -13,6 +13,8 @@ interface ResolvedReportPathTarget {
   collisionPath: string;
 }
 
+type FilesystemCaseCache = Map<string, boolean>;
+
 export async function validateReportPathTargets(
   projectRoot: string,
   targets: ReportPathTarget[]
@@ -21,8 +23,11 @@ export async function validateReportPathTargets(
     target.path !== undefined
   ));
   const shouldCheckCaseCollisions = reportTargets.length > 1;
+  const filesystemCaseCache: FilesystemCaseCache = new Map();
   const resolvedTargets = await Promise.all(
-    reportTargets.map((target) => resolveReportPathTarget(projectRoot, target, shouldCheckCaseCollisions))
+    reportTargets.map((target) => (
+      resolveReportPathTarget(projectRoot, target, shouldCheckCaseCollisions, filesystemCaseCache)
+    ))
   );
 
   for (let leftIndex = 0; leftIndex < resolvedTargets.length; leftIndex += 1) {
@@ -35,7 +40,8 @@ export async function validateReportPathTargets(
 async function resolveReportPathTarget(
   projectRoot: string,
   target: { label: string; path: string },
-  shouldCheckCaseCollisions: boolean
+  shouldCheckCaseCollisions: boolean,
+  filesystemCaseCache: FilesystemCaseCache
 ): Promise<ResolvedReportPathTarget> {
   const absolutePath = path.resolve(projectRoot, target.path);
   if (isFilesystemRoot(absolutePath)) {
@@ -49,7 +55,7 @@ async function resolveReportPathTarget(
 
   const canonicalPath = await canonicalizeReportPath(absolutePath);
   const caseInsensitiveFilesystem = shouldCheckCaseCollisions
-    ? await isCaseInsensitiveFilesystem(await nearestExistingParent(path.dirname(absolutePath)))
+    ? await caseInsensitiveFilesystemForTarget(absolutePath, filesystemCaseCache)
     : false;
 
   return {
@@ -58,6 +64,20 @@ async function resolveReportPathTarget(
     absolutePath,
     collisionPath: normalizeReportPathForCollision(canonicalPath, caseInsensitiveFilesystem)
   };
+}
+
+async function caseInsensitiveFilesystemForTarget(
+  absolutePath: string,
+  filesystemCaseCache: FilesystemCaseCache
+): Promise<boolean> {
+  const parent = await nearestExistingParent(path.dirname(absolutePath));
+  const cached = filesystemCaseCache.get(parent);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const caseInsensitiveFilesystem = await isCaseInsensitiveFilesystem(parent);
+  filesystemCaseCache.set(parent, caseInsensitiveFilesystem);
+  return caseInsensitiveFilesystem;
 }
 
 async function statIfExists(filePath: string): Promise<Awaited<ReturnType<typeof stat>> | undefined> {

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -55,15 +55,33 @@ async function resolveReportPathTarget(
 async function lstatIfExists(filePath: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
   try {
     return await lstat(filePath);
-  } catch {
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
     return undefined;
   }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
 }
 
 async function canonicalizeReportPath(filePath: string): Promise<string> {
   try {
     return await realpath(filePath);
-  } catch {
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
     return path.join(await canonicalizeExistingParent(path.dirname(filePath)), path.basename(filePath));
   }
 }
@@ -71,7 +89,10 @@ async function canonicalizeReportPath(filePath: string): Promise<string> {
 async function canonicalizeExistingParent(directoryPath: string): Promise<string> {
   try {
     return await realpath(directoryPath);
-  } catch {
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
     const parent = path.dirname(directoryPath);
     if (parent === directoryPath) {
       return directoryPath;
@@ -86,7 +107,7 @@ function normalizeReportPathForCollision(filePath: string): string {
 }
 
 function isCaseInsensitivePlatform(): boolean {
-  return process.platform === "win32" || process.platform === "darwin";
+  return process.platform === "win32";
 }
 
 function isFilesystemRoot(filePath: string): boolean {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -259,6 +259,23 @@ describe("cli", () => {
     expect(result.stderr).toContain("--output must target a report file, not an existing directory");
   });
 
+  it("rejects symlinked directory report targets", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await mkdir(path.join(projectRoot, "reports"));
+    await symlink(path.join(projectRoot, "reports"), path.join(projectRoot, "linked-reports"), "junction");
+
+    const result = await runPathValidation([
+      "--format",
+      "none",
+      "--output",
+      "linked-reports"
+    ], projectRoot);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("--output must target a report file, not an existing directory");
+  });
+
   it("rejects filesystem root report targets", async () => {
     const projectRoot = await createTempDir("crap-cli-");
     tempDirs.push(projectRoot);

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -242,6 +242,23 @@ describe("cli", () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("--output and --junit-report must target different report files");
     });
+
+    it("rejects case-insensitive absolute report path collisions outside the project root on Windows", async () => {
+      const projectRoot = await createTempDir("crap-cli-");
+      const reportRoot = await createTempDir("crap-reports-");
+      tempDirs.push(projectRoot, reportRoot);
+      const result = await runPathValidation([
+        "--format",
+        "none",
+        "--output",
+        path.join(reportRoot, "CRAP.xml"),
+        "--junit-report",
+        path.join(reportRoot, "crap.xml")
+      ], projectRoot);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--output and --junit-report must target different report files");
+    });
   }
 
   it("rejects existing directory report targets", async () => {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, symlink } from "node:fs/promises";
+import path from "node:path";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { parseCliArguments, runCli } from "../src/cli";
@@ -8,6 +11,21 @@ const tempDirs: string[] = [];
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(disposeTempDir));
 });
+
+async function runPathValidation(args: string[], projectRoot: string): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const stdout = new StringWriter();
+  const stderr = new StringWriter();
+  const exitCode = await runCli(args, projectRoot, stdout, stderr);
+  return {
+    exitCode,
+    stdout: stdout.toString(),
+    stderr: stderr.toString()
+  };
+}
 
 describe("cli", () => {
   it("parses supported options", () => {
@@ -171,6 +189,88 @@ describe("cli", () => {
     expect(parseCliArguments(["--omit-redundancy=false"])).toMatchObject({
       omitRedundancy: false
     });
+  });
+
+  it("rejects identical primary and JUnit report paths", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    const result = await runPathValidation([
+      "--format",
+      "none",
+      "--output",
+      "reports/crap.xml",
+      "--junit-report",
+      "reports/crap.xml"
+    ], projectRoot);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("--output and --junit-report must target different report files");
+  });
+
+  it("rejects realpath aliases for primary and JUnit report paths", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await mkdir(path.join(projectRoot, "real-reports"));
+    await symlink(path.join(projectRoot, "real-reports"), path.join(projectRoot, "linked-reports"), "junction");
+
+    const result = await runPathValidation([
+      "--format",
+      "none",
+      "--output",
+      "real-reports/crap.xml",
+      "--junit-report",
+      "linked-reports/crap.xml"
+    ], projectRoot);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("--output and --junit-report must target different report files");
+  });
+
+  if (process.platform === "win32") {
+    it("rejects case-insensitive report path collisions on Windows", async () => {
+      const projectRoot = await createTempDir("crap-cli-");
+      tempDirs.push(projectRoot);
+      const result = await runPathValidation([
+        "--format",
+        "none",
+        "--output",
+        "reports/CRAP.xml",
+        "--junit-report",
+        "reports/crap.xml"
+      ], projectRoot);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--output and --junit-report must target different report files");
+    });
+  }
+
+  it("rejects existing directory report targets", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await mkdir(path.join(projectRoot, "reports"));
+    const result = await runPathValidation([
+      "--format",
+      "none",
+      "--output",
+      "reports"
+    ], projectRoot);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("--output must target a report file, not an existing directory");
+  });
+
+  it("rejects filesystem root report targets", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    const result = await runPathValidation([
+      "--format",
+      "none",
+      "--output",
+      path.parse(projectRoot).root
+    ], projectRoot);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("--output must target a report file, not a filesystem root");
   });
 
   it("applies agent composite defaults and explicit overrides", () => {

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -4,7 +4,8 @@ import path from "node:path";
 import {
   analyzeProject,
   COVERAGE_REPORT_RELATIVE_PATH,
-  formatAnalysisReport
+  formatAnalysisReport,
+  validateReportPathTargets
 } from "@barney-media/crap-typescript-core";
 import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
 
@@ -66,6 +67,7 @@ export default class CrapTypescriptJestReporter {
   private async finalize(): Promise<void> {
     const options = resolveReporterOptions(this.options);
     try {
+      await validateReporterReportPaths(options);
       await waitForCoverageReport(options.projectRoot, options.coverageReportPath);
       const result = await analyzeProject({
         projectRoot: options.projectRoot,
@@ -224,6 +226,13 @@ async function writeReporterReports(
       threshold: options.threshold
     }));
   }
+}
+
+async function validateReporterReportPaths(options: ResolvedReporterOptions): Promise<void> {
+  await validateReportPathTargets(options.projectRoot, [
+    { label: "output", path: options.output },
+    { label: "junitReport", path: options.junit ? options.junitReport : undefined }
+  ]);
 }
 
 async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -128,6 +128,28 @@ describe("CrapTypescriptJestReporter", () => {
     expect(stderr.toString()).toBe("");
   });
 
+  it("rejects colliding output and JUnit report paths", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptJestReporter(undefined, {
+      projectRoot,
+      output: "reports/crap.xml",
+      junitReport: "reports/crap.xml",
+      stdout,
+      stderr
+    });
+
+    await callFinalize(reporter);
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toContain("output and junitReport must target different report files");
+    expect(reporter.getLastError()?.message).toContain("output and junitReport must target different report files");
+    expect(process.exitCode).toBe(1);
+  });
+
   it("honors custom thresholds and emits threshold warnings", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -1,3 +1,4 @@
+import { mkdir, symlink } from "node:fs/promises";
 import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,7 +11,7 @@ import {
   readText,
   writeProjectFiles
 } from "../../core/test/testUtils";
-import CrapTypescriptJestReporter from "../src/reporter";
+import CrapTypescriptJestReporter, { type CrapTypescriptJestOptions } from "../src/reporter";
 
 const tempDirs: string[] = [];
 let originalExitCode: number | undefined;
@@ -27,6 +28,23 @@ afterEach(async () => {
 
 async function callFinalize(reporter: CrapTypescriptJestReporter): Promise<void> {
   await (reporter as unknown as { finalize: () => Promise<void> }).finalize();
+}
+
+async function finalizeWithOptions(
+  projectRoot: string,
+  options: CrapTypescriptJestOptions
+): Promise<{ stdout: StringWriter; stderr: StringWriter; reporter: CrapTypescriptJestReporter }> {
+  const stdout = new StringWriter();
+  const stderr = new StringWriter();
+  const reporter = new CrapTypescriptJestReporter(undefined, {
+    projectRoot,
+    stdout,
+    stderr,
+    ...options
+  });
+
+  await callFinalize(reporter);
+  return { stdout, stderr, reporter };
 }
 
 describe("CrapTypescriptJestReporter", () => {
@@ -132,21 +150,40 @@ describe("CrapTypescriptJestReporter", () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);
 
-    const stdout = new StringWriter();
-    const stderr = new StringWriter();
-    const reporter = new CrapTypescriptJestReporter(undefined, {
-      projectRoot,
+    const { stdout, stderr, reporter } = await finalizeWithOptions(projectRoot, {
       output: "reports/crap.xml",
-      junitReport: "reports/crap.xml",
-      stdout,
-      stderr
+      junitReport: "reports/crap.xml"
     });
-
-    await callFinalize(reporter);
 
     expect(stdout.toString()).toBe("");
     expect(stderr.toString()).toContain("output and junitReport must target different report files");
     expect(reporter.getLastError()?.message).toContain("output and junitReport must target different report files");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects directory, root, and aliased report paths", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+    await mkdir(path.join(projectRoot, "reports"));
+    await mkdir(path.join(projectRoot, "real-reports"));
+    await symlink(path.join(projectRoot, "real-reports"), path.join(projectRoot, "linked-reports"), "junction");
+
+    const directoryTarget = await finalizeWithOptions(projectRoot, {
+      output: "reports",
+      junit: false
+    });
+    const rootTarget = await finalizeWithOptions(projectRoot, {
+      output: path.parse(projectRoot).root,
+      junit: false
+    });
+    const aliasTarget = await finalizeWithOptions(projectRoot, {
+      output: "real-reports/crap.xml",
+      junitReport: "linked-reports/crap.xml"
+    });
+
+    expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
+    expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
+    expect(aliasTarget.stderr.toString()).toContain("output and junitReport must target different report files");
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -167,9 +167,14 @@ describe("CrapTypescriptJestReporter", () => {
     await mkdir(path.join(projectRoot, "reports"));
     await mkdir(path.join(projectRoot, "real-reports"));
     await symlink(path.join(projectRoot, "real-reports"), path.join(projectRoot, "linked-reports"), "junction");
+    await symlink(path.join(projectRoot, "reports"), path.join(projectRoot, "linked-directory"), "junction");
 
     const directoryTarget = await finalizeWithOptions(projectRoot, {
       output: "reports",
+      junit: false
+    });
+    const symlinkedDirectoryTarget = await finalizeWithOptions(projectRoot, {
+      output: "linked-directory",
       junit: false
     });
     const rootTarget = await finalizeWithOptions(projectRoot, {
@@ -182,6 +187,9 @@ describe("CrapTypescriptJestReporter", () => {
     });
 
     expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
+    expect(symlinkedDirectoryTarget.stderr.toString()).toContain(
+      "output must target a report file, not an existing directory"
+    );
     expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
     expect(aliasTarget.stderr.toString()).toContain("output and junitReport must target different report files");
     expect(process.exitCode).toBe(1);

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -173,25 +173,45 @@ describe("CrapTypescriptJestReporter", () => {
       output: "reports",
       junit: false
     });
+    expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
+    expect(directoryTarget.reporter.getLastError()?.message).toContain(
+      "output must target a report file, not an existing directory"
+    );
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+
     const symlinkedDirectoryTarget = await finalizeWithOptions(projectRoot, {
       output: "linked-directory",
       junit: false
     });
+    expect(symlinkedDirectoryTarget.stderr.toString()).toContain(
+      "output must target a report file, not an existing directory"
+    );
+    expect(symlinkedDirectoryTarget.reporter.getLastError()?.message).toContain(
+      "output must target a report file, not an existing directory"
+    );
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+
     const rootTarget = await finalizeWithOptions(projectRoot, {
       output: path.parse(projectRoot).root,
       junit: false
     });
+    expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
+    expect(rootTarget.reporter.getLastError()?.message).toContain(
+      "output must target a report file, not a filesystem root"
+    );
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+
     const aliasTarget = await finalizeWithOptions(projectRoot, {
       output: "real-reports/crap.xml",
       junitReport: "linked-reports/crap.xml"
     });
-
-    expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
-    expect(symlinkedDirectoryTarget.stderr.toString()).toContain(
-      "output must target a report file, not an existing directory"
-    );
-    expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
     expect(aliasTarget.stderr.toString()).toContain("output and junitReport must target different report files");
+    expect(aliasTarget.reporter.getLastError()?.message).toContain(
+      "output and junitReport must target different report files"
+    );
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { analyzeProject, formatAnalysisReport } from "@barney-media/crap-typescript-core";
+import { analyzeProject, formatAnalysisReport, validateReportPathTargets } from "@barney-media/crap-typescript-core";
 import type { PackageManagerSelection, ReportFormat, Writer } from "@barney-media/crap-typescript-core";
 
 type VitestReporterEntry = string | [string, unknown] | {
@@ -44,6 +44,7 @@ export class CrapTypescriptVitestReporter {
   async onFinishedReportCoverage(): Promise<void> {
     const options = resolveReporterOptions(this.options);
     try {
+      await validateReporterReportPaths(options);
       const result = await analyzeProject({
         projectRoot: options.projectRoot,
         explicitPaths: options.paths,
@@ -253,6 +254,13 @@ async function writeReporterReports(
       threshold: options.threshold
     }));
   }
+}
+
+async function validateReporterReportPaths(options: ResolvedReporterOptions): Promise<void> {
+  await validateReportPathTargets(options.projectRoot, [
+    { label: "output", path: options.output },
+    { label: "junitReport", path: options.junit ? options.junitReport : undefined }
+  ]);
 }
 
 async function writeReportFile(projectRoot: string, reportPath: string, content: string): Promise<void> {

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -94,6 +94,27 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(stderr.toString()).toBe("");
   });
 
+  it("rejects colliding output and JUnit report paths", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+
+    const stdout = new StringWriter();
+    const stderr = new StringWriter();
+    const reporter = new CrapTypescriptVitestReporter({
+      projectRoot,
+      output: "reports/crap.xml",
+      junitReport: "reports/crap.xml",
+      stdout,
+      stderr
+    });
+
+    await reporter.onFinishedReportCoverage();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toContain("output and junitReport must target different report files");
+    expect(process.exitCode).toBe(1);
+  });
+
 
   it("honors custom thresholds and emits threshold warnings", async () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -140,24 +140,32 @@ describe("CrapTypescriptVitestReporter", () => {
       output: "reports",
       junit: false
     });
+    expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+
     const symlinkedDirectoryTarget = await finishWithOptions(projectRoot, {
       output: "linked-directory",
       junit: false
     });
+    expect(symlinkedDirectoryTarget.stderr.toString()).toContain(
+      "output must target a report file, not an existing directory"
+    );
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+
     const rootTarget = await finishWithOptions(projectRoot, {
       output: path.parse(projectRoot).root,
       junit: false
     });
+    expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+
     const aliasTarget = await finishWithOptions(projectRoot, {
       output: "real-reports/crap.xml",
       junitReport: "linked-reports/crap.xml"
     });
-
-    expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
-    expect(symlinkedDirectoryTarget.stderr.toString()).toContain(
-      "output must target a report file, not an existing directory"
-    );
-    expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
     expect(aliasTarget.stderr.toString()).toContain("output and junitReport must target different report files");
     expect(process.exitCode).toBe(1);
   });

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -134,9 +134,14 @@ describe("CrapTypescriptVitestReporter", () => {
     await mkdir(path.join(projectRoot, "reports"));
     await mkdir(path.join(projectRoot, "real-reports"));
     await symlink(path.join(projectRoot, "real-reports"), path.join(projectRoot, "linked-reports"), "junction");
+    await symlink(path.join(projectRoot, "reports"), path.join(projectRoot, "linked-directory"), "junction");
 
     const directoryTarget = await finishWithOptions(projectRoot, {
       output: "reports",
+      junit: false
+    });
+    const symlinkedDirectoryTarget = await finishWithOptions(projectRoot, {
+      output: "linked-directory",
       junit: false
     });
     const rootTarget = await finishWithOptions(projectRoot, {
@@ -149,6 +154,9 @@ describe("CrapTypescriptVitestReporter", () => {
     });
 
     expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
+    expect(symlinkedDirectoryTarget.stderr.toString()).toContain(
+      "output must target a report file, not an existing directory"
+    );
     expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
     expect(aliasTarget.stderr.toString()).toContain("output and junitReport must target different report files");
     expect(process.exitCode).toBe(1);

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, symlink } from "node:fs/promises";
+import path from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -8,7 +11,7 @@ import {
   readText,
   writeProjectFiles
 } from "../../core/test/testUtils";
-import { CrapTypescriptVitestReporter } from "../src/index";
+import { CrapTypescriptVitestReporter, type CrapTypescriptVitestOptions } from "../src/index";
 
 const tempDirs: string[] = [];
 let originalExitCode: number | undefined;
@@ -21,6 +24,23 @@ afterEach(async () => {
   process.exitCode = originalExitCode;
   await Promise.all(tempDirs.splice(0).map(disposeTempDir));
 });
+
+async function finishWithOptions(projectRoot: string, options: CrapTypescriptVitestOptions): Promise<{
+  stdout: StringWriter;
+  stderr: StringWriter;
+}> {
+  const stdout = new StringWriter();
+  const stderr = new StringWriter();
+  const reporter = new CrapTypescriptVitestReporter({
+    projectRoot,
+    stdout,
+    stderr,
+    ...options
+  });
+
+  await reporter.onFinishedReportCoverage();
+  return { stdout, stderr };
+}
 
 describe("CrapTypescriptVitestReporter", () => {
   it("emits no primary report by default and writes a full JUnit sidecar", async () => {
@@ -98,20 +118,39 @@ describe("CrapTypescriptVitestReporter", () => {
     const projectRoot = await createTempDir("crap-vitest-reporter-");
     tempDirs.push(projectRoot);
 
-    const stdout = new StringWriter();
-    const stderr = new StringWriter();
-    const reporter = new CrapTypescriptVitestReporter({
-      projectRoot,
+    const { stdout, stderr } = await finishWithOptions(projectRoot, {
       output: "reports/crap.xml",
-      junitReport: "reports/crap.xml",
-      stdout,
-      stderr
+      junitReport: "reports/crap.xml"
     });
-
-    await reporter.onFinishedReportCoverage();
 
     expect(stdout.toString()).toBe("");
     expect(stderr.toString()).toContain("output and junitReport must target different report files");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects directory, root, and aliased report paths", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await mkdir(path.join(projectRoot, "reports"));
+    await mkdir(path.join(projectRoot, "real-reports"));
+    await symlink(path.join(projectRoot, "real-reports"), path.join(projectRoot, "linked-reports"), "junction");
+
+    const directoryTarget = await finishWithOptions(projectRoot, {
+      output: "reports",
+      junit: false
+    });
+    const rootTarget = await finishWithOptions(projectRoot, {
+      output: path.parse(projectRoot).root,
+      junit: false
+    });
+    const aliasTarget = await finishWithOptions(projectRoot, {
+      output: "real-reports/crap.xml",
+      junitReport: "linked-reports/crap.xml"
+    });
+
+    expect(directoryTarget.stderr.toString()).toContain("output must target a report file, not an existing directory");
+    expect(rootTarget.stderr.toString()).toContain("output must target a report file, not a filesystem root");
+    expect(aliasTarget.stderr.toString()).toContain("output and junitReport must target different report files");
     expect(process.exitCode).toBe(1);
   });
 


### PR DESCRIPTION
## Summary

- Add shared report target validation for CLI, Jest reporter, and Vitest reporter.
- Reject shared/aliased primary and JUnit report targets, filesystem roots, and existing directories.
- Cover exact collisions, realpath aliases, feasible case-insensitive collisions, directory targets, root targets, and adapter validation paths.

Closes #80