### PR TITLE
Count optional chaining in complexity

### DIFF
--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -80,9 +80,16 @@ function attachCoverageCommand(
   coverageSource: { reportPath: string; sourceRoot: string } | null,
   command: CoverageCommand | null
 ): { coverageSourcePath: string | null; coverageSourceRoot: string | null; command: CoverageCommand | null } {
+  if (!coverageSource) {
+    return {
+      coverageSourcePath: null,
+      coverageSourceRoot: null,
+      command
+    };
+  }
   return {
-    coverageSourcePath: coverageSource?.reportPath ?? null,
-    coverageSourceRoot: coverageSource?.sourceRoot ?? null,
+    coverageSourcePath: coverageSource.reportPath,
+    coverageSourceRoot: coverageSource.sourceRoot,
     command
   };
 }

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -455,6 +455,9 @@ function complexityContribution(node: ts.Node): number {
   if (COMPLEXITY_INCREMENT_KINDS.has(node.kind)) {
     return 1;
   }
+  if (hasOwnOptionalChainToken(node)) {
+    return 1;
+  }
   if (!ts.isBinaryExpression(node)) {
     return 0;
   }
@@ -465,7 +468,15 @@ function hasBranchSyntax(node: ts.Node): boolean {
   if (BRANCH_SYNTAX_KINDS.has(node.kind)) {
     return true;
   }
+  if (hasOwnOptionalChainToken(node)) {
+    return true;
+  }
   return ts.isBinaryExpression(node) && SHORT_CIRCUIT_KINDS.has(node.operatorToken.kind);
+}
+
+function hasOwnOptionalChainToken(node: ts.Node): boolean {
+  return (ts.isPropertyAccessChain(node) || ts.isElementAccessChain(node) || ts.isCallChain(node)) &&
+    node.questionDotToken !== undefined;
 }
 
 function isAssignmentExpression(node: ts.Node): node is ts.BinaryExpression {

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -188,6 +188,52 @@ const arrow = (items: number[]) => {
     });
   });
 
+  it("counts each optional chaining token as one branch and complexity contribution", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "optional-chain.ts");
+    await writeFile(
+      filePath,
+      `export function optionalProperties(value?: { first?: { second?: string } }): string | undefined {
+  return value?.first?.second;
+}
+
+export function optionalThenRegularAccess(value?: { first: { second?: string } }): string | undefined {
+  return value?.first.second;
+}
+
+export function regularThenOptionalCall(value: { first?: () => string }): string | undefined {
+  return value.first?.();
+}
+
+export function optionalPropertyThenRegularCall(value?: { first: () => string }): string | undefined {
+  return value?.first();
+}
+`,
+      "utf8"
+    );
+
+    const methods = await parseFileMethods(filePath);
+    const byName = new Map(methods.map((method) => [method.displayName, method]));
+
+    expect(byName.get("optionalProperties")).toMatchObject({
+      complexity: 3,
+      expectsBranchCoverage: true
+    });
+    expect(byName.get("optionalThenRegularAccess")).toMatchObject({
+      complexity: 2,
+      expectsBranchCoverage: true
+    });
+    expect(byName.get("regularThenOptionalCall")).toMatchObject({
+      complexity: 2,
+      expectsBranchCoverage: true
+    });
+    expect(byName.get("optionalPropertyThenRegularCall")).toMatchObject({
+      complexity: 2,
+      expectsBranchCoverage: true
+    });
+  });
+
   it("ignores declaration files", async () => {
     const tempDir = await createTempDir("crap-parser-");
     tempDirs.push(tempDir);


### PR DESCRIPTION
Closes #87

## Summary
- count each TypeScript optional chaining token as one cyclomatic-complexity contribution
- treat optional chaining as branch syntax for method branch-coverage expectations
- refactor an internal coverage helper so the repository passes its own CRAP gate under the corrected optional-chain accounting

## Verification
- `npx vitest run packages/core/test/parser.test.ts packages/core/test/coverage.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

## Notes
ESLint's current complexity rule documents `a?.b?.c` as two additional branches. The implementation deliberately counts only optional-chain nodes that own a `?.` token so continuation nodes such as `a?.b.c` are not double counted.