### PR TITLE
Fix nested container display names

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -261,16 +261,24 @@ function containerNameFromAncestors(start: ts.Node | undefined): string | null {
   while (current) {
     const segment = containerSegment(current);
     if (segment) {
-      segments.unshift(segment);
+      segments.unshift(segment.name);
+      if (segment.anchored) {
+        break;
+      }
     }
     current = current.parent;
   }
   return segments.length > 0 ? segments.join(".") : null;
 }
 
-function containerSegment(node: ts.Node): string | null {
+interface ContainerSegment {
+  name: string;
+  anchored: boolean;
+}
+
+function containerSegment(node: ts.Node): ContainerSegment | null {
   if ((ts.isClassDeclaration(node) || ts.isClassExpression(node)) && node.name) {
-    return node.name.text;
+    return relativeContainerSegment(node.name.text);
   }
   if (ts.isObjectLiteralExpression(node)) {
     return localObjectContainerName(node);
@@ -278,11 +286,11 @@ function containerSegment(node: ts.Node): string | null {
   return null;
 }
 
-function localObjectContainerName(node: ts.ObjectLiteralExpression): string | null {
+function localObjectContainerName(node: ts.ObjectLiteralExpression): ContainerSegment | null {
   for (const resolver of OBJECT_CONTAINER_RESOLVERS) {
-    const containerName = resolver(node.parent);
-    if (containerName) {
-      return containerName;
+    const segment = resolver(node.parent);
+    if (segment) {
+      return segment;
     }
   }
   return null;
@@ -301,7 +309,7 @@ function assignmentTarget(node: ts.Expression): { name: string; containerName: s
   };
 }
 
-type ObjectContainerResolver = (parent: ts.Node) => string | null;
+type ObjectContainerResolver = (parent: ts.Node) => ContainerSegment | null;
 
 const OBJECT_CONTAINER_RESOLVERS: ObjectContainerResolver[] = [
   containerFromVariableDeclaration,
@@ -310,33 +318,41 @@ const OBJECT_CONTAINER_RESOLVERS: ObjectContainerResolver[] = [
   containerFromBinaryAssignment
 ];
 
-function containerFromVariableDeclaration(parent: ts.Node): string | null {
+function containerFromVariableDeclaration(parent: ts.Node): ContainerSegment | null {
   if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
-    return parent.name.text;
+    return relativeContainerSegment(parent.name.text);
   }
   return null;
 }
 
-function containerFromPropertyAssignment(parent: ts.Node): string | null {
+function containerFromPropertyAssignment(parent: ts.Node): ContainerSegment | null {
   if (ts.isPropertyAssignment(parent)) {
-    return propertyName(parent.name);
+    return relativeContainerSegment(propertyName(parent.name));
   }
   return null;
 }
 
-function containerFromPropertyDeclaration(parent: ts.Node): string | null {
+function containerFromPropertyDeclaration(parent: ts.Node): ContainerSegment | null {
   if (ts.isPropertyDeclaration(parent)) {
-    return propertyName(parent.name);
+    return relativeContainerSegment(propertyName(parent.name));
   }
   return null;
 }
 
-function containerFromBinaryAssignment(parent: ts.Node): string | null {
+function containerFromBinaryAssignment(parent: ts.Node): ContainerSegment | null {
   if (!isAssignmentExpression(parent)) {
     return null;
   }
   const target = assignmentTarget(parent.left);
-  return toDisplayName(target.containerName, target.name);
+  return anchoredContainerSegment(toDisplayName(target.containerName, target.name));
+}
+
+function relativeContainerSegment(name: string): ContainerSegment {
+  return { name, anchored: false };
+}
+
+function anchoredContainerSegment(name: string): ContainerSegment {
+  return { name, anchored: true };
 }
 
 type AssignmentTargetResolver = (node: ts.Expression) => { name: string; containerName: string | null } | null;

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -248,23 +248,37 @@ function assignedNameFromBinaryExpression(
 }
 
 function findContainerName(node: ts.Node): string | null {
-  let current: ts.Node | undefined = node.parent;
+  return containerNameFromAncestors(node.parent);
+}
+
+function inferObjectContainerName(node: ts.ObjectLiteralExpression): string | null {
+  return containerNameFromAncestors(node);
+}
+
+function containerNameFromAncestors(start: ts.Node | undefined): string | null {
+  const segments: string[] = [];
+  let current = start;
   while (current) {
-    if ((ts.isClassDeclaration(current) || ts.isClassExpression(current)) && current.name) {
-      return current.name.text;
-    }
-    if (ts.isObjectLiteralExpression(current)) {
-      const inferred = inferObjectContainerName(current);
-      if (inferred) {
-        return inferred;
-      }
+    const segment = containerSegment(current);
+    if (segment) {
+      segments.unshift(segment);
     }
     current = current.parent;
+  }
+  return segments.length > 0 ? segments.join(".") : null;
+}
+
+function containerSegment(node: ts.Node): string | null {
+  if ((ts.isClassDeclaration(node) || ts.isClassExpression(node)) && node.name) {
+    return node.name.text;
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    return localObjectContainerName(node);
   }
   return null;
 }
 
-function inferObjectContainerName(node: ts.ObjectLiteralExpression): string | null {
+function localObjectContainerName(node: ts.ObjectLiteralExpression): string | null {
   for (const resolver of OBJECT_CONTAINER_RESOLVERS) {
     const containerName = resolver(node.parent);
     if (containerName) {

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -541,10 +541,10 @@ class Example {
         displayName: "registry.render.nested"
       },
       {
-        displayName: "child.leaf"
+        displayName: "root.child.leaf"
       },
       {
-        displayName: "helper.format"
+        displayName: "Example.helper.format"
       }
     ]);
   });

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -595,6 +595,61 @@ class Example {
     ]);
   });
 
+  it("keeps anchored assignment containers separate from enclosing classes", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "anchored-containers.ts");
+    await writeFile(
+      filePath,
+      `const obj: Record<string, unknown> = {};
+
+class Example {
+  build(): void {
+    obj.foo = {
+      bar(value: string): string {
+        return value.trim();
+      }
+    };
+  }
+}
+`,
+      "utf8"
+    );
+
+    expect(await parseFileMethods(filePath)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        displayName: "Example.build"
+      }),
+      expect.objectContaining({
+        displayName: "obj.foo.bar"
+      })
+    ]));
+  });
+
+  it("composes nested class display names", async () => {
+    const tempDir = await createTempDir("crap-parser-");
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, "nested-classes.ts");
+    await writeFile(
+      filePath,
+      `class Outer {
+  static Inner = class Inner {
+    value(flag: boolean): number {
+      return flag ? 1 : 0;
+    }
+  };
+}
+`,
+      "utf8"
+    );
+
+    expect(await parseFileMethods(filePath)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        displayName: "Outer.Inner.value"
+      })
+    ]));
+  });
+
   it("handles identifier, property, element, fallback, and unowned object-literal assignment targets", async () => {
     const tempDir = await createTempDir("crap-parser-");
     tempDirs.push(tempDir);

--- a/tests/fixtures/compatibility-matrix/matrix.json
+++ b/tests/fixtures/compatibility-matrix/matrix.json
@@ -159,6 +159,10 @@
         {
           "name": "helper.score",
           "coverage": 100
+        },
+        {
+          "name": "Outer.Inner.value",
+          "coverage": 50
         }
       ]
     },

--- a/tests/fixtures/compatibility-matrix/object-and-class-methods/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/object-and-class-methods/coverage/coverage-final.json
@@ -17,6 +17,14 @@
       "3": {
         "start": { "line": 15, "column": 8 },
         "end": { "line": 15, "column": 17 }
+      },
+      "4": {
+        "start": { "line": 25, "column": 8 },
+        "end": { "line": 25, "column": 17 }
+      },
+      "5": {
+        "start": { "line": 27, "column": 6 },
+        "end": { "line": 27, "column": 15 }
       }
     },
     "fnMap": {},
@@ -53,18 +61,36 @@
             "end": { "line": 15, "column": 17 }
           }
         ]
+      },
+      "2": {
+        "line": 24,
+        "type": "if",
+        "loc": {
+          "start": { "line": 24, "column": 6 },
+          "end": { "line": 26, "column": 7 }
+        },
+        "locations": [
+          {
+            "start": { "line": 24, "column": 6 },
+            "end": { "line": 26, "column": 7 }
+          },
+          {}
+        ]
       }
     },
     "s": {
       "0": 1,
       "1": 0,
       "2": 1,
-      "3": 1
+      "3": 1,
+      "4": 1,
+      "5": 0
     },
     "f": {},
     "b": {
       "0": [1, 0],
-      "1": [1, 1]
+      "1": [1, 1],
+      "2": [1, 0]
     }
   }
 }

--- a/tests/fixtures/compatibility-matrix/object-and-class-methods/src/sample.ts
+++ b/tests/fixtures/compatibility-matrix/object-and-class-methods/src/sample.ts
@@ -17,3 +17,14 @@ export const helper = {
     }
   }
 };
+
+export class Outer {
+  static Inner = class Inner {
+    value(flag: boolean): number {
+      if (flag) {
+        return 1;
+      }
+      return 0;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- classify the nested-container display-name review finding as valid
- compose class and object container segments from the source root to the method owner
- cover nested object/class display names in parser tests

## Verification
- `npx vitest run packages/core/test/parser.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #90