### PR TITLE
Detect package manager from package manifest

### DIFF
--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -60,8 +60,10 @@ export async function resolvePackageManager(
   if (selection !== "auto") {
     return selection;
   }
-  return await detectPackageManagerAtRoot(moduleRoot) ??
-    await detectPackageManagerAtRoot(projectRoot) ??
+  return await detectPackageManagerFieldAtRoot(moduleRoot) ??
+    await detectPackageManagerFieldAtRoot(projectRoot) ??
+    await detectPackageManagerLockfileAtRoot(moduleRoot) ??
+    await detectPackageManagerLockfileAtRoot(projectRoot) ??
     "npm";
 }
 
@@ -83,7 +85,12 @@ export async function resolveTestRunner(
   throw new Error(`Unable to detect a test runner from ${path.join(moduleRoot, "package.json")}`);
 }
 
-async function detectPackageManagerAtRoot(root: string): Promise<PackageManager | null> {
+async function detectPackageManagerFieldAtRoot(root: string): Promise<PackageManager | null> {
+  const packageJson = await readPackageJson(root);
+  return packageJson ? packageManagerFromPackageJson(packageJson) : null;
+}
+
+async function detectPackageManagerLockfileAtRoot(root: string): Promise<PackageManager | null> {
   for (const [packageManager, lockfiles] of PACKAGE_MANAGER_LOCKFILES) {
     if (await anyExists(root, lockfiles)) {
       return packageManager;
@@ -134,8 +141,17 @@ async function detectTestRunnerAtRoot(root: string): Promise<TestRunner | null> 
 interface PackageJsonShape {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  packageManager?: unknown;
   peerDependencies?: Record<string, string>;
   scripts?: Record<string, string>;
+}
+
+function packageManagerFromPackageJson(packageJson: PackageJsonShape): PackageManager | null {
+  if (typeof packageJson.packageManager !== "string") {
+    return null;
+  }
+  const match = /^(npm|pnpm|yarn)@/.exec(packageJson.packageManager);
+  return match ? match[1] as PackageManager : null;
 }
 
 function detectRunnerFromScripts(scripts: Record<string, string>): TestRunner | null {

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -82,6 +82,43 @@ describe("resolvePackageManager", () => {
     await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("yarn");
   });
 
+  it("prefers packageManager fields over lockfiles", async () => {
+    const tempDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        packageManager: "pnpm@9.15.0"
+      }),
+      "package-lock.json": "{}",
+      "packages/demo/package.json": JSON.stringify({
+        name: "demo",
+        private: true,
+        packageManager: "yarn@4.5.0"
+      }),
+      "packages/demo/pnpm-lock.yaml": "lockfileVersion: 9.0\n"
+    });
+
+    await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("yarn");
+  });
+
+  it("falls back from module packageManager fields to project packageManager fields before lockfiles", async () => {
+    const tempDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        packageManager: "pnpm@9.15.0"
+      }),
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/yarn.lock": ""
+    });
+
+    await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("pnpm");
+  });
+
   it("falls back to project-level lockfiles and then to npm defaults", async () => {
     const tempDir = await createTempDir("crap-package-manager-");
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary
- detect `package.json` `packageManager` values during automatic package-manager resolution
- prefer nearest manifest declarations before lockfile heuristics
- add module and project fallback coverage for package-manager manifest precedence

## Verification
- npx vitest run packages/core/test/moduleResolution.test.ts
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #108