### PR TITLE
Match excluded path segments at root

### DIFF
--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -57,7 +57,7 @@ export function isAnalyzableFile(filePath: string): boolean {
   if (containsAny(baseName, TEST_FILE_MARKERS)) {
     return false;
   }
-  if (containsAny(normalized, EXCLUDED_PATH_SEGMENTS)) {
+  if (containsAny(`/${normalized}`, EXCLUDED_PATH_SEGMENTS)) {
     return false;
   }
   return true;

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -159,6 +159,9 @@ describe("file selection", () => {
     expect(isAnalyzableFile("C:/repo/dist/app.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/coverage/app.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/node_modules/pkg/index.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/dist/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/coverage/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/node_modules/pkg/index.ts")).toBe(false);
   });
 
   it("ignores deleted and non-source changes and reports git errors clearly", async () => {

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -159,9 +159,14 @@ describe("file selection", () => {
     expect(isAnalyzableFile("C:/repo/dist/app.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/coverage/app.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/node_modules/pkg/index.ts")).toBe(false);
-    expect(isAnalyzableFile("C:/dist/app.ts")).toBe(false);
-    expect(isAnalyzableFile("C:/coverage/app.ts")).toBe(false);
-    expect(isAnalyzableFile("C:/node_modules/pkg/index.ts")).toBe(false);
+    expect(isAnalyzableFile("dist/app.ts")).toBe(false);
+    expect(isAnalyzableFile("coverage/app.ts")).toBe(false);
+    expect(isAnalyzableFile("node_modules/pkg/index.ts")).toBe(false);
+
+    const filesystemRoot = path.parse(process.cwd()).root;
+    expect(isAnalyzableFile(path.join(filesystemRoot, "dist", "app.ts"))).toBe(false);
+    expect(isAnalyzableFile(path.join(filesystemRoot, "coverage", "app.ts"))).toBe(false);
+    expect(isAnalyzableFile(path.join(filesystemRoot, "node_modules", "pkg", "index.ts"))).toBe(false);
   });
 
   it("ignores deleted and non-source changes and reports git errors clearly", async () => {


### PR DESCRIPTION
## Summary
- classify the root-level excluded-directory review finding as valid
- apply excluded path-segment matching with a leading slash so root segments match too
- add direct `dist`, `coverage`, and `node_modules` root-level assertions

## Verification
- `npx vitest run packages/core/test/fileSelection.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #104