### PR TITLE
Add context to coverage command failures

### DIFF
--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -79,7 +79,14 @@ async function executeCoverageCommand(command: CoverageCommand, executor: Comman
 }
 
 function formatCoverageCommand(command: CoverageCommand): string {
-  return [command.command, ...command.args].join(" ");
+  return [command.command, ...command.args].map(quoteCommandArgument).join(" ");
+}
+
+function quoteCommandArgument(argument: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(argument)) {
+    return argument;
+  }
+  return `"${argument.replace(/["\\$`]/g, "\\$&")}"`;
 }
 
 function attachCoverageCommand(

--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -72,8 +72,14 @@ function emptyCoverageResolution(): { coverageSourcePath: null; coverageSourceRo
 async function executeCoverageCommand(command: CoverageCommand, executor: CommandExecutor): Promise<void> {
   const exitCode = await executor.execute(command);
   if (exitCode !== 0) {
-    throw new Error(`Coverage command failed with exit ${exitCode}`);
+    throw new Error(
+      `Coverage command failed with exit ${exitCode} for ${command.packageManager}/${command.testRunner} in ${command.cwd}: ${formatCoverageCommand(command)}`
+    );
   }
+}
+
+function formatCoverageCommand(command: CoverageCommand): string {
+  return [command.command, ...command.args].join(" ");
 }
 
 function attachCoverageCommand(

--- a/packages/core/test/coverageCommand.test.ts
+++ b/packages/core/test/coverageCommand.test.ts
@@ -135,6 +135,30 @@ describe("ensureCoverageReport", () => {
       `Coverage command failed with exit 3 for yarn/jest in ${moduleRoot}: yarn jest --coverage --runInBand --coverageReporters=json --coverageReporters=text --coverageDirectory=coverage`
     );
   });
+
+  it("quotes coverage command arguments in failure messages", async () => {
+    const projectRoot = await createTempDir("crap-coverage-command-");
+    tempDirs.push(projectRoot);
+    const moduleRoot = path.join(projectRoot, "packages", "demo");
+
+    await writeProjectFiles(projectRoot, {
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        devDependencies: { jest: "^30.0.0" }
+      }),
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/yarn.lock": ""
+    });
+
+    await expect(
+      ensureCoverageReport(projectRoot, moduleRoot, "auto", "auto", "auto", "custom coverage/coverage-final.json", {
+        execute: vi.fn(async () => 3)
+      })
+    ).rejects.toThrow(
+      `Coverage command failed with exit 3 for yarn/jest in ${moduleRoot}: yarn jest --coverage --runInBand --coverageReporters=json --coverageReporters=text "--coverageDirectory=custom coverage"`
+    );
+  });
 });
 
 describe("expectedCoveragePath", () => {

--- a/packages/core/test/coverageCommand.test.ts
+++ b/packages/core/test/coverageCommand.test.ts
@@ -159,6 +159,34 @@ describe("ensureCoverageReport", () => {
       `Coverage command failed with exit 3 for yarn/jest in ${moduleRoot}: yarn jest --coverage --runInBand --coverageReporters=json --coverageReporters=text "--coverageDirectory=custom coverage"`
     );
   });
+
+  it("escapes special characters in quoted coverage command arguments", async () => {
+    const projectRoot = await createTempDir("crap-coverage-command-");
+    tempDirs.push(projectRoot);
+    const moduleRoot = path.join(projectRoot, "packages", "demo");
+
+    await writeProjectFiles(projectRoot, {
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        devDependencies: { jest: "^30.0.0" }
+      }),
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/yarn.lock": ""
+    });
+
+    await expect(
+      ensureCoverageReport(
+        projectRoot,
+        moduleRoot,
+        "auto",
+        "auto",
+        "auto",
+        'custom "coverage"/cost$dir/back\\slash/tick`dir/coverage-final.json',
+        { execute: vi.fn(async () => 3) }
+      )
+    ).rejects.toThrow('"--coverageDirectory=custom \\"coverage\\"/cost\\$dir/back\\\\slash/tick\\`dir"');
+  });
 });
 
 describe("expectedCoveragePath", () => {

--- a/packages/core/test/coverageCommand.test.ts
+++ b/packages/core/test/coverageCommand.test.ts
@@ -131,7 +131,9 @@ describe("ensureCoverageReport", () => {
       ensureCoverageReport(projectRoot, moduleRoot, "auto", "auto", "auto", undefined, {
         execute: vi.fn(async () => 3)
       })
-    ).rejects.toThrow("Coverage command failed with exit 3");
+    ).rejects.toThrow(
+      `Coverage command failed with exit 3 for yarn/jest in ${moduleRoot}: yarn jest --coverage --runInBand --coverageReporters=json --coverageReporters=text --coverageDirectory=coverage`
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- classify the sparse coverage-command error review finding as valid
- include package manager, test runner, module cwd, and command line in failed coverage command errors
- update the coverage command test to pin the actionable message

## Verification
- `npx vitest run packages/core/test/coverageCommand.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #102