### PR TITLE
Run TypeScript build tests across platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,12 @@ permissions:
 
 jobs:
   build:
-    name: Build and Test
-    runs-on: ubuntu-latest
+    name: Build and Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- run the main build/test workflow on Ubuntu, Windows, and macOS
- leave the cognitive and CRAP gates on Ubuntu to keep quality gates focused and avoid tripling those jobs

## Verification
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #125