### PR TITLE
Make report metric sorting deterministic

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -15,6 +15,7 @@ import type {
 const METHOD_COLUMNS = ["status", "crap", "cc", "cov", "covKind", "method", "src", "lineStart", "lineEnd"] as const;
 const AGENT_METHOD_COLUMNS = ["crap", "cc", "cov", "covKind", "method", "src", "lineStart", "lineEnd"] as const;
 const RIGHT_ALIGNED_TEXT_COLUMNS = new Set<MethodColumn>(["crap", "cc", "cov", "lineStart", "lineEnd"]);
+const REPORT_SORT_COLLATOR = new Intl.Collator("en");
 
 export interface MethodReportEntry {
   status: MethodReportStatus;
@@ -76,20 +77,38 @@ const REPORT_FORMATTERS: Record<ReportFormat, ReportFormatter> = {
 
 export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
   return [...metrics].sort((left, right) => {
-    if (left.crapScore === null && right.crapScore !== null) {
-      return 1;
-    }
-    if (left.crapScore !== null && right.crapScore === null) {
-      return -1;
-    }
-    if (left.crapScore !== null && right.crapScore !== null && left.crapScore !== right.crapScore) {
-      return right.crapScore - left.crapScore;
-    }
-    if (left.relativePath !== right.relativePath) {
-      return left.relativePath.localeCompare(right.relativePath);
-    }
-    return left.startLine - right.startLine;
+    return compareCrapScores(left.crapScore, right.crapScore)
+      || compareReportText(left.relativePath, right.relativePath)
+      || compareNumber(left.startLine, right.startLine)
+      || compareReportText(left.displayName, right.displayName)
+      || compareNumber(left.bodySpan.startColumn, right.bodySpan.startColumn)
+      || compareNumber(left.endLine, right.endLine)
+      || compareNumber(left.bodySpan.endLine, right.bodySpan.endLine)
+      || compareNumber(left.bodySpan.endColumn, right.bodySpan.endColumn)
+      || compareReportText(left.containerName ?? "", right.containerName ?? "")
+      || compareReportText(left.functionName, right.functionName);
   });
+}
+
+function compareCrapScores(left: number | null, right: number | null): number {
+  if (left === null && right !== null) {
+    return 1;
+  }
+  if (left !== null && right === null) {
+    return -1;
+  }
+  if (left !== null && right !== null) {
+    return right - left;
+  }
+  return 0;
+}
+
+function compareReportText(left: string, right: string): number {
+  return REPORT_SORT_COLLATOR.compare(left, right);
+}
+
+function compareNumber(left: number, right: number): number {
+  return left - right;
 }
 
 export function buildAnalysisReport(

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -7,7 +7,8 @@ import {
   formatAnalysisReport,
   formatJunitReport,
   formatTextReport,
-  formatToonReport
+  formatToonReport,
+  sortMetrics
 } from "../src/report";
 import type { CoverageMetric, MethodMetrics } from "../src/types";
 import type { SourceExclusionAudit } from "../src/types";
@@ -119,6 +120,57 @@ describe("report formatting", () => {
         covKind: "N/A"
       }
     ]);
+  });
+
+  it("uses display names as a deterministic tie-breaker for same-line methods", () => {
+    const report = buildAnalysisReport([
+      metric({
+        displayName: "zeta",
+        startLine: 10,
+        endLine: 10
+      }),
+      metric({
+        displayName: "alpha",
+        startLine: 10,
+        endLine: 10
+      }),
+      metric({
+        displayName: "earlier",
+        startLine: 9,
+        endLine: 9
+      })
+    ]);
+
+    expect(report.methods.map((method) => method.method)).toEqual(["earlier", "alpha", "zeta"]);
+  });
+
+  it("uses source spans as deterministic tie-breakers for duplicate same-line display names", () => {
+    const sorted = sortMetrics([
+      metric({
+        displayName: "same",
+        startLine: 10,
+        endLine: 10,
+        bodySpan: {
+          startLine: 10,
+          startColumn: 7,
+          endLine: 10,
+          endColumn: 8
+        }
+      }),
+      metric({
+        displayName: "same",
+        startLine: 10,
+        endLine: 10,
+        bodySpan: {
+          startLine: 10,
+          startColumn: 3,
+          endLine: 10,
+          endColumn: 4
+        }
+      })
+    ]);
+
+    expect(sorted.map((item) => item.bodySpan.startColumn)).toEqual([3, 7]);
   });
 
   it("reports N/A coverage kind when score coverage is unavailable", () => {


### PR DESCRIPTION
## Summary
- use a shared fixed-locale collator for report path and method-name tie-break comparisons
- add display-name and source-span/function tie-breakers so report ordering does not depend on parser emission order
- cover same-path, same-line ordering and duplicate-display-name ordering in report tests

## Verification
- npx vitest run packages/core/test/report.test.ts
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #119