### PR TITLE
Document CLI exit codes

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -45,6 +45,11 @@ Behavior:
   (no args)                  Analyze all TypeScript files under any nested src/ tree
   <file ...>                 Analyze explicit TypeScript files
   <directory ...>            Analyze TypeScript files under each directory's nested src/ tree
+
+Exit codes:
+  0                          Pass; no methods exceed the threshold
+  1                          Error; invalid arguments, IO failure, parse failure, or report write failure
+  2                          Threshold exceeded; at least one method has CRAP greater than the threshold
 `;
 
 export function usage(): string {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -47,7 +47,7 @@ Behavior:
   <directory ...>            Analyze TypeScript files under each directory's nested src/ tree
 
 Exit codes:
-  0                          Pass; no methods exceed the threshold
+  0                          Success; help requested or analysis completed without threshold failures
   1                          Error; invalid arguments, IO failure, parse failure, or report write failure
   2                          Threshold exceeded; at least one method has CRAP greater than the threshold
 `;

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -361,6 +361,12 @@ describe("cli", () => {
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("Usage:");
+    expect(stdout.toString()).toContain("Exit codes:");
+    expect(stdout.toString()).toContain("0                          Pass; no methods exceed the threshold");
+    expect(stdout.toString()).toContain("1                          Error; invalid arguments, IO failure, parse failure, or report write failure");
+    expect(stdout.toString()).toContain(
+      "2                          Threshold exceeded; at least one method has CRAP greater than the threshold"
+    );
     expect(stderr.toString()).toBe("");
   });
 

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -360,13 +360,12 @@ describe("cli", () => {
     const exitCode = await runCli(["--help"], process.cwd(), stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toContain("Usage:");
-    expect(stdout.toString()).toContain("Exit codes:");
-    expect(stdout.toString()).toContain("0                          Pass; no methods exceed the threshold");
-    expect(stdout.toString()).toContain("1                          Error; invalid arguments, IO failure, parse failure, or report write failure");
-    expect(stdout.toString()).toContain(
-      "2                          Threshold exceeded; at least one method has CRAP greater than the threshold"
-    );
+    const help = stdout.toString();
+    expect(help).toContain("Usage:");
+    expect(help).toContain("Exit codes:");
+    expect(help).toMatch(/0\s+Success; help requested or analysis completed without threshold failures/);
+    expect(help).toMatch(/1\s+Error; invalid arguments, IO failure, parse failure, or report write failure/);
+    expect(help).toMatch(/2\s+Threshold exceeded; at least one method has CRAP greater than the threshold/);
     expect(stderr.toString()).toBe("");
   });
 


### PR DESCRIPTION
## Summary
- document CLI exit code meanings in `--help`
- assert the documented exit-code section in CLI help tests

## Verification
- npm ci
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #117