### PR TITLE
Report N/A coverage kind for structural gaps

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -4,6 +4,7 @@ import { XMLBuilder } from "fast-xml-parser";
 import { CRAP_THRESHOLD, validateThreshold } from "./constants.js";
 import { formatNumber } from "./utils.js";
 import type {
+  CoverageMetric,
   CoverageKind,
   MethodMetrics,
   MethodReportStatus,
@@ -16,6 +17,10 @@ const METHOD_COLUMNS = ["status", "crap", "cc", "cov", "covKind", "method", "src
 const AGENT_METHOD_COLUMNS = ["crap", "cc", "cov", "covKind", "method", "src", "lineStart", "lineEnd"] as const;
 const RIGHT_ALIGNED_TEXT_COLUMNS = new Set<MethodColumn>(["crap", "cc", "cov", "lineStart", "lineEnd"]);
 const REPORT_SORT_COLLATOR = new Intl.Collator("en");
+const NON_MEASURED_COVERAGE_KINDS = {
+  structural_na: "N/A",
+  unknown: "N/A"
+} as const satisfies Record<Exclude<CoverageMetric["status"], "measured">, CoverageKind>;
 
 export interface MethodReportEntry {
   status: MethodReportStatus;
@@ -274,16 +279,20 @@ function methodStatus(metric: MethodMetrics, threshold: number): MethodReportSta
 }
 
 function coverageKind(metric: MethodMetrics): CoverageKind {
-  if (metric.coverage.status === "unknown") {
-    return "N/A";
+  if (metric.coverage.status !== "measured") {
+    return NON_MEASURED_COVERAGE_KINDS[metric.coverage.status];
   }
-  if (metric.statementCoverage.status === "measured" && metric.branchCoverage.status === "measured") {
-    return metric.branchCoverage.percent! < metric.statementCoverage.percent! ? "branch" : "stmt";
+  return measuredCoverageKind(metric.statementCoverage, metric.branchCoverage);
+}
+
+function measuredCoverageKind(statementCoverage: CoverageMetric, branchCoverage: CoverageMetric): CoverageKind {
+  if (statementCoverage.status === "measured" && branchCoverage.status === "measured") {
+    return branchCoverage.percent! < statementCoverage.percent! ? "branch" : "stmt";
   }
-  if (metric.statementCoverage.status === "measured") {
+  if (statementCoverage.status === "measured") {
     return "stmt";
   }
-  if (metric.branchCoverage.status === "measured") {
+  if (branchCoverage.status === "measured") {
     return "branch";
   }
   return "stmt";

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -202,13 +202,12 @@ describe("report formatting", () => {
         },
         statementCoverage: structuralNa(),
         branchCoverage: structuralNa(),
-        coveragePercent: 100,
-        crapScore: null
+        coveragePercent: 100
       })
     ]);
 
     expect(report.methods[0]).toMatchObject({
-      status: "skipped",
+      status: "passed",
       covKind: "N/A"
     });
   });

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -190,6 +190,29 @@ describe("report formatting", () => {
     });
   });
 
+  it("reports N/A coverage kind when coverage is structurally not applicable", () => {
+    const report = buildAnalysisReport([
+      metric({
+        expectsStatementCoverage: false,
+        expectsBranchCoverage: false,
+        coverage: {
+          percent: 100,
+          status: "structural_na",
+          unknownReason: null
+        },
+        statementCoverage: structuralNa(),
+        branchCoverage: structuralNa(),
+        coveragePercent: 100,
+        crapScore: null
+      })
+    ]);
+
+    expect(report.methods[0]).toMatchObject({
+      status: "skipped",
+      covKind: "N/A"
+    });
+  });
+
   it("reports statement coverage kind when it is the only measured component", () => {
     const report = buildAnalysisReport([
       metric({


### PR DESCRIPTION
Closes #120.

## Summary
- report structural coverage gaps as `N/A` instead of `stmt`
- keep the report formatting logic below the repo CRAP gate by isolating measured-coverage handling
- add coverage for structurally not applicable methods in the report formatter tests

## Verification
- `npm run build`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
