### PR TITLE
Skip files that fail parser analysis

### DIFF
--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -203,8 +203,19 @@ async function analyzeFile(
   loadedCoverage: LoadedCoverage,
   context: AnalyzeContext
 ): Promise<FileAnalysisResult> {
-  const descriptors = await parseFileMethods(filePath);
   const relativePath = toRelativePath(context.projectRoot, filePath);
+  let descriptors: MethodDescriptor[];
+  try {
+    descriptors = await parseFileMethods(filePath);
+  } catch (error) {
+    return {
+      metrics: [],
+      warnings: [emitWarning(
+        context.stderr,
+        `Warning: Could not parse ${relativePath}: ${(error as Error).message}. Skipping file.`
+      )]
+    };
+  }
   const fileCoverage = resolveFileCoverage(loadedCoverage.coverageByFile, filePath, relativePath, loadedCoverage.unknownReason);
   const methodCoverage = coverageForMethods(descriptors, fileCoverage.coverage, fileCoverage.unknownReason ?? undefined);
   const warnings: string[] = [];

--- a/packages/core/test/analysis.test.ts
+++ b/packages/core/test/analysis.test.ts
@@ -169,6 +169,36 @@ describe("analyzeProject", () => {
     expect(result.metrics[0]?.coverage.unknownReason).toBe("unparseable_report");
   });
 
+  it("skips files that fail parsing and keeps analyzing sibling files", async () => {
+    const projectRoot = await createTempDir("crap-analysis-");
+    tempDirs.push(projectRoot);
+    const warnings: string[] = [];
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/good.ts": `export function good(): number {
+  return 1;
+}
+`,
+      "src/bad.ts": "export function bad( {\n",
+      "coverage/coverage-final.json": "{}"
+    });
+
+    const result = await analyzeProject({
+      projectRoot,
+      coverageMode: "existing-only",
+      stderr: {
+        write(chunk: string) {
+          warnings.push(chunk);
+        }
+      }
+    });
+
+    expect(result.metrics.map((metric) => metric.displayName)).toEqual(["good"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(warnings.join("")).toContain("Could not parse src/bad.ts");
+    expect(warnings.join("")).toContain("Skipping file");
+  });
+
   it("reports file-unmatched coverage diagnostics when the report does not contain the analyzed file", async () => {
     const projectRoot = await createTempDir("crap-analysis-");
     tempDirs.push(projectRoot);


### PR DESCRIPTION
## Summary
- classify the single-file parser failure review finding as valid
- convert per-file parse failures into warnings and empty metrics for that file
- keep sibling files in the same module analyzed normally

## Verification
- `npx vitest run packages/core/test/analysis.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #112