### PR TITLE
Bound command execution time and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For each resolved module today:
 6. Use Istanbul `fnMap` as a validation and secondary matching aid when it is present.
 7. Derive function statement and branch coverage from the Istanbul coverage counters and use their minimum as CRAP coverage.
 
-Commands run by the built-in executor, including coverage commands and changed-file discovery, time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+Commands run by the built-in executor, including coverage commands and changed-file discovery, time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout. Captured stdout and stderr are capped at 10 MiB per stream. User-facing command failures may include truncated output, while internal commands that require complete output, such as `git status --porcelain -z`, fail if the cap is exceeded.
 
 ## Compatibility Matrix
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For each resolved module today:
 6. Use Istanbul `fnMap` as a validation and secondary matching aid when it is present.
 7. Derive function statement and branch coverage from the Istanbul coverage counters and use their minimum as CRAP coverage.
 
-Coverage commands run by the built-in executor time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+Commands run by the built-in executor, including coverage commands and changed-file discovery, time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
 
 ## Compatibility Matrix
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ For each resolved module today:
 6. Use Istanbul `fnMap` as a validation and secondary matching aid when it is present.
 7. Derive function statement and branch coverage from the Istanbul coverage counters and use their minimum as CRAP coverage.
 
+Coverage commands run by the built-in executor time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+
 ## Compatibility Matrix
 
 Verified and unverified coverage-attribution shapes are tracked in [docs/compatibility-matrix.md](docs/compatibility-matrix.md). The matrix is backed by golden fixtures under `tests/fixtures/compatibility-matrix/`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,6 +52,8 @@ Baseline analyzability exclusions always skip declarations, test/spec files, `__
 
 Full primary reports and JUnit sidecars include source-exclusion audit counts when files were excluded. Default agent primary output omits those details.
 
+Coverage commands run by the built-in executor time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+
 The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
 
 ## Exit Codes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,7 +52,7 @@ Baseline analyzability exclusions always skip declarations, test/spec files, `__
 
 Full primary reports and JUnit sidecars include source-exclusion audit counts when files were excluded. Default agent primary output omits those details.
 
-Coverage commands run by the built-in executor time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+Commands run by the built-in executor, including coverage commands and `--changed` discovery, time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
 
 The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,7 +52,7 @@ Baseline analyzability exclusions always skip declarations, test/spec files, `__
 
 Full primary reports and JUnit sidecars include source-exclusion audit counts when files were excluded. Default agent primary output omits those details.
 
-Commands run by the built-in executor, including coverage commands and `--changed` discovery, time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+Commands run by the built-in executor, including coverage commands and `--changed` discovery, time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout. Captured stdout and stderr are capped at 10 MiB per stream. User-facing command failures may include truncated output, while internal commands that require complete output, such as `git status --porcelain -z`, fail if the cap is exceeded.
 
 The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,6 +22,8 @@ Key exports: `analyzeProject`, `calculateCrapScore`, `formatAnalysisReport`, `fo
 
 `analyzeProject` accepts `threshold` to override the default CRAP threshold of `8.0`. Values below `4.0` emit a warning because they are likely too noisy; values above `8.0` emit a warning because they are too lenient even for hard gates.
 
+When the default command executor has to run a coverage command, it times out after 300 seconds. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+
 `analyzeProject` also accepts `excludes`, `excludePathRegexes`, `excludeGeneratedMarkers`, and `useDefaultExclusions`. These filters run after `explicitPaths` or `changedOnly` select candidate files and before parsing, coverage attribution, reporting, and threshold evaluation. Baseline analyzability exclusions always remain active for declarations, test/spec files, `__tests__/`, `dist/`, `coverage/`, and `node_modules/`; `useDefaultExclusions: false` only disables generated-code defaults.
 
 Generated-code defaults exclude directory segments containing `generated`, directory segments exactly named `gen`, common generated filename suffixes such as `*.generated.ts`, `*.gen.ts`, `*Generated.ts`, protobuf outputs, and Angular generated artifacts. Leading generated-header markers are matched only in comments before the first non-comment token.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,7 +22,7 @@ Key exports: `analyzeProject`, `calculateCrapScore`, `formatAnalysisReport`, `fo
 
 `analyzeProject` accepts `threshold` to override the default CRAP threshold of `8.0`. Values below `4.0` emit a warning because they are likely too noisy; values above `8.0` emit a warning because they are too lenient even for hard gates.
 
-Commands run by the default command executor, including coverage commands and changed-file discovery, time out after 300 seconds. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+Commands run by the default command executor, including coverage commands and changed-file discovery, time out after 300 seconds. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout. Captured stdout and stderr are capped at 10 MiB per stream. User-facing command failures may include truncated output, while internal commands that require complete output, such as `git status --porcelain -z`, fail if the cap is exceeded.
 
 `analyzeProject` also accepts `excludes`, `excludePathRegexes`, `excludeGeneratedMarkers`, and `useDefaultExclusions`. These filters run after `explicitPaths` or `changedOnly` select candidate files and before parsing, coverage attribution, reporting, and threshold evaluation. Baseline analyzability exclusions always remain active for declarations, test/spec files, `__tests__/`, `dist/`, `coverage/`, and `node_modules/`; `useDefaultExclusions: false` only disables generated-code defaults.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,7 +22,7 @@ Key exports: `analyzeProject`, `calculateCrapScore`, `formatAnalysisReport`, `fo
 
 `analyzeProject` accepts `threshold` to override the default CRAP threshold of `8.0`. Values below `4.0` emit a warning because they are likely too noisy; values above `8.0` emit a warning because they are too lenient even for hard gates.
 
-When the default command executor has to run a coverage command, it times out after 300 seconds. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
+Commands run by the default command executor, including coverage commands and changed-file discovery, time out after 300 seconds. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout.
 
 `analyzeProject` also accepts `excludes`, `excludePathRegexes`, `excludeGeneratedMarkers`, and `useDefaultExclusions`. These filters run after `explicitPaths` or `changedOnly` select candidate files and before parsing, coverage attribution, reporting, and threshold evaluation. Baseline analyzability exclusions always remain active for declarations, test/spec files, `__tests__/`, `dist/`, `coverage/`, and `node_modules/`; `useDefaultExclusions: false` only disables generated-code defaults.
 

--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { COVERAGE_REPORT_RELATIVE_PATH } from "./constants.js";
 import { locateCoverageReport, resolvePackageManager, resolveTestRunner } from "./moduleResolution.js";
-import { isAbsolutePath } from "./utils.js";
+import { formatCommandForMessage, isAbsolutePath } from "./utils.js";
 import type { CommandExecutor, CoverageMode, CoverageCommand, PackageManager, TestRunner } from "./types.js";
 
 export async function ensureCoverageReport(
@@ -79,14 +79,7 @@ async function executeCoverageCommand(command: CoverageCommand, executor: Comman
 }
 
 function formatCoverageCommand(command: CoverageCommand): string {
-  return [command.command, ...command.args].map(quoteCommandArgument).join(" ");
-}
-
-function quoteCommandArgument(argument: string): string {
-  if (/^[A-Za-z0-9_./:=@+-]+$/.test(argument)) {
-    return argument;
-  }
-  return `"${argument.replace(/["\\$`]/g, "\\$&")}"`;
+  return formatCommandForMessage(command.command, command.args);
 }
 
 function attachCoverageCommand(

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -38,7 +38,9 @@ export async function expandExplicitPaths(
 }
 
 export async function changedTypeScriptFilesUnderSourceRoots(projectRoot: string): Promise<string[]> {
-  const result = await runCommand("git", ["status", "--porcelain", "-z"], projectRoot);
+  const result = await runCommand("git", ["status", "--porcelain", "-z"], projectRoot, {
+    rejectOnTruncatedOutput: true
+  });
   if (result.exitCode !== 0) {
     throw new Error(result.stderr.trim() || "git status --porcelain failed");
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -107,9 +107,16 @@ function createBoundedOutput(maxBufferBytes: number): { append(chunk: Buffer): v
     },
     toString() {
       const output = Buffer.concat(chunks, totalBytes).toString();
-      return truncated ? `${output}\n[output truncated after ${limit} bytes]` : output;
+      return truncated ? appendTruncationMarker(output, limit) : output;
     }
   };
+}
+
+function appendTruncationMarker(output: string, limit: number): string {
+  const marker = `[output truncated after ${limit} bytes]`;
+  return output.length > 0 && !output.endsWith("\n")
+    ? `${output}\n${marker}`
+    : `${output}${marker}`;
 }
 
 export function formatNumber(value: number): string {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -161,7 +161,7 @@ function createBoundedOutput(maxBufferBytes: number): {
   };
 }
 
-function formatCommandForMessage(command: string, args: string[]): string {
+export function formatCommandForMessage(command: string, args: string[]): string {
   return [command, ...args].map(quoteCommandArgument).join(" ");
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -104,25 +104,24 @@ function createBoundedOutput(maxBufferBytes: number): {
   append(chunk: Buffer): void;
   toResult(): { output: string; truncated: boolean };
 } {
-  const chunks: Buffer[] = [];
-  let totalBytes = 0;
-  let truncated = false;
   const limit = Math.max(0, maxBufferBytes);
+  const buffer = Buffer.allocUnsafe(limit);
+  let offset = 0;
+  let truncated = false;
 
   return {
     append(chunk) {
-      const remainingBytes = limit - totalBytes;
+      const remainingBytes = limit - offset;
       if (remainingBytes > 0) {
-        const retainedView = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
-        const retained = Buffer.from(retainedView);
-        chunks.push(retained);
-        totalBytes += retained.byteLength;
+        const bytesToCopy = Math.min(chunk.byteLength, remainingBytes);
+        chunk.copy(buffer, offset, 0, bytesToCopy);
+        offset += bytesToCopy;
       }
       truncated ||= chunk.byteLength > remainingBytes;
     },
     toResult() {
       return {
-        output: Buffer.concat(chunks, totalBytes).toString(),
+        output: buffer.toString("utf8", 0, offset),
         truncated
       };
     }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,12 +5,15 @@ import type { CoverageCommand, Writer } from "./types.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 300_000;
 const DEFAULT_COMMAND_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const COMMAND_TIMEOUT_ENV_VAR = "CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS";
 
 export interface RunCommandOptions {
-  /** Defaults to 300 seconds. */
+  /** Defaults to 300 seconds. Set 0 to disable the timeout. */
   timeoutMs?: number;
   /** Defaults to 10 MiB per stream. */
   maxBufferBytes?: number;
+  /** Reject instead of returning partial stdout/stderr when either stream is truncated. */
+  rejectOnTruncatedOutput?: boolean;
 }
 
 export interface RunCommandResult {
@@ -49,7 +52,7 @@ export async function runCommand(
   options: RunCommandOptions = {}
 ): Promise<RunCommandResult> {
   return new Promise((resolve, reject) => {
-    const timeoutMs = options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+    const timeoutMs = options.timeoutMs ?? defaultCommandTimeoutMs();
     const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_COMMAND_MAX_BUFFER_BYTES;
     const child = spawn(command, args, {
       cwd,
@@ -58,19 +61,21 @@ export async function runCommand(
     const stdout = createBoundedOutput(maxBufferBytes);
     const stderr = createBoundedOutput(maxBufferBytes);
     let settled = false;
-    let timeout: ReturnType<typeof setTimeout>;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const rejectOnce = (error: Error) => {
       if (settled) {
         return;
       }
       settled = true;
-      clearTimeout(timeout);
+      clearCommandTimeout(timeout);
       reject(error);
     };
-    timeout = setTimeout(() => {
-      child.kill("SIGKILL");
-      rejectOnce(new Error(`Command timed out after ${timeoutMs}ms: ${formatCommandForMessage(command, args)}`));
-    }, timeoutMs);
+    if (timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        child.kill("SIGKILL");
+        rejectOnce(new Error(`Command timed out after ${timeoutMs}ms: ${formatCommandForMessage(command, args)}`));
+      }, timeoutMs);
+    }
 
     child.stdout.on("data", (chunk) => {
       stdout.append(chunk);
@@ -85,10 +90,16 @@ export async function runCommand(
       if (settled) {
         return;
       }
-      settled = true;
-      clearTimeout(timeout);
       const stdoutResult = stdout.toResult();
       const stderrResult = stderr.toResult();
+      if (options.rejectOnTruncatedOutput && (stdoutResult.truncated || stderrResult.truncated)) {
+        rejectOnce(new Error(
+          `Command output exceeded ${maxBufferBytes} bytes: ${formatCommandForMessage(command, args)}`
+        ));
+        return;
+      }
+      settled = true;
+      clearCommandTimeout(timeout);
       resolve({
         exitCode: exitCode ?? 1,
         stdout: stdoutResult.output,
@@ -98,6 +109,21 @@ export async function runCommand(
       });
     });
   });
+}
+
+function defaultCommandTimeoutMs(): number {
+  const configured = process.env[COMMAND_TIMEOUT_ENV_VAR]?.trim();
+  if (configured === undefined || configured === "") {
+    return DEFAULT_COMMAND_TIMEOUT_MS;
+  }
+  const parsed = Number(configured);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_COMMAND_TIMEOUT_MS;
+}
+
+function clearCommandTimeout(timeout: ReturnType<typeof setTimeout> | undefined): void {
+  if (timeout !== undefined) {
+    clearTimeout(timeout);
+  }
 }
 
 function createBoundedOutput(maxBufferBytes: number): {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -49,11 +49,19 @@ export async function runCommand(
     });
     const stdout = createBoundedOutput(maxBufferBytes);
     const stderr = createBoundedOutput(maxBufferBytes);
-    let timedOut = false;
     let settled = false;
-    const timeout = setTimeout(() => {
-      timedOut = true;
+    let timeout: ReturnType<typeof setTimeout>;
+    const rejectOnce = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    };
+    timeout = setTimeout(() => {
       child.kill("SIGKILL");
+      rejectOnce(new Error(`Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`));
     }, timeoutMs);
 
     child.stdout.on("data", (chunk) => {
@@ -63,12 +71,7 @@ export async function runCommand(
       stderr.append(chunk);
     });
     child.on("error", (error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      reject(error);
+      rejectOnce(error);
     });
     child.on("close", (exitCode) => {
       if (settled) {
@@ -76,10 +79,6 @@ export async function runCommand(
       }
       settled = true;
       clearTimeout(timeout);
-      if (timedOut) {
-        reject(new Error(`Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`));
-        return;
-      }
       resolve({
         exitCode: exitCode ?? 1,
         stdout: stdout.toString(),
@@ -99,7 +98,8 @@ function createBoundedOutput(maxBufferBytes: number): { append(chunk: Buffer): v
     append(chunk) {
       const remainingBytes = limit - totalBytes;
       if (remainingBytes > 0) {
-        const retained = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
+        const retainedView = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
+        const retained = Buffer.from(retainedView);
         chunks.push(retained);
         totalBytes += retained.byteLength;
       }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -52,8 +52,8 @@ export async function runCommand(
   options: RunCommandOptions = {}
 ): Promise<RunCommandResult> {
   return new Promise((resolve, reject) => {
-    const timeoutMs = options.timeoutMs ?? defaultCommandTimeoutMs();
-    const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_COMMAND_MAX_BUFFER_BYTES;
+    const timeoutMs = normalizeNonNegativeOption(options.timeoutMs, defaultCommandTimeoutMs());
+    const maxBufferBytes = normalizeNonNegativeOption(options.maxBufferBytes, DEFAULT_COMMAND_MAX_BUFFER_BYTES);
     const child = spawn(command, args, {
       cwd,
       stdio: ["ignore", "pipe", "pipe"]
@@ -118,6 +118,13 @@ function defaultCommandTimeoutMs(): number {
   }
   const parsed = Number(configured);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_COMMAND_TIMEOUT_MS;
+}
+
+function normalizeNonNegativeOption(value: number | undefined, defaultValue: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return defaultValue;
+  }
+  return Math.max(0, value);
 }
 
 function clearCommandTimeout(timeout: ReturnType<typeof setTimeout> | undefined): void {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -3,6 +3,16 @@ import { spawn } from "node:child_process";
 
 import type { CoverageCommand, Writer } from "./types.js";
 
+const DEFAULT_COMMAND_TIMEOUT_MS = 300_000;
+const DEFAULT_COMMAND_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+export interface RunCommandOptions {
+  /** Defaults to 300 seconds. */
+  timeoutMs?: number;
+  /** Defaults to 10 MiB per stream. */
+  maxBufferBytes?: number;
+}
+
 export function writeLine(writer: Writer | undefined, message: string): void {
   writer?.write(`${message}\n`);
 }
@@ -27,31 +37,79 @@ export function toRelativePath(projectRoot: string, filePath: string): string {
 export async function runCommand(
   command: string,
   args: string[],
-  cwd: string
+  cwd: string,
+  options: RunCommandOptions = {}
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+    const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_COMMAND_MAX_BUFFER_BYTES;
     const child = spawn(command, args, {
       cwd,
       stdio: ["ignore", "pipe", "pipe"]
     });
-    let stdout = "";
-    let stderr = "";
+    const stdout = createBoundedOutput(maxBufferBytes);
+    const stderr = createBoundedOutput(maxBufferBytes);
+    let timedOut = false;
+    let settled = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
 
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
+      stdout.append(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
+      stderr.append(chunk);
     });
-    child.on("error", reject);
+    child.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
     child.on("close", (exitCode) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (timedOut) {
+        reject(new Error(`Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`));
+        return;
+      }
       resolve({
         exitCode: exitCode ?? 1,
-        stdout,
-        stderr
+        stdout: stdout.toString(),
+        stderr: stderr.toString()
       });
     });
   });
+}
+
+function createBoundedOutput(maxBufferBytes: number): { append(chunk: Buffer): void; toString(): string } {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let truncated = false;
+  const limit = Math.max(0, maxBufferBytes);
+
+  return {
+    append(chunk) {
+      const remainingBytes = limit - totalBytes;
+      if (remainingBytes > 0) {
+        const retained = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
+        chunks.push(retained);
+        totalBytes += retained.byteLength;
+      }
+      truncated ||= chunk.byteLength > remainingBytes;
+    },
+    toString() {
+      const output = Buffer.concat(chunks, totalBytes).toString();
+      return truncated ? `${output}\n[output truncated after ${limit} bytes]` : output;
+    }
+  };
 }
 
 export function formatNumber(value: number): string {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -13,6 +13,14 @@ export interface RunCommandOptions {
   maxBufferBytes?: number;
 }
 
+export interface RunCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+}
+
 export function writeLine(writer: Writer | undefined, message: string): void {
   writer?.write(`${message}\n`);
 }
@@ -39,7 +47,7 @@ export async function runCommand(
   args: string[],
   cwd: string,
   options: RunCommandOptions = {}
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+): Promise<RunCommandResult> {
   return new Promise((resolve, reject) => {
     const timeoutMs = options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
     const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_COMMAND_MAX_BUFFER_BYTES;
@@ -61,7 +69,7 @@ export async function runCommand(
     };
     timeout = setTimeout(() => {
       child.kill("SIGKILL");
-      rejectOnce(new Error(`Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`));
+      rejectOnce(new Error(`Command timed out after ${timeoutMs}ms: ${formatCommandForMessage(command, args)}`));
     }, timeoutMs);
 
     child.stdout.on("data", (chunk) => {
@@ -79,16 +87,23 @@ export async function runCommand(
       }
       settled = true;
       clearTimeout(timeout);
+      const stdoutResult = stdout.toResult();
+      const stderrResult = stderr.toResult();
       resolve({
         exitCode: exitCode ?? 1,
-        stdout: stdout.toString(),
-        stderr: stderr.toString()
+        stdout: stdoutResult.output,
+        stderr: stderrResult.output,
+        stdoutTruncated: stdoutResult.truncated,
+        stderrTruncated: stderrResult.truncated
       });
     });
   });
 }
 
-function createBoundedOutput(maxBufferBytes: number): { append(chunk: Buffer): void; toString(): string } {
+function createBoundedOutput(maxBufferBytes: number): {
+  append(chunk: Buffer): void;
+  toResult(): { output: string; truncated: boolean };
+} {
   const chunks: Buffer[] = [];
   let totalBytes = 0;
   let truncated = false;
@@ -105,18 +120,24 @@ function createBoundedOutput(maxBufferBytes: number): { append(chunk: Buffer): v
       }
       truncated ||= chunk.byteLength > remainingBytes;
     },
-    toString() {
-      const output = Buffer.concat(chunks, totalBytes).toString();
-      return truncated ? appendTruncationMarker(output, limit) : output;
+    toResult() {
+      return {
+        output: Buffer.concat(chunks, totalBytes).toString(),
+        truncated
+      };
     }
   };
 }
 
-function appendTruncationMarker(output: string, limit: number): string {
-  const marker = `[output truncated after ${limit} bytes]`;
-  return output.length > 0 && !output.endsWith("\n")
-    ? `${output}\n${marker}`
-    : `${output}${marker}`;
+function formatCommandForMessage(command: string, args: string[]): string {
+  return [command, ...args].map(quoteCommandArgument).join(" ");
+}
+
+function quoteCommandArgument(argument: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(argument)) {
+    return argument;
+  }
+  return `"${argument.replace(/(["\\$`])/g, "\\$1")}"`;
 }
 
 export function formatNumber(value: number): string {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -138,23 +138,23 @@ function createBoundedOutput(maxBufferBytes: number): {
   toResult(): { output: string; truncated: boolean };
 } {
   const limit = Math.max(0, maxBufferBytes);
-  const buffer = Buffer.allocUnsafe(limit);
-  let offset = 0;
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
   let truncated = false;
 
   return {
     append(chunk) {
-      const remainingBytes = limit - offset;
+      const remainingBytes = limit - byteLength;
       if (remainingBytes > 0) {
         const bytesToCopy = Math.min(chunk.byteLength, remainingBytes);
-        chunk.copy(buffer, offset, 0, bytesToCopy);
-        offset += bytesToCopy;
+        chunks.push(Buffer.from(chunk.subarray(0, bytesToCopy)));
+        byteLength += bytesToCopy;
       }
       truncated ||= chunk.byteLength > remainingBytes;
     },
     toResult() {
       return {
-        output: buffer.toString("utf8", 0, offset),
+        output: chunks.length > 0 ? Buffer.concat(chunks, byteLength).toString("utf8") : "",
         truncated
       };
     }

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   changedTypeScriptFilesUnderSourceRoots,
@@ -14,6 +14,8 @@ import { createTempDir, disposeTempDir, initGitRepository, runProcess, writeProj
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.doUnmock("../src/utils");
+  vi.resetModules();
   await Promise.all(tempDirs.splice(0).map(disposeTempDir));
 });
 
@@ -194,5 +196,25 @@ describe("file selection", () => {
     const nonRepoDir = await createTempDir("crap-files-nonrepo-");
     tempDirs.push(nonRepoDir);
     await expect(changedTypeScriptFilesUnderSourceRoots(nonRepoDir)).rejects.toThrow("not a git repository");
+  });
+
+  it("requires complete git status output for changed-file parsing", async () => {
+    vi.resetModules();
+    const runCommand = vi.fn(async () => {
+      throw new Error("Command output exceeded 1 bytes: git status --porcelain -z");
+    });
+    vi.doMock("../src/utils", async () => {
+      const actual = await vi.importActual<typeof import("../src/utils")>("../src/utils");
+      return {
+        ...actual,
+        runCommand
+      };
+    });
+    const { changedTypeScriptFilesUnderSourceRoots: changedFiles } = await import("../src/fileSelection");
+
+    await expect(changedFiles("repo")).rejects.toThrow("Command output exceeded 1 bytes");
+    expect(runCommand).toHaveBeenCalledWith("git", ["status", "--porcelain", "-z"], "repo", {
+      rejectOnTruncatedOutput: true
+    });
   });
 });

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -8,6 +8,7 @@ import { runCommand } from "../src/utils";
 afterEach(() => {
   vi.doUnmock("node:child_process");
   vi.resetModules();
+  vi.unstubAllEnvs();
 });
 
 describe("runCommand", () => {
@@ -41,6 +42,31 @@ describe("runCommand", () => {
     expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 
+  it("uses the configured default timeout from the environment", async () => {
+    vi.resetModules();
+    vi.stubEnv("CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS", "1");
+    const kill = vi.fn();
+    vi.doMock("node:child_process", () => ({
+      spawn: vi.fn(() => {
+        const child = new EventEmitter() as EventEmitter & {
+          stdout: PassThrough;
+          stderr: PassThrough;
+          kill: (signal: string) => boolean;
+        };
+        child.stdout = new PassThrough();
+        child.stderr = new PassThrough();
+        child.kill = kill.mockReturnValue(true);
+        return child;
+      })
+    }));
+    const { runCommand: runMockedCommand } = await import("../src/utils");
+
+    await expect(runMockedCommand("never-closes", [], process.cwd())).rejects.toThrow(
+      "Command timed out after 1ms: never-closes"
+    );
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
   it("bounds captured stdout and stderr", async () => {
     const result = await runCommand(
       process.execPath,
@@ -53,6 +79,17 @@ describe("runCommand", () => {
     expect(result.stderr).toBe("uvw");
     expect(result.stdoutTruncated).toBe(true);
     expect(result.stderrTruncated).toBe(true);
+  });
+
+  it("rejects when truncated output is not allowed", async () => {
+    await expect(
+      runCommand(
+        process.execPath,
+        ["-e", "process.stdout.write('abcdef')"],
+        process.cwd(),
+        { maxBufferBytes: 3, rejectOnTruncatedOutput: true }
+      )
+    ).rejects.toThrow("Command output exceeded 3 bytes:");
   });
 
   it("returns raw bounded output without mutation when truncated", async () => {

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -55,7 +55,7 @@ describe("runCommand", () => {
     expect(result.stderrTruncated).toBe(true);
   });
 
-  it("does not mutate bounded output with truncation markers", async () => {
+  it("returns raw bounded output without mutation when truncated", async () => {
     const emptyResult = await runCommand(
       process.execPath,
       ["-e", "process.stdout.write('abc')"],

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { runCommand } from "../src/utils";
+
+describe("runCommand", () => {
+  it("rejects when the command exceeds the timeout", async () => {
+    await expect(
+      runCommand(process.execPath, ["-e", "setTimeout(() => {}, 1000)"], process.cwd(), { timeoutMs: 50 })
+    ).rejects.toThrow("Command timed out after 50ms");
+  });
+
+  it("bounds captured stdout and stderr", async () => {
+    const result = await runCommand(
+      process.execPath,
+      ["-e", "process.stdout.write('abcdef'); process.stderr.write('uvwxyz')"],
+      process.cwd(),
+      { maxBufferBytes: 3 }
+    );
+
+    expect(result.stdout).toBe("abc\n[output truncated after 3 bytes]");
+    expect(result.stderr).toBe("uvw\n[output truncated after 3 bytes]");
+  });
+});

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -35,9 +35,9 @@ describe("runCommand", () => {
     }));
     const { runCommand: runMockedCommand } = await import("../src/utils");
 
-    await expect(runMockedCommand("never-closes", [], process.cwd(), { timeoutMs: 1 })).rejects.toThrow(
-      "Command timed out after 1ms"
-    );
+    await expect(
+      runMockedCommand("never-closes", ["arg with space", 'quoted"value'], process.cwd(), { timeoutMs: 1 })
+    ).rejects.toThrow('Command timed out after 1ms: never-closes "arg with space" "quoted\\"value"');
     expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 
@@ -49,11 +49,13 @@ describe("runCommand", () => {
       { maxBufferBytes: 3 }
     );
 
-    expect(result.stdout).toBe("abc\n[output truncated after 3 bytes]");
-    expect(result.stderr).toBe("uvw\n[output truncated after 3 bytes]");
+    expect(result.stdout).toBe("abc");
+    expect(result.stderr).toBe("uvw");
+    expect(result.stdoutTruncated).toBe(true);
+    expect(result.stderrTruncated).toBe(true);
   });
 
-  it("formats truncation markers without extra blank lines", async () => {
+  it("does not mutate bounded output with truncation markers", async () => {
     const emptyResult = await runCommand(
       process.execPath,
       ["-e", "process.stdout.write('abc')"],
@@ -67,7 +69,9 @@ describe("runCommand", () => {
       { maxBufferBytes: 4 }
     );
 
-    expect(emptyResult.stdout).toBe("[output truncated after 0 bytes]");
-    expect(newlineResult.stdout).toBe("abc\n[output truncated after 4 bytes]");
+    expect(emptyResult.stdout).toBe("");
+    expect(emptyResult.stdoutTruncated).toBe(true);
+    expect(newlineResult.stdout).toBe("abc\n");
+    expect(newlineResult.stdoutTruncated).toBe(true);
   });
 });

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -52,4 +52,22 @@ describe("runCommand", () => {
     expect(result.stdout).toBe("abc\n[output truncated after 3 bytes]");
     expect(result.stderr).toBe("uvw\n[output truncated after 3 bytes]");
   });
+
+  it("formats truncation markers without extra blank lines", async () => {
+    const emptyResult = await runCommand(
+      process.execPath,
+      ["-e", "process.stdout.write('abc')"],
+      process.cwd(),
+      { maxBufferBytes: 0 }
+    );
+    const newlineResult = await runCommand(
+      process.execPath,
+      ["-e", "process.stdout.write('abc\\ndef')"],
+      process.cwd(),
+      { maxBufferBytes: 4 }
+    );
+
+    expect(emptyResult.stdout).toBe("[output truncated after 0 bytes]");
+    expect(newlineResult.stdout).toBe("abc\n[output truncated after 4 bytes]");
+  });
 });

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -1,12 +1,44 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { runCommand } from "../src/utils";
+
+afterEach(() => {
+  vi.doUnmock("node:child_process");
+  vi.resetModules();
+});
 
 describe("runCommand", () => {
   it("rejects when the command exceeds the timeout", async () => {
     await expect(
       runCommand(process.execPath, ["-e", "setTimeout(() => {}, 1000)"], process.cwd(), { timeoutMs: 50 })
     ).rejects.toThrow("Command timed out after 50ms");
+  });
+
+  it("rejects on timeout even when the child process does not close", async () => {
+    vi.resetModules();
+    const kill = vi.fn();
+    vi.doMock("node:child_process", () => ({
+      spawn: vi.fn(() => {
+        const child = new EventEmitter() as EventEmitter & {
+          stdout: PassThrough;
+          stderr: PassThrough;
+          kill: (signal: string) => boolean;
+        };
+        child.stdout = new PassThrough();
+        child.stderr = new PassThrough();
+        child.kill = kill.mockReturnValue(true);
+        return child;
+      })
+    }));
+    const { runCommand: runMockedCommand } = await import("../src/utils");
+
+    await expect(runMockedCommand("never-closes", [], process.cwd(), { timeoutMs: 1 })).rejects.toThrow(
+      "Command timed out after 1ms"
+    );
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 
   it("bounds captured stdout and stderr", async () => {

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -92,6 +92,17 @@ describe("runCommand", () => {
     ).rejects.toThrow("Command output exceeded 3 bytes:");
   });
 
+  it("normalizes negative command buffer limits before diagnostics", async () => {
+    await expect(
+      runCommand(
+        process.execPath,
+        ["-e", "process.stdout.write('x')"],
+        process.cwd(),
+        { maxBufferBytes: -1, rejectOnTruncatedOutput: true }
+      )
+    ).rejects.toThrow("Command output exceeded 0 bytes:");
+  });
+
   it("returns raw bounded output without mutation when truncated", async () => {
     const emptyResult = await runCommand(
       process.execPath,


### PR DESCRIPTION
## Summary
- classify the unbounded subprocess review finding as valid
- add a default 300s timeout to spawned commands
- cap captured stdout/stderr at 10 MiB per stream and mark truncated output
- cover timeout and buffer truncation behavior in utility tests

## Verification
- `npx vitest run packages/core/test/utils.test.ts packages/core/test/fileSelection.test.ts packages/core/test/coverageCommand.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #105