### PR TITLE
Report malformed package manifests with context

### DIFF
--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -142,7 +142,16 @@ async function readPackageJson(root: string): Promise<PackageJsonShape | null> {
     return null;
   }
   const raw = await readFile(packageJsonPath, "utf8");
-  return JSON.parse(raw) as PackageJsonShape;
+  return parsePackageJson(packageJsonPath, raw);
+}
+
+function parsePackageJson(packageJsonPath: string, content: string): PackageJsonShape {
+  try {
+    return JSON.parse(content) as PackageJsonShape;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Package manifest at ${packageJsonPath} could not be parsed: ${message}`);
+  }
 }
 
 async function exists(filePath: string): Promise<boolean> {

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -159,6 +159,18 @@ describe("resolveTestRunner", () => {
     );
   });
 
+  it("reports malformed package.json files with their path", async () => {
+    const tempDir = await createTempDir("crap-runner-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": "{not-json"
+    });
+
+    await expect(resolveTestRunner("auto", tempDir, tempDir)).rejects.toThrow(
+      `Package manifest at ${path.join(tempDir, "package.json")} could not be parsed:`
+    );
+  });
+
   it("prefers module scripts, detects runners from peer dependencies, and skips missing package.json files", async () => {
     const tempDir = await createTempDir("crap-runner-");
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary
- classify the malformed package.json review finding as valid
- wrap package manifest JSON parsing with a path-aware error message
- add a module-resolution test for malformed manifests

## Verification
- `npx vitest run packages/core/test/moduleResolution.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #107