### PR TITLE
Fail on TypeScript parse diagnostics

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ export { calculateCrapScore, maxCrap } from "./crapScore.js";
 export { buildCoverageCommand } from "./coverage.js";
 export { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots, isAnalyzableFile } from "./fileSelection.js";
 export { coverageForMethods, parseCoverageReport } from "./istanbul.js";
-export { parseFileMethods } from "./parser.js";
+export { ParseError, parseFileMethods } from "./parser.js";
 export { filterSourceFiles } from "./sourceExclusions.js";
 export {
   buildAgentAnalysisReport,

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -4,6 +4,20 @@ import ts from "typescript";
 import { resolveScriptKind } from "./utils.js";
 import type { MethodDescriptor, SourceSpan } from "./types.js";
 
+type SourceFileWithParseDiagnostics = ts.SourceFile & {
+  parseDiagnostics?: readonly ts.Diagnostic[];
+};
+
+export class ParseError extends Error {
+  readonly diagnostics: readonly ts.Diagnostic[];
+
+  constructor(filePath: string, diagnostics: readonly ts.Diagnostic[]) {
+    super(`Unable to parse TypeScript source ${filePath}: ${diagnostics.map(formatDiagnostic).join("; ")}`);
+    this.name = "ParseError";
+    this.diagnostics = diagnostics;
+  }
+}
+
 const COMPLEXITY_INCREMENT_KINDS = new Set([
   ts.SyntaxKind.IfStatement,
   ts.SyntaxKind.ForStatement,
@@ -40,6 +54,7 @@ export async function parseFileMethods(filePath: string): Promise<MethodDescript
   const sourceText = await readFile(filePath, "utf8");
   const scriptKind = resolveScriptKind(filePath) === "tsx" ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
   const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, scriptKind);
+  throwIfParseDiagnostics(sourceFile);
   const methods: MethodDescriptor[] = [];
 
   const visit = (node: ts.Node): void => {
@@ -52,6 +67,25 @@ export async function parseFileMethods(filePath: string): Promise<MethodDescript
 
   visit(sourceFile);
   return methods;
+}
+
+function throwIfParseDiagnostics(sourceFile: ts.SourceFile): void {
+  const diagnostics = (sourceFile as SourceFileWithParseDiagnostics).parseDiagnostics ?? [];
+  if (diagnostics.length > 0) {
+    throw new ParseError(sourceFile.fileName, diagnostics);
+  }
+}
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  return `${formatDiagnosticLocation(diagnostic)}: ${ts.flattenDiagnosticMessageText(diagnostic.messageText, " ")}`;
+}
+
+function formatDiagnosticLocation(diagnostic: ts.Diagnostic): string {
+  if (!diagnostic.file || diagnostic.start === undefined) {
+    return "unknown location";
+  }
+  const location = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+  return `line ${location.line + 1}, column ${location.character + 1}`;
 }
 
 function toMethodDescriptor(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { parseFileMethods } from "../src/parser";
+import { ParseError, parseFileMethods } from "../src/parser";
 import { createTempDir, disposeTempDir } from "./testUtils";
 
 const tempDirs: string[] = [];
@@ -143,6 +143,26 @@ const arrow = (items: number[]) => {
     await writeFile(filePath, "export declare function missing(): void;", "utf8");
 
     expect(await parseFileMethods(filePath)).toEqual([]);
+  });
+
+  it("fails on parse diagnostics instead of returning partial methods", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "broken.ts");
+    await writeFile(
+      filePath,
+      `export function partial(flag: boolean): number {
+  if (flag) {
+    return 1;
+}
+`,
+      "utf8"
+    );
+
+    await expect(parseFileMethods(filePath)).rejects.toThrow(ParseError);
+    await expect(parseFileMethods(filePath)).rejects.toThrow(
+      new RegExp(`Unable to parse TypeScript source .*broken\\.ts: line \\d+, column \\d+:`)
+    );
   });
 
   it("includes anonymous default-exported function declarations", async () => {


### PR DESCRIPTION
## Summary
- classified #86 as valid parser diagnostic handling feedback
- add a typed `ParseError` for TypeScript parse diagnostics before walking the partial AST
- export the parse error and cover broken syntax with a parser regression test

## Verification
- `npx vitest run packages/core/test/parser.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #86