### PR TITLE
Align reporter threshold exit codes

### DIFF
--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -28,6 +28,8 @@ Baseline analyzability exclusions always skip declarations, test/spec files, `__
 
 The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
+Exit code `2` means the CRAP threshold was exceeded. Reporter errors such as invalid options, missing coverage, or report-write failures use exit code `1`.
+
 The reporter is also available as a standalone export at `@barney-media/crap-typescript-jest/reporter` for direct configuration.
 
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -112,7 +112,7 @@ export default class CrapTypescriptJestReporter {
       if (result.thresholdExceeded) {
         this.error = createThresholdExceededError(result.maxCrap, result.threshold);
         options.stderr.write(`${this.error.message}\n`);
-        process.exitCode = 1;
+        process.exitCode = 2;
       }
     } catch (error) {
       this.error = toError(error);

--- a/packages/jest/test/integration.test.ts
+++ b/packages/jest/test/integration.test.ts
@@ -47,7 +47,7 @@ export default withCrapTypescriptJest(
       projectRoot
     );
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(2);
     await expect(access(path.join(projectRoot, "coverage", "coverage-final.json"))).resolves.toBeUndefined();
     expect(`${result.stdout}\n${result.stderr}`).toContain("CRAP threshold exceeded");
   });
@@ -87,7 +87,7 @@ export default withCrapTypescriptJest(
       projectRoot
     );
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(2);
     await expect(access(path.join(projectRoot, "custom-coverage", "coverage-final.json"))).resolves.toBeUndefined();
     expect(`${result.stdout}\n${result.stderr}`).toContain("CRAP threshold exceeded");
     expect(`${result.stdout}\n${result.stderr}`).not.toContain("Coverage will be N/A");

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -510,7 +510,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
     expect(reporter.getLastError()).toBeInstanceOf(Error);
     expect(reporter.getLastError()?.message).toContain("CRAP threshold exceeded");
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
   });
 
   it("applies primary report controls without reducing the JUnit sidecar", async () => {
@@ -556,7 +556,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(junit).toContain('<property name="status" value="passed"/>');
     expect(junit).toContain('<property name="status" value="failed"/>');
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
   });
 
   it("supports agent defaults and disabled JUnit output", async () => {

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -30,6 +30,8 @@ Baseline analyzability exclusions always skip declarations, test/spec files, `__
 
 The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
+Exit code `2` means the CRAP threshold was exceeded. Reporter errors such as invalid options, missing coverage, or report-write failures use exit code `1`.
+
 See the [main documentation](https://github.com/fabian-barney/crap-typescript) for full details.
 
 ## License

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -75,7 +75,7 @@ export class CrapTypescriptVitestReporter {
       if (result.thresholdExceeded) {
         const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${result.threshold.toFixed(1)}`;
         options.stderr.write(`${error}\n`);
-        process.exitCode = 1;
+        process.exitCode = 2;
       }
     } catch (error) {
       options.stderr.write(`${toError(error).message}\n`);

--- a/packages/vitest/test/integration.test.ts
+++ b/packages/vitest/test/integration.test.ts
@@ -39,7 +39,7 @@ export default withCrapTypescriptVitest(
       projectRoot
     );
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(2);
     await expect(access(path.join(projectRoot, "coverage", "coverage-final.json"))).resolves.toBeUndefined();
     expect(`${result.stdout}\n${result.stderr}`).toContain("CRAP threshold exceeded");
   });
@@ -73,7 +73,7 @@ export default withCrapTypescriptVitest(
       projectRoot
     );
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(2);
     await expect(access(path.join(projectRoot, "custom-coverage", "coverage-final.json"))).resolves.toBeUndefined();
     expect(`${result.stdout}\n${result.stderr}`).toContain("CRAP threshold exceeded");
     expect(`${result.stdout}\n${result.stderr}`).not.toContain("Coverage will be N/A");

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -293,7 +293,7 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(junit).toContain('tests="1"');
     expect(junit).toContain("<failure");
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
   });
 
   it("applies primary report controls without reducing the JUnit sidecar", async () => {
@@ -339,7 +339,7 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(junit).toContain('<property name="status" value="passed"/>');
     expect(junit).toContain('<property name="status" value="failed"/>');
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
   });
 
   it("supports agent defaults and disabled JUnit output", async () => {


### PR DESCRIPTION
## Summary
- return exit code 2 for Jest and Vitest CRAP threshold failures
- keep reporter error paths on exit code 1
- document reporter exit-code meanings in adapter READMEs

## Verification
- npm ci
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #123