### PR TITLE
Enable noUncheckedIndexedAccess

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,7 @@ All changes in this repository are expected to be issue-linked.
 5. Keep the pull request green, reply to review comments, and resolve threads only after the fix or an explicit invalidation response.
 6. Merge only after the latest review is newer than the latest push and all required checks are green.
 
+## TypeScript
+
+The shared TypeScript configuration enables `strict` and `noUncheckedIndexedAccess`.
+Handle indexed array and object access explicitly with a fallback, guard, or narrow non-null assertion.

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -223,7 +223,7 @@ async function analyzeFile(
   const methodCoverage = coverageForMethods(descriptors, fileCoverage.coverage, fileCoverage.unknownReason ?? undefined);
   const warnings: string[] = [];
   const metrics = descriptors.map((descriptor, index) =>
-    toMetric(descriptor, methodCoverage[index], filePath, relativePath, moduleRoot, context.stderr, warnings)
+    toMetric(descriptor, methodCoverage[index]!, filePath, relativePath, moduleRoot, context.stderr, warnings)
   );
 
   return { metrics, warnings };

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -60,12 +60,12 @@ export function parseCliArguments(args: string[]): CliArguments {
   const state = createParseState();
 
   for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
+    const arg = args[index]!;
     if (!arg.startsWith("--")) {
       state.fileArgs.push(arg);
       continue;
     }
-    index = consumeOption(state, args, index);
+    index = consumeOption(state, args, index, arg);
   }
 
   return finalizeCliArguments(state);
@@ -219,19 +219,19 @@ function createParseState(): ParseState {
   };
 }
 
-function consumeOption(state: ParseState, args: string[], index: number): number {
-  const [option, value] = splitInlineOption(args[index]);
+function consumeOption(state: ParseState, args: string[], index: number, arg: string): number {
+  const [option, value] = splitInlineOption(arg);
   const inlineBooleanHandler = INLINE_BOOLEAN_OPTION_HANDLERS[option];
   if (inlineBooleanHandler) {
     inlineBooleanHandler(state, value);
     return index;
   }
 
-  const handler = requiredOptionHandler(option, args[index]);
+  const handler = requiredOptionHandler(option, arg);
   if (value === undefined) {
     return handler(state, args, index);
   }
-  return consumeInlineValueOption(state, args, index, option, value, handler);
+  return consumeInlineValueOption(state, args, index, option, value, handler, arg);
 }
 
 function requiredOptionHandler(option: string, rawArg: string): OptionHandler {
@@ -248,10 +248,11 @@ function consumeInlineValueOption(
   index: number,
   option: string,
   value: string,
-  handler: OptionHandler
+  handler: OptionHandler,
+  rawArg: string
 ): number {
   if (!INLINE_VALUE_OPTIONS.has(option)) {
-    throw new Error(`Unknown option: ${args[index]}`);
+    throw new Error(`Unknown option: ${rawArg}`);
   }
   handler(state, inlineValueArgs(args, index, option, value), index);
   return index;
@@ -362,8 +363,10 @@ function parseThreshold(value: string | undefined): number {
 }
 
 function splitInlineOption(arg: string): [string, string | undefined] {
-  const [option, ...values] = arg.split("=");
-  return [option, values.length === 0 ? undefined : values.join("=")];
+  const separatorIndex = arg.indexOf("=");
+  return separatorIndex === -1
+    ? [arg, undefined]
+    : [arg.slice(0, separatorIndex), arg.slice(separatorIndex + 1)];
 }
 
 function inlineValueArgs(args: string[], index: number, option: string, value: string): string[] {

--- a/packages/core/src/coverageAttribution.ts
+++ b/packages/core/src/coverageAttribution.ts
@@ -31,21 +31,21 @@ export function coverageForMethods(
   for (const statement of fileCoverage.statements) {
     const owner = findOwningMethodIndex(attributableMethods, statement.span);
     if (owner !== null) {
-      attributed[owner].statements.push(statement);
+      attributed[owner]!.statements.push(statement);
     }
   }
 
   for (const branch of fileCoverage.branches) {
     const owner = findOwningMethodIndex(attributableMethods, branch.span);
     if (owner !== null) {
-      attributed[owner].branches.push(branch);
+      attributed[owner]!.branches.push(branch);
     }
   }
 
   return methods.map((method, index) =>
-    attributableMethods[index].fnMapConflict
+    attributableMethods[index]!.fnMapConflict
       ? unavailableMethodCoverage(method, "fnmap_conflict")
-      : computeMethodCoverage(method, attributed[index].statements, attributed[index].branches)
+      : computeMethodCoverage(method, attributed[index]!.statements, attributed[index]!.branches)
   );
 }
 
@@ -140,14 +140,14 @@ function findOwningMethodIndex(methods: AttributableMethod[], span: SourceSpan):
   let bestMatch: number | null = null;
 
   for (let index = 0; index < methods.length; index += 1) {
-    const method = methods[index];
+    const method = methods[index]!;
     if (method.fnMapConflict) {
       continue;
     }
     if (!spanContains(method.span, span) && !spanContainsPosition(method.span, span.startLine, span.startColumn)) {
       continue;
     }
-    if (bestMatch === null || spanContains(methods[bestMatch].span, method.span)) {
+    if (bestMatch === null || spanContains(methods[bestMatch]!.span, method.span)) {
       bestMatch = index;
     }
   }
@@ -209,7 +209,7 @@ function matchesMethodDeclaration(entry: FunctionCoverageUnit, method: MethodDes
 
 function resolveUniqueMatch(matches: FunctionCoverageUnit[]): FunctionCoverageUnit | typeof AMBIGUOUS_MATCH | null {
   if (matches.length === 1) {
-    return matches[0];
+    return matches[0] ?? null;
   }
   if (matches.length > 1) {
     return AMBIGUOUS_MATCH;

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -93,7 +93,7 @@ function collectChangedFile(projectRoot: string, entry: GitStatusEntry, files: S
 function collectChangedFilesFromStatus(projectRoot: string, entries: string[]): Set<string> {
   const files = new Set<string>();
   for (let index = 0; index < entries.length; index += 1) {
-    const entry = parseGitStatusEntry(entries[index]);
+    const entry = parseGitStatusEntry(entries[index]!);
     if (!entry) {
       continue;
     }

--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -376,7 +376,7 @@ function selectCanonicalFunctionEntry(entries: FunctionCoverageUnit[]): Function
     }
   }
 
-  return [...uniqueBySpan.values()].sort(compareFunctionSpecificity)[0];
+  return [...uniqueBySpan.values()].sort(compareFunctionSpecificity)[0]!;
 }
 
 function compareFunctionSpecificity(left: FunctionCoverageUnit, right: FunctionCoverageUnit): number {
@@ -421,7 +421,7 @@ function comparePosition(
 function mergeBranchHits(existingHits: number[], nextHits: number[]): number[] {
   const mergedHits = nextHits.map((hits, index) => Math.max(hits, existingHits[index] ?? 0));
   for (let index = mergedHits.length; index < existingHits.length; index += 1) {
-    mergedHits.push(existingHits[index]);
+    mergedHits.push(existingHits[index]!);
   }
   return mergedHits;
 }

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -245,8 +245,10 @@ function environmentWrapperRunnerTokenIndex(tokens: string[], commandIndex: numb
 
 function skipEnvironmentWrapperOptions(tokens: string[], startIndex: number): number {
   let index = startIndex;
-  while (isSkippableWrapperToken(tokens[index])) {
-    index += environmentWrapperOptionWidth(tokens[index]);
+  let token = tokens[index];
+  while (isSkippableWrapperToken(token)) {
+    index += environmentWrapperOptionWidth(token);
+    token = tokens[index];
   }
   return index;
 }
@@ -280,8 +282,10 @@ function packageManagerRunnerTokenIndex(tokens: string[], commandIndex: number):
 
 function skipWrapperOptions(tokens: string[], startIndex: number): number {
   let index = startIndex;
-  while (isSkippableWrapperToken(tokens[index])) {
-    index += optionWidth(tokens[index]);
+  let token = tokens[index];
+  while (isSkippableWrapperToken(token)) {
+    index += optionWidth(token);
+    token = tokens[index];
   }
   return index;
 }

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -201,9 +201,9 @@ export function formatTextReport(report: SerializableReport, agent = false): str
     ? report.methods.map((method) => METHOD_COLUMNS.map((column) => formatTextValue(column, method[column])))
     : (report as AgentAnalysisReport).methods.map((method) =>
       AGENT_METHOD_COLUMNS.map((column) => formatTextValue(column, method[column]))
-    );
+  );
   const widths = columns.map((column, index) =>
-    rows.reduce((max, row) => Math.max(max, row[index].length), column.length)
+    rows.reduce((max, row) => Math.max(max, row[index]?.length ?? 0), column.length)
   );
   const headerLine = formatTextRow([...columns], widths, columns);
   const separator = formatTextSeparator(widths);
@@ -297,10 +297,10 @@ function formatTextRow(
   widths: number[],
   columns: readonly (MethodColumn | AgentMethodColumn)[] = METHOD_COLUMNS
 ): string {
-  return `| ${values.map((value, index) => formatTextCell(value, widths[index], columns[index])).join(" | ")} |`;
+  return `| ${values.map((value, index) => formatTextCell(value, widths[index] ?? value.length, columns[index])).join(" | ")} |`;
 }
 
-function formatTextCell(value: string, width: number, column: MethodColumn | AgentMethodColumn): string {
+function formatTextCell(value: string, width: number, column: MethodColumn | AgentMethodColumn | undefined): string {
   return RIGHT_ALIGNED_TEXT_COLUMNS.has(column as MethodColumn) ? value.padStart(width) : value.padEnd(width);
 }
 

--- a/packages/core/src/reportPaths.ts
+++ b/packages/core/src/reportPaths.ts
@@ -34,8 +34,9 @@ export async function validateReportPathTargets(
   );
 
   for (let leftIndex = 0; leftIndex < resolvedTargets.length; leftIndex += 1) {
+    const leftTarget = resolvedTargets[leftIndex]!;
     for (let rightIndex = leftIndex + 1; rightIndex < resolvedTargets.length; rightIndex += 1) {
-      ensureDistinctReportPaths(resolvedTargets[leftIndex], resolvedTargets[rightIndex]);
+      ensureDistinctReportPaths(leftTarget, resolvedTargets[rightIndex]!);
     }
   }
 }

--- a/packages/core/src/sourceExclusions.ts
+++ b/packages/core/src/sourceExclusions.ts
@@ -315,7 +315,7 @@ function readBlockComment(sourceText: string, index: number, finalChunk: boolean
 
 function skipWhitespace(sourceText: string, startIndex: number): number {
   let index = startIndex;
-  while (index < sourceText.length && /\s/.test(sourceText[index])) {
+  while (index < sourceText.length && /\s/.test(sourceText.charAt(index))) {
     index += 1;
   }
   return index;
@@ -356,7 +356,7 @@ function globToRegex(glob: string): RegExp {
   const normalizedGlob = normalizeGlob(glob);
   let pattern = "^";
   for (let index = 0; index < normalizedGlob.length; index += 1) {
-    const char = normalizedGlob[index];
+    const char = normalizedGlob.charAt(index);
     if (char === "*") {
       const nextChar = normalizedGlob[index + 1];
       if (nextChar === "*") {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
       "ES2022"
     ],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Closes #128.

## Summary
- Enable `noUncheckedIndexedAccess` in the shared TypeScript config.
- Make existing indexed reads explicit with fallbacks, guards, or narrow non-null assertions where the surrounding loop/construction proves the index is valid.
- Document the stricter indexed-access expectation in the contribution guide.

## Verification
- `npm run build`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`