### PR TITLE
Report malformed coverage JSON with context

### DIFF
--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -6,7 +6,7 @@ import { ensureCoverageReport, expectedCoveragePath } from "./coverage.js";
 import type { FileCoverage } from "./coverageUnits.js";
 import { calculateCrapScore, maxCrap } from "./crapScore.js";
 import { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots } from "./fileSelection.js";
-import { parseCoverageReport } from "./istanbul.js";
+import { CoverageReportParseError, parseCoverageReport } from "./istanbul.js";
 import { resolveModuleRoot } from "./moduleResolution.js";
 import { parseFileMethods } from "./parser.js";
 import { emptySourceExclusionAudit, filterSourceFiles } from "./sourceExclusions.js";
@@ -173,12 +173,15 @@ async function loadModuleCoverage(
       warnings: []
     };
   } catch (error) {
+    const parseMessage = error instanceof CoverageReportParseError
+      ? error.message
+      : `Coverage report at ${coverageResult.coverageSourcePath} could not be parsed: ${(error as Error).message}`;
     return {
       coverageByFile: new Map<string, FileCoverage>(),
       unknownReason: "unparseable_report",
       warnings: [emitWarning(
         context.stderr,
-        `Warning: Coverage report at ${coverageResult.coverageSourcePath} could not be parsed: ${(error as Error).message}. Coverage will be N/A.`
+        `Warning: ${parseMessage}. Coverage will be N/A.`
       )]
     };
   }

--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -20,11 +20,21 @@ export type { FileCoverage } from "./coverageUnits.js";
 
 type JsonRecord = Record<string, unknown>;
 
+export class CoverageReportParseError extends Error {
+  readonly reportPath: string;
+
+  constructor(reportPath: string, cause: unknown) {
+    super(`Coverage report at ${reportPath} could not be parsed: ${errorMessage(cause)}`);
+    this.name = "CoverageReportParseError";
+    this.reportPath = reportPath;
+  }
+}
+
 export async function parseCoverageReport(
   reportPath: string,
   sourceRoot: string
 ): Promise<Map<string, FileCoverage>> {
-  const raw = JSON.parse(await readFile(reportPath, "utf8")) as unknown;
+  const raw = parseCoverageJson(reportPath, await readFile(reportPath, "utf8"));
   const report = isRecord(raw) ? raw : {};
   const records = new Map<string, FileCoverage>();
 
@@ -39,6 +49,17 @@ export async function parseCoverageReport(
   return records;
 }
 
+function parseCoverageJson(reportPath: string, content: string): unknown {
+  try {
+    return JSON.parse(content) as unknown;
+  } catch (error) {
+    throw new CoverageReportParseError(reportPath, error);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 function parseStatements(statementMapValue: unknown, hitsValue: unknown): StatementCoverageUnit[] {
   if (!isRecord(statementMapValue) || !isRecord(hitsValue)) {

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildCoverageCommand } from "../src/coverage";
-import { coverageForMethods, parseCoverageReport } from "../src/istanbul";
+import { CoverageReportParseError, coverageForMethods, parseCoverageReport } from "../src/istanbul";
 import { parseFileMethods } from "../src/parser";
 import { createTempDir, disposeTempDir, writeProjectFiles } from "./testUtils";
 
@@ -57,6 +57,20 @@ describe("coverage helpers", () => {
     );
     expect(buildCoverageCommand("pnpm", "jest", "C:/tmp", "custom-coverage/coverage-final.json").args).toContain(
       "--coverageDirectory=custom-coverage"
+    );
+  });
+
+  it("throws a path-aware error for malformed coverage JSON", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    const reportPath = path.join(projectRoot, "coverage", "coverage-final.json");
+    await writeProjectFiles(projectRoot, {
+      "coverage/coverage-final.json": "{not-json"
+    });
+
+    await expect(parseCoverageReport(reportPath, projectRoot)).rejects.toThrow(CoverageReportParseError);
+    await expect(parseCoverageReport(reportPath, projectRoot)).rejects.toThrow(
+      `Coverage report at ${reportPath} could not be parsed:`
     );
   });
 


### PR DESCRIPTION
## Summary
- classify the malformed coverage JSON review finding as valid for the exported parser path
- add a typed, path-aware coverage report parse error
- preserve `unparseable_report` analysis behavior while making warnings use the contextual message

## Verification
- `npx vitest run packages/core/test/coverage.test.ts packages/core/test/analysis.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #97