### PR TITLE
Tighten element access assignment names

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -419,9 +419,13 @@ function dottedAccessRootName(node: ts.Expression): string | null {
 
 function assignmentFromElementAccess(node: ts.Expression): { name: string; containerName: string | null } | null {
   if (ts.isElementAccessExpression(node)) {
+    const containerName = dottedAccessName(node.expression);
+    if (!containerName) {
+      return null;
+    }
     return {
-      name: `[${node.argumentExpression?.getText() ?? ""}]`,
-      containerName: node.expression.getText()
+      name: `[${node.argumentExpression.getText()}]`,
+      containerName
     };
   }
   return null;

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -721,6 +721,10 @@ registry["upper"] = function (value: string): string {
   return value;
 };
 
+(direct + direct)["element"] = function (value: string): string {
+  return value;
+};
+
 export function createHandlers() {
   return {
     returned(value: number): number {
@@ -754,6 +758,6 @@ export function createHandlers() {
         displayName: "returned"
       })
     ]));
-    expect(methods.filter((method) => method.displayName === "<assigned>")).toHaveLength(2);
+    expect(methods.filter((method) => method.displayName === "<assigned>")).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Summary
- remove the unreachable empty element-access assignment fallback
- reuse dotted-access validation for element-access assignment containers
- cover non-dotted element-access assignments falling back to `<assigned>`

## Verification
- npx vitest run packages/core/test/parser.test.ts
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #92