### PR TITLE
Support inline values for CLI options

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -170,6 +170,17 @@ const INLINE_BOOLEAN_OPTION_HANDLERS: Record<string, InlineBooleanOptionHandler>
   "--omit-redundancy": parseOmitRedundancy,
   "--use-default-exclusions": parseUseDefaultExclusions
 };
+const INLINE_VALUE_OPTIONS = new Set([
+  "--package-manager",
+  "--test-runner",
+  "--format",
+  "--threshold",
+  "--output",
+  "--junit-report",
+  "--exclude",
+  "--exclude-path-regex",
+  "--exclude-generated-marker"
+]);
 
 function createParseState(): ParseState {
   return {
@@ -204,18 +215,41 @@ function createParseState(): ParseState {
 }
 
 function consumeOption(state: ParseState, args: string[], index: number): number {
-  const [option, value] = splitInlineBooleanOption(args[index]);
+  const [option, value] = splitInlineOption(args[index]);
   const inlineBooleanHandler = INLINE_BOOLEAN_OPTION_HANDLERS[option];
   if (inlineBooleanHandler) {
     inlineBooleanHandler(state, value);
     return index;
   }
 
-  const handler = OPTION_HANDLERS[args[index]];
+  const handler = requiredOptionHandler(option, args[index]);
+  if (value === undefined) {
+    return handler(state, args, index);
+  }
+  return consumeInlineValueOption(state, args, index, option, value, handler);
+}
+
+function requiredOptionHandler(option: string, rawArg: string): OptionHandler {
+  const handler = OPTION_HANDLERS[option];
   if (!handler) {
+    throw new Error(`Unknown option: ${rawArg}`);
+  }
+  return handler;
+}
+
+function consumeInlineValueOption(
+  state: ParseState,
+  args: string[],
+  index: number,
+  option: string,
+  value: string,
+  handler: OptionHandler
+): number {
+  if (!INLINE_VALUE_OPTIONS.has(option)) {
     throw new Error(`Unknown option: ${args[index]}`);
   }
-  return handler(state, args, index);
+  handler(state, inlineValueArgs(args, index, option, value), index);
+  return index;
 }
 
 function ensureOptionIsUnique(seen: boolean, option: string): void {
@@ -322,9 +356,16 @@ function parseThreshold(value: string | undefined): number {
   }
 }
 
-function splitInlineBooleanOption(arg: string): [string, string | undefined] {
+function splitInlineOption(arg: string): [string, string | undefined] {
   const [option, ...values] = arg.split("=");
   return [option, values.length === 0 ? undefined : values.join("=")];
+}
+
+function inlineValueArgs(args: string[], index: number, option: string, value: string): string[] {
+  const normalized = [...args];
+  normalized[index] = option;
+  normalized[index + 1] = value;
+  return normalized;
 }
 
 function parseFailuresOnly(state: ParseState, value: string | undefined): void {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -173,6 +173,8 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--use-default-exclusions=maybe"])).toThrow(
       "--use-default-exclusions requires true or false when a value is provided"
     );
+    expect(() => parseCliArguments(["--changed=true"])).toThrow("Unknown option: --changed=true");
+    expect(() => parseCliArguments(["--agent=false"])).toThrow("Unknown option: --agent=false");
     expect(() => parseCliArguments(["--unknown"])).toThrow("Unknown option: --unknown");
   });
 
@@ -180,6 +182,34 @@ describe("cli", () => {
     expect(parseCliArguments(["--threshold", "6", "--changed"])).toMatchObject({
       mode: "changed",
       threshold: 6
+    });
+  });
+
+  it("parses inline values for value options without consuming following file arguments", () => {
+    expect(parseCliArguments([
+      "--package-manager=pnpm",
+      "--test-runner=jest",
+      "--format=json",
+      "--threshold=6",
+      "--output=reports/crap.json",
+      "--junit-report=reports/crap.xml",
+      "--exclude=**/*.pb.ts",
+      "--exclude-path-regex=^src/generated/",
+      "--exclude-generated-marker=DO NOT EDIT",
+      "src/app.ts"
+    ])).toMatchObject({
+      mode: "explicit",
+      fileArgs: ["src/app.ts"],
+      packageManager: "pnpm",
+      testRunner: "jest",
+      format: "json",
+      threshold: 6,
+      output: "reports/crap.json",
+      junit: true,
+      junitReport: "reports/crap.xml",
+      excludes: ["**/*.pb.ts"],
+      excludePathRegexes: ["^src/generated/"],
+      excludeGeneratedMarkers: ["DO NOT EDIT"]
     });
   });
 


### PR DESCRIPTION
## Summary
- support `--key=value` syntax for value-taking CLI options
- keep valueless flags strict while preserving existing optional boolean inline syntax
- add coverage that inline value options do not consume the following file argument

## Verification
- npx vitest run packages/core/test/cli.test.ts
- npm test
- npm run build
- npm run cognitive-typescript-check
- npm run crap-typescript-check

Closes #116