### PR TITLE
Document switch default complexity behavior

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -27,6 +27,7 @@ const COMPLEXITY_INCREMENT_KINDS = new Set([
   ts.SyntaxKind.DoStatement,
   ts.SyntaxKind.CatchClause,
   ts.SyntaxKind.ConditionalExpression,
+  // Match ESLint classic complexity: case labels add paths; default is the existing fallthrough path.
   ts.SyntaxKind.CaseClause
 ]);
 const SHORT_CIRCUIT_KINDS = new Set([

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -188,6 +188,44 @@ const arrow = (items: number[]) => {
     });
   });
 
+  it("does not count switch default clauses as additional complexity", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "switch-default.ts");
+    await writeFile(
+      filePath,
+      `export function fallbackOnly(value: number): number {
+  switch (value) {
+    default:
+      return 0;
+  }
+}
+
+export function oneCaseAndDefault(value: number): number {
+  switch (value) {
+    case 1:
+      return 1;
+    default:
+      return 0;
+  }
+}
+`,
+      "utf8"
+    );
+
+    const methods = await parseFileMethods(filePath);
+    const byName = new Map(methods.map((method) => [method.displayName, method]));
+
+    expect(byName.get("fallbackOnly")).toMatchObject({
+      complexity: 1,
+      expectsBranchCoverage: true
+    });
+    expect(byName.get("oneCaseAndDefault")).toMatchObject({
+      complexity: 2,
+      expectsBranchCoverage: true
+    });
+  });
+
   it("ignores declaration files", async () => {
     const tempDir = await createTempDir("crap-parser-");
     tempDirs.push(tempDir);


### PR DESCRIPTION
Closes #88

## Summary
- document that `default` is not an added cyclomatic-complexity increment
- add parser coverage pinning default-only and case-plus-default switch behavior

## Verification
- `npx vitest run packages/core/test/parser.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

## Notes
This keeps the existing algorithm. ESLint's classic complexity documentation treats switch cases as added paths and does not count `default` as its own extra increment.