### PR TITLE
Respect disabled Vitest coverage

### DIFF
--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -22,6 +22,8 @@ export default withCrapTypescriptVitest({
 
 `withCrapTypescriptVitest` wraps your Vitest config to enable coverage collection and register the CRAP reporter. The test run fails when any function exceeds the CRAP threshold.
 
+If `test.coverage.enabled` is explicitly `false`, the helper preserves that value and does not register the CRAP reporter. Coverage provider, reporter, and directory settings are still normalized, but threshold enforcement resumes only when coverage is enabled again.
+
 The reporter defaults primary `format` to `none`, so it emits no primary stdout report unless configured. It enables `junit` by default and writes a full sidecar for CI test-report UIs. With the default coverage report path, the sidecar is `coverage/crap-typescript-junit.xml`; custom coverage paths derive a matching sidecar path. Pass `format`, `agent`, `failuresOnly`, `omitRedundancy`, `output`, `junit`, `junitReport`, `threshold`, `excludes`, `excludePathRegexes`, `excludeGeneratedMarkers`, or `useDefaultExclusions` in the adapter options to customize analysis and reporting. Set `junit: false` to disable the JUnit artifact.
 
 `agent: true` defaults primary output to `format: "toon"`, `failuresOnly: true`, and `omitRedundancy: true`. Explicit `format`, `failuresOnly: false`, or `omitRedundancy: false` options override those defaults. JUnit sidecars are full reports and are not affected by `agent`, `failuresOnly`, or `omitRedundancy`.

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -90,10 +90,13 @@ export function withCrapTypescriptVitest(
 ): VitestConfig {
   const testConfig = config.test ?? {};
   const coverage = testConfig.coverage ?? {};
+  const coverageEnabled = coverage.enabled ?? true;
   const coverageReporters = ensureReporterEntries(asArray(coverage.reporter), "json", "text");
   const reporters = ensureDefaultReporter(asArray(testConfig.reporters));
   const coverageReportPath = options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory);
-  reporters.push(new CrapTypescriptVitestReporter(reporterOptions(options, coverageReportPath)));
+  if (coverageEnabled) {
+    reporters.push(new CrapTypescriptVitestReporter(reporterOptions(options, coverageReportPath)));
+  }
 
   return {
     ...config,
@@ -101,7 +104,7 @@ export function withCrapTypescriptVitest(
       ...testConfig,
       coverage: {
         ...coverage,
-        enabled: true,
+        enabled: coverageEnabled,
         provider: coverage.provider ?? "v8",
         reporter: coverageReporters,
         reportsDirectory: coverage.reportsDirectory ?? "coverage"

--- a/packages/vitest/test/config.test.ts
+++ b/packages/vitest/test/config.test.ts
@@ -87,6 +87,25 @@ describe("withCrapTypescriptVitest", () => {
     ]);
   });
 
+  it("preserves explicitly disabled coverage without registering the CRAP reporter", () => {
+    const config = withCrapTypescriptVitest({
+      test: {
+        reporters: ["default"],
+        coverage: {
+          enabled: false,
+          reporter: "json",
+          reportsDirectory: "custom-coverage"
+        }
+      }
+    });
+
+    expect(config.test?.coverage?.enabled).toBe(false);
+    expect(config.test?.coverage?.provider).toBe("v8");
+    expect(config.test?.coverage?.reporter).toEqual(["json", "text"]);
+    expect(config.test?.coverage?.reportsDirectory).toBe("custom-coverage");
+    expect(config.test?.reporters).toEqual(["default"]);
+  });
+
   it("derives the default JUnit report from an overridden coverage report", () => {
     const config = withCrapTypescriptVitest({}, {
       coverageReportPath: "custom-coverage/results/coverage-final.json"


### PR DESCRIPTION
## Summary
- preserve an explicit Vitest `coverage.enabled: false`
- skip registering the CRAP Vitest reporter when coverage is disabled
- document the disabled-coverage behavior and cover it in config tests

## Verification
- npm ci
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #124