### PR TITLE
Normalize property assignment display names

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -345,12 +345,45 @@ function assignmentFromIdentifier(node: ts.Expression): { name: string; containe
 
 function assignmentFromPropertyAccess(node: ts.Expression): { name: string; containerName: string | null } | null {
   if (ts.isPropertyAccessExpression(node)) {
+    const containerName = dottedAccessName(node.expression);
+    if (!containerName) {
+      return null;
+    }
     return {
       name: node.name.text,
-      containerName: node.expression.getText()
+      containerName
     };
   }
   return null;
+}
+
+function dottedAccessName(node: ts.Expression): string | null {
+  const parts: string[] = [];
+  let current = node;
+  while (ts.isPropertyAccessExpression(current)) {
+    parts.unshift(current.name.text);
+    current = current.expression;
+  }
+  const rootName = dottedAccessRootName(current);
+  if (!rootName) {
+    return null;
+  }
+  parts.unshift(rootName);
+  return parts.join(".");
+}
+
+function dottedAccessRootName(node: ts.Expression): string | null {
+  if (ts.isIdentifier(node)) {
+    return node.text;
+  }
+  switch (node.kind) {
+    case ts.SyntaxKind.ThisKeyword:
+      return "this";
+    case ts.SyntaxKind.SuperKeyword:
+      return "super";
+    default:
+      return null;
+  }
 }
 
 function assignmentFromElementAccess(node: ts.Expression): { name: string; containerName: string | null } | null {

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -566,11 +566,19 @@ registry.format = function (value: string): string {
   return value.toUpperCase();
 };
 
+registry /* comment */ .nested.format = function (value: string): string {
+  return value.trim();
+};
+
 registry["upper"] = function (value: string): string {
   return value ? value.toUpperCase() : value;
 };
 
 (registry as Record<string, unknown>) = function (value: string): string {
+  return value;
+};
+
+(direct + direct).method = function (value: string): string {
   return value;
 };
 
@@ -585,12 +593,17 @@ export function createHandlers() {
       "utf8"
     );
 
-    expect(await parseFileMethods(filePath)).toEqual(expect.arrayContaining([
+    const methods = await parseFileMethods(filePath);
+
+    expect(methods).toEqual(expect.arrayContaining([
       expect.objectContaining({
         displayName: "direct"
       }),
       expect.objectContaining({
         displayName: "registry.format"
+      }),
+      expect.objectContaining({
+        displayName: "registry.nested.format"
       }),
       expect.objectContaining({
         displayName: "registry[\"upper\"]"
@@ -602,5 +615,6 @@ export function createHandlers() {
         displayName: "returned"
       })
     ]));
+    expect(methods.filter((method) => method.displayName === "<assigned>")).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- classify the property-assignment display-name review finding as valid
- build container names from normalized dotted access chains instead of raw source slices
- fall back to the existing `<assigned>` identity for expression-based property targets

## Verification
- `npx vitest run packages/core/test/parser.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #91