### PR TITLE
Include constructor descriptors in parser

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -30,6 +30,7 @@ const NESTED_BOUNDARY_KINDS = new Set([
   ts.SyntaxKind.FunctionExpression,
   ts.SyntaxKind.ArrowFunction,
   ts.SyntaxKind.MethodDeclaration,
+  ts.SyntaxKind.Constructor,
   ts.SyntaxKind.GetAccessor,
   ts.SyntaxKind.SetAccessor,
   ts.SyntaxKind.ClassDeclaration,
@@ -70,6 +71,7 @@ type DescriptorBuilder = (node: ts.Node, sourceFile: ts.SourceFile) => MethodDes
 const DESCRIPTOR_BUILDERS: DescriptorBuilder[] = [
   descriptorFromFunctionDeclaration,
   descriptorFromMethodDeclaration,
+  descriptorFromConstructorDeclaration,
   descriptorFromAccessorDeclaration,
   descriptorFromAssignedFunction
 ];
@@ -90,6 +92,13 @@ function descriptorFromMethodDeclaration(node: ts.Node, sourceFile: ts.SourceFil
     return null;
   }
   return buildMethodDescriptor(propertyName(node.name), findContainerName(node), node, sourceFile);
+}
+
+function descriptorFromConstructorDeclaration(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
+  if (!ts.isConstructorDeclaration(node) || !node.body) {
+    return null;
+  }
+  return buildMethodDescriptor("constructor", findContainerName(node), node, sourceFile);
 }
 
 function descriptorFromAccessorDeclaration(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -136,6 +136,58 @@ const arrow = (items: number[]) => {
     ]);
   });
 
+  it("extracts constructor bodies and excludes nested functions from constructor complexity", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "constructor.ts");
+    await writeFile(
+      filePath,
+      `class Example {
+  constructor(flag: boolean) {
+    const inner = () => {
+      if (flag) {
+        return 1;
+      }
+      return 0;
+    };
+    if (flag) {
+      this.value = inner();
+    }
+  }
+
+  value = 0;
+}
+`,
+      "utf8"
+    );
+
+    const methods = await parseFileMethods(filePath);
+    const byName = new Map(methods.map((method) => [method.displayName, method]));
+
+    expect(methods.map((method) => method.displayName)).toEqual([
+      "Example.constructor",
+      "Example.inner"
+    ]);
+    expect(byName.get("Example.constructor")).toMatchObject({
+      functionName: "constructor",
+      containerName: "Example",
+      startLine: 2,
+      endLine: 12,
+      complexity: 2,
+      bodySpan: {
+        startLine: 2,
+        endLine: 12
+      },
+      expectsStatementCoverage: true,
+      expectsBranchCoverage: true
+    });
+    expect(byName.get("Example.inner")).toMatchObject({
+      functionName: "inner",
+      containerName: "Example",
+      complexity: 2
+    });
+  });
+
   it("ignores declaration files", async () => {
     const tempDir = await createTempDir("crap-parser-");
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary
- classified #85 as valid constructor under-reporting
- add constructor descriptor extraction with `Example.constructor` display names
- treat constructors as nested boundaries and cover nested function complexity isolation

## Verification
- `npx vitest run packages/core/test/parser.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #85