### PR TITLE
Avoid runner detection false positives

### DIFF
--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -97,7 +97,20 @@ const PACKAGE_MANAGER_LOCKFILES: [PackageManager, string[]][] = [
   ["yarn", ["yarn.lock"]],
   ["npm", ["package-lock.json", "npm-shrinkwrap.json"]]
 ];
-const SCRIPT_COMMAND_WRAPPERS = new Set(["npx", "pnpm", "yarn", "bun", "node", "node.exe"]);
+const SCRIPT_COMMAND_WRAPPERS = new Set(["npx", "pnpm", "yarn", "bun", "node"]);
+const PACKAGE_MANAGER_RUN_SUBCOMMANDS = new Set(["exec", "run"]);
+const NPM_RUN_SUBCOMMANDS = new Set(["exec", "x"]);
+const WRAPPER_OPTIONS_WITH_VALUE = new Set([
+  "-c",
+  "-p",
+  "--call",
+  "--cwd",
+  "--dir",
+  "--filter",
+  "--package",
+  "--shell",
+  "--workspace"
+]);
 
 async function detectTestRunnerAtRoot(root: string): Promise<TestRunner | null> {
   const packageJson = await readPackageJson(root);
@@ -179,11 +192,43 @@ function runnerTokenIndex(tokens: string[], commandIndex: number): number {
   if (commandName === "npm") {
     return npmRunnerTokenIndex(tokens, commandIndex);
   }
-  return SCRIPT_COMMAND_WRAPPERS.has(commandName) ? commandIndex + 1 : commandIndex;
+  if (commandName === "pnpm" || commandName === "yarn") {
+    return packageManagerRunnerTokenIndex(tokens, commandIndex);
+  }
+  return SCRIPT_COMMAND_WRAPPERS.has(commandName)
+    ? skipWrapperOptions(tokens, commandIndex + 1)
+    : commandIndex;
 }
 
 function npmRunnerTokenIndex(tokens: string[], commandIndex: number): number {
-  return ["exec", "x"].includes(tokens[commandIndex + 1] ?? "") ? commandIndex + 2 : commandIndex;
+  const subcommandIndex = skipWrapperOptions(tokens, commandIndex + 1);
+  return NPM_RUN_SUBCOMMANDS.has(tokens[subcommandIndex] ?? "")
+    ? skipWrapperOptions(tokens, subcommandIndex + 1)
+    : commandIndex;
+}
+
+function packageManagerRunnerTokenIndex(tokens: string[], commandIndex: number): number {
+  const runnerIndex = skipWrapperOptions(tokens, commandIndex + 1);
+  const subcommand = tokens[runnerIndex] ?? "";
+  return PACKAGE_MANAGER_RUN_SUBCOMMANDS.has(subcommand)
+    ? skipWrapperOptions(tokens, runnerIndex + 1)
+    : runnerIndex;
+}
+
+function skipWrapperOptions(tokens: string[], startIndex: number): number {
+  let index = startIndex;
+  while (isSkippableWrapperToken(tokens[index])) {
+    index += optionWidth(tokens[index]);
+  }
+  return index;
+}
+
+function isSkippableWrapperToken(token: string | undefined): token is string {
+  return token === "--" || token?.startsWith("-") === true;
+}
+
+function optionWidth(token: string): number {
+  return WRAPPER_OPTIONS_WITH_VALUE.has(token) ? 2 : 1;
 }
 
 function firstCommandTokenIndex(tokens: string[]): number | null {

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -196,7 +196,14 @@ function resolveScriptExecutableName(tokens: string[]): string | null {
   if (commandIndex === null) {
     return null;
   }
-  return executableBaseName(tokens[runnerTokenIndex(tokens, commandIndex)]);
+  return executableNameFromRunnerToken(tokens[runnerTokenIndex(tokens, commandIndex)]);
+}
+
+function executableNameFromRunnerToken(token: string | undefined): string {
+  const commandToken = token?.includes(" ") === true
+    ? tokenizeShellWords(token)[0]
+    : token;
+  return executableBaseName(commandToken);
 }
 
 function runnerTokenIndex(tokens: string[], commandIndex: number): number {

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -97,6 +97,8 @@ const PACKAGE_MANAGER_LOCKFILES: [PackageManager, string[]][] = [
   ["yarn", ["yarn.lock"]],
   ["npm", ["package-lock.json", "npm-shrinkwrap.json"]]
 ];
+const VITEST_SCRIPT_COMMAND = /(?:^|[\s;&|()])vitest(?=$|[\s;&|()])/;
+const JEST_SCRIPT_COMMAND = /(?:^|[\s;&|()])jest(?=$|[\s;&|()])/;
 
 async function detectTestRunnerAtRoot(root: string): Promise<TestRunner | null> {
   const packageJson = await readPackageJson(root);
@@ -116,24 +118,36 @@ interface PackageJsonShape {
 }
 
 function detectRunnerFromScripts(scripts: Record<string, string>): TestRunner | null {
-  return detectSingleRunner(Object.values(scripts).join("\n"));
+  return detectSingleRunner(Object.values(scripts), matchesScriptRunner);
 }
 
 function detectRunnerFromDependencies(packageJson: PackageJsonShape): TestRunner | null {
   const dependencyFields = [packageJson.dependencies, packageJson.devDependencies, packageJson.peerDependencies];
-  const dependencyNames = dependencyFields
-    .flatMap((field) => field ? Object.keys(field) : [])
-    .join("\n");
-  return detectSingleRunner(dependencyNames);
+  return detectSingleRunner(
+    dependencyFields.flatMap((field) => field ? Object.keys(field) : []),
+    matchesDependencyRunner
+  );
 }
 
-function detectSingleRunner(text: string): TestRunner | null {
-  const hasVitest = /\bvitest\b/.test(text);
-  const hasJest = /\bjest\b/.test(text) || /\bts-jest\b/.test(text);
+function detectSingleRunner(candidates: string[], matcher: (candidate: string, runner: TestRunner) => boolean): TestRunner | null {
+  const hasVitest = candidates.some((candidate) => matcher(candidate, "vitest"));
+  const hasJest = candidates.some((candidate) => matcher(candidate, "jest"));
   if (hasVitest === hasJest) {
     return null;
   }
   return hasVitest ? "vitest" : "jest";
+}
+
+function matchesScriptRunner(script: string, runner: TestRunner): boolean {
+  return runner === "vitest"
+    ? VITEST_SCRIPT_COMMAND.test(script)
+    : JEST_SCRIPT_COMMAND.test(script);
+}
+
+function matchesDependencyRunner(dependencyName: string, runner: TestRunner): boolean {
+  return runner === "vitest"
+    ? dependencyName === "vitest"
+    : dependencyName === "jest" || dependencyName === "ts-jest";
 }
 
 async function readPackageJson(root: string): Promise<PackageJsonShape | null> {

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -97,8 +97,7 @@ const PACKAGE_MANAGER_LOCKFILES: [PackageManager, string[]][] = [
   ["yarn", ["yarn.lock"]],
   ["npm", ["package-lock.json", "npm-shrinkwrap.json"]]
 ];
-const VITEST_SCRIPT_COMMAND = /(?:^|[\s;&|()])vitest(?=$|[\s;&|()])/;
-const JEST_SCRIPT_COMMAND = /(?:^|[\s;&|()])jest(?=$|[\s;&|()])/;
+const SCRIPT_COMMAND_WRAPPERS = new Set(["npx", "pnpm", "yarn", "bun", "node", "node.exe"]);
 
 async function detectTestRunnerAtRoot(root: string): Promise<TestRunner | null> {
   const packageJson = await readPackageJson(root);
@@ -139,15 +138,65 @@ function detectSingleRunner(candidates: string[], matcher: (candidate: string, r
 }
 
 function matchesScriptRunner(script: string, runner: TestRunner): boolean {
-  return runner === "vitest"
-    ? VITEST_SCRIPT_COMMAND.test(script)
-    : JEST_SCRIPT_COMMAND.test(script);
+  return scriptExecutableNames(script).some((executableName) => executableName === runner);
 }
 
 function matchesDependencyRunner(dependencyName: string, runner: TestRunner): boolean {
   return runner === "vitest"
     ? dependencyName === "vitest"
     : dependencyName === "jest" || dependencyName === "ts-jest";
+}
+
+function scriptExecutableNames(script: string): string[] {
+  return splitShellCommandSegments(script)
+    .map(tokenizeShellWords)
+    .map(resolveScriptExecutableName)
+    .filter((name): name is string => name !== null);
+}
+
+function splitShellCommandSegments(script: string): string[] {
+  return script.split(/&&|\|\||[;|]/).map((segment) => segment.trim()).filter(Boolean);
+}
+
+function tokenizeShellWords(segment: string): string[] {
+  return segment.match(/"[^"]*"|'[^']*'|[^\s]+/g)?.map(unquoteShellWord) ?? [];
+}
+
+function unquoteShellWord(token: string): string {
+  return token.replace(/^(['"])(.*)\1$/, "$2");
+}
+
+function resolveScriptExecutableName(tokens: string[]): string | null {
+  const commandIndex = firstCommandTokenIndex(tokens);
+  if (commandIndex === null) {
+    return null;
+  }
+  return executableBaseName(tokens[runnerTokenIndex(tokens, commandIndex)]);
+}
+
+function runnerTokenIndex(tokens: string[], commandIndex: number): number {
+  const commandName = executableBaseName(tokens[commandIndex]);
+  if (commandName === "npm") {
+    return npmRunnerTokenIndex(tokens, commandIndex);
+  }
+  return SCRIPT_COMMAND_WRAPPERS.has(commandName) ? commandIndex + 1 : commandIndex;
+}
+
+function npmRunnerTokenIndex(tokens: string[], commandIndex: number): number {
+  return ["exec", "x"].includes(tokens[commandIndex + 1] ?? "") ? commandIndex + 2 : commandIndex;
+}
+
+function firstCommandTokenIndex(tokens: string[]): number | null {
+  const index = tokens.findIndex((token) => !isEnvironmentAssignment(token));
+  return index === -1 ? null : index;
+}
+
+function isEnvironmentAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+function executableBaseName(token: string | undefined): string {
+  return path.basename(token?.replace(/\\/g, "/") ?? "").replace(/\.(?:cmd|ps1|bat|exe)$/i, "");
 }
 
 async function readPackageJson(root: string): Promise<PackageJsonShape | null> {

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -116,6 +116,8 @@ const WRAPPER_OPTIONS_WITH_VALUE = new Set([
   "--shell",
   "--workspace"
 ]);
+const SHELL_TOKEN_PATTERN = /(?:[^\s'"]+|"[^"]*"|'[^']*')+/g;
+const QUOTED_SHELL_TOKEN_PART_PATTERN = /"([^"]*)"|'([^']*)'/g;
 
 async function detectTestRunnerAtRoot(root: string): Promise<TestRunner | null> {
   const packageJson = await readPackageJson(root);
@@ -177,11 +179,14 @@ function splitShellCommandSegments(script: string): string[] {
 }
 
 function tokenizeShellWords(segment: string): string[] {
-  return segment.match(/"[^"]*"|'[^']*'|[^\s]+/g)?.map(unquoteShellWord) ?? [];
+  return segment.match(SHELL_TOKEN_PATTERN)?.map(unquoteShellTokenParts) ?? [];
 }
 
-function unquoteShellWord(token: string): string {
-  return token.replace(/^(['"])(.*)\1$/, "$2");
+function unquoteShellTokenParts(token: string): string {
+  return token.replace(
+    QUOTED_SHELL_TOKEN_PART_PATTERN,
+    (_match, doubleQuoted: string | undefined, singleQuoted: string | undefined) => doubleQuoted ?? singleQuoted ?? ""
+  );
 }
 
 function resolveScriptExecutableName(tokens: string[]): string | null {

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -97,9 +97,11 @@ const PACKAGE_MANAGER_LOCKFILES: [PackageManager, string[]][] = [
   ["yarn", ["yarn.lock"]],
   ["npm", ["package-lock.json", "npm-shrinkwrap.json"]]
 ];
+const ENVIRONMENT_COMMAND_WRAPPERS = new Set(["cross-env", "cross-env-shell", "dotenv", "env-cmd"]);
 const SCRIPT_COMMAND_WRAPPERS = new Set(["npx", "pnpm", "yarn", "bun", "node"]);
 const PACKAGE_MANAGER_RUN_SUBCOMMANDS = new Set(["exec", "run"]);
 const NPM_RUN_SUBCOMMANDS = new Set(["exec", "x"]);
+const ENVIRONMENT_WRAPPER_OPTIONS_WITH_VALUE = new Set(["-e", "-f", "--environments", "--file"]);
 const WRAPPER_OPTIONS_WITH_VALUE = new Set([
   "-c",
   "-p",
@@ -199,6 +201,9 @@ function resolveScriptExecutableName(tokens: string[]): string | null {
 
 function runnerTokenIndex(tokens: string[], commandIndex: number): number {
   const commandName = executableBaseName(tokens[commandIndex]);
+  if (ENVIRONMENT_COMMAND_WRAPPERS.has(commandName)) {
+    return environmentWrapperRunnerTokenIndex(tokens, commandIndex);
+  }
   if (commandName === "npm") {
     return npmRunnerTokenIndex(tokens, commandIndex);
   }
@@ -208,6 +213,31 @@ function runnerTokenIndex(tokens: string[], commandIndex: number): number {
   return SCRIPT_COMMAND_WRAPPERS.has(commandName)
     ? skipWrapperOptions(tokens, commandIndex + 1)
     : commandIndex;
+}
+
+function environmentWrapperRunnerTokenIndex(tokens: string[], commandIndex: number): number {
+  const runnerIndex = skipEnvironmentWrapperOptions(tokens, commandIndex + 1);
+  return skipEnvironmentAssignments(tokens, runnerIndex);
+}
+
+function skipEnvironmentWrapperOptions(tokens: string[], startIndex: number): number {
+  let index = startIndex;
+  while (isSkippableWrapperToken(tokens[index])) {
+    index += environmentWrapperOptionWidth(tokens[index]);
+  }
+  return index;
+}
+
+function environmentWrapperOptionWidth(token: string): number {
+  return ENVIRONMENT_WRAPPER_OPTIONS_WITH_VALUE.has(token) ? 2 : 1;
+}
+
+function skipEnvironmentAssignments(tokens: string[], startIndex: number): number {
+  let index = startIndex;
+  while (isEnvironmentAssignment(tokens[index] ?? "")) {
+    index += 1;
+  }
+  return index;
 }
 
 function npmRunnerTokenIndex(tokens: string[], commandIndex: number): number {

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -103,11 +103,16 @@ const NPM_RUN_SUBCOMMANDS = new Set(["exec", "x"]);
 const WRAPPER_OPTIONS_WITH_VALUE = new Set([
   "-c",
   "-p",
+  "-r",
   "--call",
   "--cwd",
   "--dir",
+  "--experimental-loader",
   "--filter",
+  "--import",
+  "--loader",
   "--package",
+  "--require",
   "--shell",
   "--workspace"
 ]);

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -146,6 +146,9 @@ describe("resolveTestRunner", () => {
     const nodeRequireDir = await createTempDir("crap-runner-");
     const nodeLoaderDir = await createTempDir("crap-runner-");
     const quotedEnvDir = await createTempDir("crap-runner-");
+    const crossEnvDir = await createTempDir("crap-runner-");
+    const envCmdDir = await createTempDir("crap-runner-");
+    const dotenvDir = await createTempDir("crap-runner-");
     tempDirs.push(
       npmExecDir,
       npmExecSeparatorDir,
@@ -156,7 +159,10 @@ describe("resolveTestRunner", () => {
       nodeBinDir,
       nodeRequireDir,
       nodeLoaderDir,
-      quotedEnvDir
+      quotedEnvDir,
+      crossEnvDir,
+      envCmdDir,
+      dotenvDir
     );
 
     await writeProjectFiles(npmExecDir, {
@@ -249,6 +255,33 @@ describe("resolveTestRunner", () => {
         }
       })
     });
+    await writeProjectFiles(crossEnvDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "cross-env NODE_ENV=test vitest run"
+        }
+      })
+    });
+    await writeProjectFiles(envCmdDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "env-cmd -f .env jest --runInBand"
+        }
+      })
+    });
+    await writeProjectFiles(dotenvDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "dotenv -e .env -- vitest run"
+        }
+      })
+    });
 
     await expect(resolveTestRunner("auto", npmExecDir, npmExecDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", npmExecSeparatorDir, npmExecSeparatorDir)).resolves.toBe("jest");
@@ -260,6 +293,9 @@ describe("resolveTestRunner", () => {
     await expect(resolveTestRunner("auto", nodeRequireDir, nodeRequireDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", nodeLoaderDir, nodeLoaderDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", quotedEnvDir, quotedEnvDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", crossEnvDir, crossEnvDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", envCmdDir, envCmdDir)).resolves.toBe("jest");
+    await expect(resolveTestRunner("auto", dotenvDir, dotenvDir)).resolves.toBe("vitest");
   });
 
   it("honors explicit selection, falls back from module to project dependencies, and errors when nothing can be detected", async () => {

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -215,4 +215,25 @@ describe("resolveTestRunner", () => {
       resolveTestRunner("auto", missingModulePackageDir, `${missingModulePackageDir}/packages/demo`)
     ).resolves.toBe("vitest");
   });
+
+  it("does not detect runners from plugin package names or non-command script text", async () => {
+    const tempDir = await createTempDir("crap-runner-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        devDependencies: {
+          "vitest-coverage-istanbul": "^4.0.0",
+          "eslint-plugin-jest": "^29.0.0",
+          "ts-jest-mock-extended": "^1.0.0"
+        },
+        scripts: {
+          test: "echo vitest-coverage-istanbul && echo eslint-plugin-jest"
+        }
+      })
+    });
+
+    await expect(resolveTestRunner("auto", tempDir, tempDir)).rejects.toThrow("Unable to detect a test runner");
+  });
 });

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -127,12 +127,51 @@ describe("resolveTestRunner", () => {
           vitest: "^4.0.0"
         },
         scripts: {
-          test: "jest --runInBand"
+          test: "./node_modules/.bin/jest --runInBand"
         }
       })
     });
 
     await expect(resolveTestRunner("auto", tempDir, tempDir)).resolves.toBe("jest");
+  });
+
+  it("detects script runners through common command wrappers", async () => {
+    const npmExecDir = await createTempDir("crap-runner-");
+    const npxDir = await createTempDir("crap-runner-");
+    const nodeBinDir = await createTempDir("crap-runner-");
+    tempDirs.push(npmExecDir, npxDir, nodeBinDir);
+
+    await writeProjectFiles(npmExecDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "npm exec jest -- --runInBand"
+        }
+      })
+    });
+    await writeProjectFiles(npxDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "npx vitest run"
+        }
+      })
+    });
+    await writeProjectFiles(nodeBinDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "node ./node_modules/.bin/vitest run"
+        }
+      })
+    });
+
+    await expect(resolveTestRunner("auto", npmExecDir, npmExecDir)).resolves.toBe("jest");
+    await expect(resolveTestRunner("auto", npxDir, npxDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", nodeBinDir, nodeBinDir)).resolves.toBe("vitest");
   });
 
   it("honors explicit selection, falls back from module to project dependencies, and errors when nothing can be detected", async () => {
@@ -241,7 +280,8 @@ describe("resolveTestRunner", () => {
           "ts-jest-mock-extended": "^1.0.0"
         },
         scripts: {
-          test: "echo vitest-coverage-istanbul && echo eslint-plugin-jest"
+          test: "echo vitest-coverage-istanbul && echo eslint-plugin-jest && echo jest && echo vitest",
+          env: "NODE_ENV=jest VITEST_POOL=threads"
         }
       })
     });

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -143,7 +143,19 @@ describe("resolveTestRunner", () => {
     const yarnRunDir = await createTempDir("crap-runner-");
     const pnpmExecDir = await createTempDir("crap-runner-");
     const nodeBinDir = await createTempDir("crap-runner-");
-    tempDirs.push(npmExecDir, npmExecSeparatorDir, npxDir, npxFlagDir, yarnRunDir, pnpmExecDir, nodeBinDir);
+    const nodeRequireDir = await createTempDir("crap-runner-");
+    const nodeLoaderDir = await createTempDir("crap-runner-");
+    tempDirs.push(
+      npmExecDir,
+      npmExecSeparatorDir,
+      npxDir,
+      npxFlagDir,
+      yarnRunDir,
+      pnpmExecDir,
+      nodeBinDir,
+      nodeRequireDir,
+      nodeLoaderDir
+    );
 
     await writeProjectFiles(npmExecDir, {
       "package.json": JSON.stringify({
@@ -208,6 +220,24 @@ describe("resolveTestRunner", () => {
         }
       })
     });
+    await writeProjectFiles(nodeRequireDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "node -r ts-node/register ./node_modules/.bin/jest --runInBand"
+        }
+      })
+    });
+    await writeProjectFiles(nodeLoaderDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "node --loader ts-node/esm ./node_modules/.bin/vitest run"
+        }
+      })
+    });
 
     await expect(resolveTestRunner("auto", npmExecDir, npmExecDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", npmExecSeparatorDir, npmExecSeparatorDir)).resolves.toBe("jest");
@@ -216,6 +246,8 @@ describe("resolveTestRunner", () => {
     await expect(resolveTestRunner("auto", yarnRunDir, yarnRunDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", pnpmExecDir, pnpmExecDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", nodeBinDir, nodeBinDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", nodeRequireDir, nodeRequireDir)).resolves.toBe("jest");
+    await expect(resolveTestRunner("auto", nodeLoaderDir, nodeLoaderDir)).resolves.toBe("vitest");
   });
 
   it("honors explicit selection, falls back from module to project dependencies, and errors when nothing can be detected", async () => {

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -145,6 +145,7 @@ describe("resolveTestRunner", () => {
     const nodeBinDir = await createTempDir("crap-runner-");
     const nodeRequireDir = await createTempDir("crap-runner-");
     const nodeLoaderDir = await createTempDir("crap-runner-");
+    const quotedEnvDir = await createTempDir("crap-runner-");
     tempDirs.push(
       npmExecDir,
       npmExecSeparatorDir,
@@ -154,7 +155,8 @@ describe("resolveTestRunner", () => {
       pnpmExecDir,
       nodeBinDir,
       nodeRequireDir,
-      nodeLoaderDir
+      nodeLoaderDir,
+      quotedEnvDir
     );
 
     await writeProjectFiles(npmExecDir, {
@@ -238,6 +240,15 @@ describe("resolveTestRunner", () => {
         }
       })
     });
+    await writeProjectFiles(quotedEnvDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "NODE_OPTIONS=\"--loader ts-node/esm\" vitest run"
+        }
+      })
+    });
 
     await expect(resolveTestRunner("auto", npmExecDir, npmExecDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", npmExecSeparatorDir, npmExecSeparatorDir)).resolves.toBe("jest");
@@ -248,6 +259,7 @@ describe("resolveTestRunner", () => {
     await expect(resolveTestRunner("auto", nodeBinDir, nodeBinDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", nodeRequireDir, nodeRequireDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", nodeLoaderDir, nodeLoaderDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", quotedEnvDir, quotedEnvDir)).resolves.toBe("vitest");
   });
 
   it("honors explicit selection, falls back from module to project dependencies, and errors when nothing can be detected", async () => {

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -137,9 +137,13 @@ describe("resolveTestRunner", () => {
 
   it("detects script runners through common command wrappers", async () => {
     const npmExecDir = await createTempDir("crap-runner-");
+    const npmExecSeparatorDir = await createTempDir("crap-runner-");
     const npxDir = await createTempDir("crap-runner-");
+    const npxFlagDir = await createTempDir("crap-runner-");
+    const yarnRunDir = await createTempDir("crap-runner-");
+    const pnpmExecDir = await createTempDir("crap-runner-");
     const nodeBinDir = await createTempDir("crap-runner-");
-    tempDirs.push(npmExecDir, npxDir, nodeBinDir);
+    tempDirs.push(npmExecDir, npmExecSeparatorDir, npxDir, npxFlagDir, yarnRunDir, pnpmExecDir, nodeBinDir);
 
     await writeProjectFiles(npmExecDir, {
       "package.json": JSON.stringify({
@@ -150,12 +154,48 @@ describe("resolveTestRunner", () => {
         }
       })
     });
+    await writeProjectFiles(npmExecSeparatorDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "npm exec -- jest --runInBand"
+        }
+      })
+    });
     await writeProjectFiles(npxDir, {
       "package.json": JSON.stringify({
         name: "fixture",
         private: true,
         scripts: {
           test: "npx vitest run"
+        }
+      })
+    });
+    await writeProjectFiles(npxFlagDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "npx --yes vitest run"
+        }
+      })
+    });
+    await writeProjectFiles(yarnRunDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "yarn run jest --runInBand"
+        }
+      })
+    });
+    await writeProjectFiles(pnpmExecDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "pnpm exec vitest run"
         }
       })
     });
@@ -170,7 +210,11 @@ describe("resolveTestRunner", () => {
     });
 
     await expect(resolveTestRunner("auto", npmExecDir, npmExecDir)).resolves.toBe("jest");
+    await expect(resolveTestRunner("auto", npmExecSeparatorDir, npmExecSeparatorDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", npxDir, npxDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", npxFlagDir, npxFlagDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", yarnRunDir, yarnRunDir)).resolves.toBe("jest");
+    await expect(resolveTestRunner("auto", pnpmExecDir, pnpmExecDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", nodeBinDir, nodeBinDir)).resolves.toBe("vitest");
   });
 

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -147,6 +147,7 @@ describe("resolveTestRunner", () => {
     const nodeLoaderDir = await createTempDir("crap-runner-");
     const quotedEnvDir = await createTempDir("crap-runner-");
     const crossEnvDir = await createTempDir("crap-runner-");
+    const crossEnvShellDir = await createTempDir("crap-runner-");
     const envCmdDir = await createTempDir("crap-runner-");
     const dotenvDir = await createTempDir("crap-runner-");
     tempDirs.push(
@@ -161,6 +162,7 @@ describe("resolveTestRunner", () => {
       nodeLoaderDir,
       quotedEnvDir,
       crossEnvDir,
+      crossEnvShellDir,
       envCmdDir,
       dotenvDir
     );
@@ -264,6 +266,15 @@ describe("resolveTestRunner", () => {
         }
       })
     });
+    await writeProjectFiles(crossEnvShellDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "cross-env-shell NODE_ENV=test \"vitest run\""
+        }
+      })
+    });
     await writeProjectFiles(envCmdDir, {
       "package.json": JSON.stringify({
         name: "fixture",
@@ -294,6 +305,7 @@ describe("resolveTestRunner", () => {
     await expect(resolveTestRunner("auto", nodeLoaderDir, nodeLoaderDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", quotedEnvDir, quotedEnvDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", crossEnvDir, crossEnvDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", crossEnvShellDir, crossEnvShellDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", envCmdDir, envCmdDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", dotenvDir, dotenvDir)).resolves.toBe("vitest");
   });


### PR DESCRIPTION
## Summary
- classify the runner auto-detection false-positive review finding as valid
- match dependency runner evidence by exact package name
- match script runner evidence as command tokens instead of substrings
- add a false-positive regression test for plugin/wrapper package names

## Verification
- `npx vitest run packages/core/test/moduleResolution.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #106