### PR TITLE
Align Node CI matrix with supported tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,21 +10,22 @@ permissions:
 
 jobs:
   build:
-    name: Build and Test (${{ matrix.os }})
+    name: Build and Test (Node ${{ matrix.node-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: ["20.17.0", "22.9.0", "24"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node 24
+      - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Set up npm 11.14.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ["20.17.0", "22.9.0", "24"]
+        node-version: ["20.19.0", "22.12.0", "24.0.0"]
 
     steps:
       - name: Checkout
@@ -44,17 +44,21 @@ jobs:
         run: npm pack --workspaces
 
   cognitive-typescript-gate:
-    name: cognitive-typescript Gate
+    name: cognitive-typescript Gate (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.19.0", "22.12.0", "24.0.0"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node 24
+      - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Set up npm 11.14.1
@@ -67,17 +71,21 @@ jobs:
         run: npm run cognitive-typescript-check
 
   crap-typescript-gate:
-    name: crap-typescript Gate
+    name: crap-typescript Gate (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.19.0", "22.12.0", "24.0.0"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Node 24
+      - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Set up npm 11.14.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,18 @@ jobs:
 
       - name: Run crap-typescript gate
         run: npm run crap-typescript-check
+
+  crap-typescript-gate-required:
+    name: crap-typescript Gate
+    runs-on: ubuntu-latest
+    needs: [crap-typescript-gate]
+    if: ${{ always() }}
+
+    steps:
+      - name: Require the matrix CRAP gate to pass
+        shell: bash
+        run: |
+          if [ "${{ needs.crap-typescript-gate.result }}" != "success" ]; then
+            echo "The matrix crap-typescript gate did not complete successfully." >&2
+            exit 1
+          fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/fabian-barney/crap-typescript/issues"
   },
   "engines": {
-    "node": ">=18"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "packageManager": "npm@11.14.1",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/fabian-barney/crap-typescript/issues"
   },
   "engines": {
-    "node": "^20.17.0 || >=22.9.0"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "packageManager": "npm@11.14.1",
   "workspaces": [


### PR DESCRIPTION
## Summary
- add pinned Node 20.19.0, 22.12.0, and 24.0.0 to the build/test OS matrix
- run the cognitive-typescript and crap-typescript gates on the same pinned Node versions on Ubuntu
- tighten the private workspace engine range to match the current dev-dependency floors
- keep the published package runtime engines unchanged

Node 18 is not added to the CI matrix because the repo pins npm 11.14.1 and the current Vitest/Vite/Rolldown validation stack requires Node `^20.19.0 || >=22.12.0` for development-time validation.

## Verification
- npm ci
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #127