### PR TITLE
Handle case probe errors conservatively

### DIFF
--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -149,7 +149,7 @@ function normalizeReportPathForCollision(filePath: string, caseInsensitiveFilesy
 async function isCaseInsensitiveFilesystem(projectRoot: string): Promise<boolean> {
   const probeDirectory = await createCaseProbeDirectory(projectRoot);
   if (probeDirectory === undefined) {
-    return process.platform === "win32";
+    return defaultCaseInsensitiveFilesystem();
   }
 
   try {
@@ -157,11 +157,15 @@ async function isCaseInsensitiveFilesystem(projectRoot: string): Promise<boolean
     await writeFile(probeFile, "");
     await access(path.join(probeDirectory, "CRAP-TYPESCRIPT-CASE-PROBE"));
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    return isMissingPathError(error) ? false : defaultCaseInsensitiveFilesystem();
   } finally {
     await rm(probeDirectory, { force: true, recursive: true });
   }
+}
+
+function defaultCaseInsensitiveFilesystem(): boolean {
+  return process.platform === "win32" || process.platform === "darwin";
 }
 
 async function createCaseProbeDirectory(projectRoot: string): Promise<string | undefined> {

--- a/packages/core/test/reportPaths.test.ts
+++ b/packages/core/test/reportPaths.test.ts
@@ -13,6 +13,18 @@ afterEach(async () => {
 });
 
 describe("report path validation", () => {
+  it("falls back to platform defaults when the case-sensitivity probe directory cannot be created", async () => {
+    stubPlatform("win32");
+    const projectRoot = await createTempDir("crap-report-paths-");
+    tempDirs.push(projectRoot);
+    await mockCaseProbeDirectoryCreationFailure();
+    const { validateReportPathTargets } = await import("../src/reportPaths");
+
+    await expect(validateReportPathTargets(projectRoot, collidingReportTargets())).rejects.toThrow(
+      "--output and --junit-report must target different report files"
+    );
+  });
+
   it("falls back to platform defaults when the case-sensitivity probe fails unexpectedly", async () => {
     stubPlatform("win32");
     await mockCaseProbeAccessFailure("EACCES");
@@ -35,6 +47,19 @@ describe("report path validation", () => {
     await expect(validateReportPathTargets(projectRoot, collidingReportTargets())).resolves.toBeUndefined();
   });
 });
+
+async function mockCaseProbeDirectoryCreationFailure(): Promise<void> {
+  const fsPromises = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  vi.doMock("node:fs/promises", () => ({
+    ...fsPromises,
+    mkdtemp: vi.fn(async (prefix: string) => {
+      if (prefix.includes(".crap-typescript-case-")) {
+        throw Object.assign(new Error("probe directory failed"), { code: "EACCES" });
+      }
+      return fsPromises.mkdtemp(prefix);
+    })
+  }));
+}
 
 async function mockCaseProbeAccessFailure(code: string): Promise<void> {
   const fsPromises = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");

--- a/packages/core/test/reportPaths.test.ts
+++ b/packages/core/test/reportPaths.test.ts
@@ -15,26 +15,46 @@ afterEach(async () => {
 describe("report path validation", () => {
   it("falls back to platform defaults when the case-sensitivity probe fails unexpectedly", async () => {
     stubPlatform("win32");
-    const fsPromises = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-    vi.doMock("node:fs/promises", () => ({
-      ...fsPromises,
-      access: vi.fn(async (filePath: string | Buffer | URL, mode?: number) => {
-        if (String(filePath).includes("CRAP-TYPESCRIPT-CASE-PROBE")) {
-          throw Object.assign(new Error("access denied"), { code: "EACCES" });
-        }
-        return fsPromises.access(filePath, mode);
-      })
-    }));
+    await mockCaseProbeAccessFailure("EACCES");
     const { validateReportPathTargets } = await import("../src/reportPaths");
     const projectRoot = await createTempDir("crap-report-paths-");
     tempDirs.push(projectRoot);
 
-    await expect(validateReportPathTargets(projectRoot, [
-      { label: "--output", path: "reports/CRAP.xml" },
-      { label: "--junit-report", path: "reports/crap.xml" }
-    ])).rejects.toThrow("--output and --junit-report must target different report files");
+    await expect(validateReportPathTargets(projectRoot, collidingReportTargets())).rejects.toThrow(
+      "--output and --junit-report must target different report files"
+    );
+  });
+
+  it("treats a missing uppercase case-sensitivity probe as a case-sensitive result", async () => {
+    stubPlatform("win32");
+    await mockCaseProbeAccessFailure("ENOENT");
+    const { validateReportPathTargets } = await import("../src/reportPaths");
+    const projectRoot = await createTempDir("crap-report-paths-");
+    tempDirs.push(projectRoot);
+
+    await expect(validateReportPathTargets(projectRoot, collidingReportTargets())).resolves.toBeUndefined();
   });
 });
+
+async function mockCaseProbeAccessFailure(code: string): Promise<void> {
+  const fsPromises = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  vi.doMock("node:fs/promises", () => ({
+    ...fsPromises,
+    access: vi.fn(async (filePath: string | Buffer | URL, mode?: number) => {
+      if (String(filePath).includes("CRAP-TYPESCRIPT-CASE-PROBE")) {
+        throw Object.assign(new Error("probe failed"), { code });
+      }
+      return fsPromises.access(filePath, mode);
+    })
+  }));
+}
+
+function collidingReportTargets(): Array<{ label: string; path: string }> {
+  return [
+    { label: "--output", path: "reports/CRAP.xml" },
+    { label: "--junit-report", path: "reports/crap.xml" }
+  ];
+}
 
 function stubPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", {

--- a/packages/core/test/reportPaths.test.ts
+++ b/packages/core/test/reportPaths.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createTempDir, disposeTempDir } from "./testUtils";
+
+const tempDirs: string[] = [];
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+afterEach(async () => {
+  vi.doUnmock("node:fs/promises");
+  vi.resetModules();
+  restorePlatform();
+  await Promise.all(tempDirs.splice(0).map(disposeTempDir));
+});
+
+describe("report path validation", () => {
+  it("falls back to platform defaults when the case-sensitivity probe fails unexpectedly", async () => {
+    stubPlatform("win32");
+    const fsPromises = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    vi.doMock("node:fs/promises", () => ({
+      ...fsPromises,
+      access: vi.fn(async (filePath: string | Buffer | URL, mode?: number) => {
+        if (String(filePath).includes("CRAP-TYPESCRIPT-CASE-PROBE")) {
+          throw Object.assign(new Error("access denied"), { code: "EACCES" });
+        }
+        return fsPromises.access(filePath, mode);
+      })
+    }));
+    const { validateReportPathTargets } = await import("../src/reportPaths");
+    const projectRoot = await createTempDir("crap-report-paths-");
+    tempDirs.push(projectRoot);
+
+    await expect(validateReportPathTargets(projectRoot, [
+      { label: "--output", path: "reports/CRAP.xml" },
+      { label: "--junit-report", path: "reports/crap.xml" }
+    ])).rejects.toThrow("--output and --junit-report must target different report files");
+  });
+});
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    enumerable: true,
+    value: platform
+  });
+}
+
+function restorePlatform(): void {
+  if (originalPlatform === undefined) {
+    return;
+  }
+  Object.defineProperty(process, "platform", originalPlatform);
+}


### PR DESCRIPTION
## Summary
- classify the case-sensitivity probe review finding as valid
- treat ENOENT as the true case-sensitive probe result
- fall back to platform defaults for probe setup failures and unexpected probe errors

## Verification
- `npx vitest run packages/core/test/reportPaths.test.ts`
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #110