### PR TITLE
Make coverage unknown reason invariant explicit

### DIFF
--- a/packages/core/src/coverageNormalization.ts
+++ b/packages/core/src/coverageNormalization.ts
@@ -62,7 +62,7 @@ function toBranchCoverageMetric(
 
 function combineCoverageMetrics(statementCoverage: CoverageMetric, branchCoverage: CoverageMetric): CoverageMetric {
   if (statementCoverage.status === "unknown" && branchCoverage.status === "unknown") {
-    return unknownCoverageMetric(statementCoverage.unknownReason ?? branchCoverage.unknownReason!);
+    return unknownCoverageMetric(requiredUnknownReason(statementCoverage, branchCoverage));
   }
   return combinedKnownCoverage(statementCoverage, branchCoverage);
 }
@@ -83,7 +83,15 @@ function combinedKnownCoverage(statementCoverage: CoverageMetric, branchCoverage
     };
   }
 
-  return unknownCoverageMetric(statementCoverage.unknownReason ?? branchCoverage.unknownReason!);
+  return unknownCoverageMetric(requiredUnknownReason(statementCoverage, branchCoverage));
+}
+
+function requiredUnknownReason(...metrics: CoverageMetric[]): CoverageUnknownReason {
+  const reason = metrics.find((metric) => metric.status === "unknown")?.unknownReason;
+  if (reason) {
+    return reason;
+  }
+  throw new Error("Expected unknown coverage metric to carry an unknown reason");
 }
 
 function measuredCoverageMetric(percent: number): CoverageMetric {

--- a/packages/core/src/coverageNormalization.ts
+++ b/packages/core/src/coverageNormalization.ts
@@ -87,11 +87,27 @@ function combinedKnownCoverage(statementCoverage: CoverageMetric, branchCoverage
 }
 
 function requiredUnknownReason(...metrics: CoverageMetric[]): CoverageUnknownReason {
-  const reason = metrics.find((metric) => metric.status === "unknown")?.unknownReason;
-  if (reason) {
+  const invalidMetric = metrics.find(isUnknownMetricWithoutReason);
+  if (invalidMetric !== undefined) {
+    throw new Error(`Expected unknown coverage metric to carry an unknown reason: ${formatMetric(invalidMetric)}`);
+  }
+  const reason = firstUnknownReason(metrics);
+  if (reason !== null) {
     return reason;
   }
   throw new Error("Expected unknown coverage metric to carry an unknown reason");
+}
+
+function isUnknownMetricWithoutReason(metric: CoverageMetric): boolean {
+  return metric.status === "unknown" && metric.unknownReason === null;
+}
+
+function firstUnknownReason(metrics: CoverageMetric[]): CoverageUnknownReason | null {
+  return metrics.find((metric) => metric.status === "unknown")?.unknownReason ?? null;
+}
+
+function formatMetric(metric: CoverageMetric): string {
+  return `status=${metric.status}, percent=${metric.percent}, unknownReason=${metric.unknownReason}`;
 }
 
 function measuredCoverageMetric(percent: number): CoverageMetric {


### PR DESCRIPTION
## Summary
- classify the coverage unknown-reason invariant finding as valid
- replace non-null assertions with an explicit invariant helper
- preserve existing coverage metric semantics and outputs

## Verification
- `npx vitest run packages/core/test/coverage.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #99