### PR TITLE
Add Bun package manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npx crap-typescript
 --exclude-path-regex <regex> Exclude source paths by normalized relative regex; repeatable
 --exclude-generated-marker <marker> Exclude leading generated-header markers; repeatable
 --use-default-exclusions[=true|false] Enable generated-code defaults (`true` by default)
---package-manager <tool>     Force auto, npm, pnpm, or yarn
+--package-manager <tool>     Force auto, npm, pnpm, yarn, or bun
 --test-runner <runner>       Force auto, vitest, or jest
 --format <format>            Emit toon, json, text, junit, or none (default: toon)
 --agent                      Default primary output to toon, failures-only, omit-redundancy

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,7 +33,7 @@ npx crap-typescript packages/api packages/web
 --exclude-path-regex <regex> Exclude source paths by normalized relative regex; repeatable
 --exclude-generated-marker <marker> Exclude leading generated-header markers; repeatable
 --use-default-exclusions[=true|false] Enable generated-code defaults (`true` by default)
---package-manager <tool>     Force auto, npm, pnpm, or yarn
+--package-manager <tool>     Force auto, npm, pnpm, yarn, or bun
 --test-runner <runner>       Force auto, vitest, or jest
 --format <format>            Emit toon, json, text, junit, or none (default: toon)
 --agent                      Default primary output to toon, failures-only, omit-redundancy

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -11,6 +11,9 @@ import type { CliArguments, PackageManagerSelection, ReportFormat, TestRunnerSel
 const REPORT_FORMATS = ["toon", "json", "text", "junit", "none"] as const;
 const REPORT_FORMAT_LIST = REPORT_FORMATS.join(", ");
 const REPORT_FORMAT_ERROR = `--format requires one of: ${REPORT_FORMAT_LIST}`;
+const PACKAGE_MANAGERS = ["auto", "npm", "pnpm", "yarn", "bun"] as const;
+const PACKAGE_MANAGER_LIST = PACKAGE_MANAGERS.join(", ");
+const PACKAGE_MANAGER_ERROR = `--package-manager requires one of: ${PACKAGE_MANAGER_LIST}`;
 
 const HELP_TEXT = `crap-typescript
 
@@ -29,7 +32,7 @@ Options:
                              Exclude files with a leading generated-header marker; repeatable
   --use-default-exclusions[=true|false]
                              Enable generated-code defaults (default: true)
-  --package-manager <tool>   Force auto, npm, pnpm, or yarn
+  --package-manager <tool>   Force ${PACKAGE_MANAGER_LIST}
   --test-runner <runner>     Force auto, vitest, or jest
   --format <format>          Emit ${REPORT_FORMAT_LIST} (default: toon)
   --agent                    Default primary output to --format toon --failures-only --omit-redundancy
@@ -322,12 +325,12 @@ function optionalPath<K extends "output" | "junitReport">(key: K, value: string 
 
 function parsePackageManagerSelection(value: string | undefined): PackageManagerSelection {
   if (!value) {
-    throw new Error("--package-manager requires one of: auto, npm, pnpm, yarn");
+    throw new Error(PACKAGE_MANAGER_ERROR);
   }
-  if (value === "auto" || value === "npm" || value === "pnpm" || value === "yarn") {
-    return value;
+  if ((PACKAGE_MANAGERS as readonly string[]).includes(value)) {
+    return value as PackageManagerSelection;
   }
-  throw new Error("--package-manager requires one of: auto, npm, pnpm, yarn");
+  throw new Error(PACKAGE_MANAGER_ERROR);
 }
 
 function parseTestRunnerSelection(value: string | undefined): TestRunnerSelection {

--- a/packages/core/src/coverage.ts
+++ b/packages/core/src/coverage.ts
@@ -134,6 +134,16 @@ function vitestArguments(packageManager: PackageManager, coverageReportPath: str
         "--coverage.reporter=text",
         `--coverage.reportsDirectory=${reportsDirectory}`
       ];
+    case "bun":
+      return [
+        "x",
+        "vitest",
+        "run",
+        "--coverage.enabled=true",
+        "--coverage.reporter=json",
+        "--coverage.reporter=text",
+        `--coverage.reportsDirectory=${reportsDirectory}`
+      ];
   }
 }
 
@@ -164,6 +174,16 @@ function jestArguments(packageManager: PackageManager, coverageReportPath: strin
       ];
     case "yarn":
       return [
+        "jest",
+        "--coverage",
+        "--runInBand",
+        "--coverageReporters=json",
+        "--coverageReporters=text",
+        `--coverageDirectory=${coverageDirectory}`
+      ];
+    case "bun":
+      return [
+        "x",
         "jest",
         "--coverage",
         "--runInBand",

--- a/packages/core/src/moduleResolution.ts
+++ b/packages/core/src/moduleResolution.ts
@@ -102,10 +102,11 @@ async function detectPackageManagerLockfileAtRoot(root: string): Promise<Package
 const PACKAGE_MANAGER_LOCKFILES: [PackageManager, string[]][] = [
   ["pnpm", ["pnpm-lock.yaml"]],
   ["yarn", ["yarn.lock"]],
+  ["bun", ["bun.lock", "bun.lockb"]],
   ["npm", ["package-lock.json", "npm-shrinkwrap.json"]]
 ];
 const ENVIRONMENT_COMMAND_WRAPPERS = new Set(["cross-env", "cross-env-shell", "dotenv", "env-cmd"]);
-const SCRIPT_COMMAND_WRAPPERS = new Set(["npx", "pnpm", "yarn", "bun", "node"]);
+const SCRIPT_COMMAND_WRAPPERS = new Set(["npx", "pnpm", "yarn", "bun", "bunx", "node"]);
 const PACKAGE_MANAGER_RUN_SUBCOMMANDS = new Set(["exec", "run"]);
 const NPM_RUN_SUBCOMMANDS = new Set(["exec", "x"]);
 const ENVIRONMENT_WRAPPER_OPTIONS_WITH_VALUE = new Set(["-e", "-f", "--environments", "--file"]);
@@ -127,6 +128,12 @@ const WRAPPER_OPTIONS_WITH_VALUE = new Set([
 ]);
 const SHELL_TOKEN_PATTERN = /(?:[^\s'"]+|"[^"]*"|'[^']*')+/g;
 const QUOTED_SHELL_TOKEN_PART_PATTERN = /"([^"]*)"|'([^']*)'/g;
+const RUNNER_TOKEN_RESOLVERS: Record<string, (tokens: string[], commandIndex: number) => number> = {
+  npm: npmRunnerTokenIndex,
+  pnpm: packageManagerRunnerTokenIndex,
+  yarn: packageManagerRunnerTokenIndex,
+  bun: bunRunnerTokenIndex
+};
 
 async function detectTestRunnerAtRoot(root: string): Promise<TestRunner | null> {
   const packageJson = await readPackageJson(root);
@@ -150,7 +157,7 @@ function packageManagerFromPackageJson(packageJson: PackageJsonShape): PackageMa
   if (typeof packageJson.packageManager !== "string") {
     return null;
   }
-  const match = /^(npm|pnpm|yarn)@/.exec(packageJson.packageManager);
+  const match = /^(npm|pnpm|yarn|bun)@/.exec(packageJson.packageManager);
   return match ? match[1] as PackageManager : null;
 }
 
@@ -227,12 +234,13 @@ function runnerTokenIndex(tokens: string[], commandIndex: number): number {
   if (ENVIRONMENT_COMMAND_WRAPPERS.has(commandName)) {
     return environmentWrapperRunnerTokenIndex(tokens, commandIndex);
   }
-  if (commandName === "npm") {
-    return npmRunnerTokenIndex(tokens, commandIndex);
-  }
-  if (commandName === "pnpm" || commandName === "yarn") {
-    return packageManagerRunnerTokenIndex(tokens, commandIndex);
-  }
+  const resolveRunnerToken = RUNNER_TOKEN_RESOLVERS[commandName];
+  return resolveRunnerToken
+    ? resolveRunnerToken(tokens, commandIndex)
+    : nonPackageManagerRunnerTokenIndex(tokens, commandIndex, commandName);
+}
+
+function nonPackageManagerRunnerTokenIndex(tokens: string[], commandIndex: number, commandName: string): number {
   return SCRIPT_COMMAND_WRAPPERS.has(commandName)
     ? skipWrapperOptions(tokens, commandIndex + 1)
     : commandIndex;
@@ -276,6 +284,14 @@ function packageManagerRunnerTokenIndex(tokens: string[], commandIndex: number):
   const runnerIndex = skipWrapperOptions(tokens, commandIndex + 1);
   const subcommand = tokens[runnerIndex] ?? "";
   return PACKAGE_MANAGER_RUN_SUBCOMMANDS.has(subcommand)
+    ? skipWrapperOptions(tokens, runnerIndex + 1)
+    : runnerIndex;
+}
+
+function bunRunnerTokenIndex(tokens: string[], commandIndex: number): number {
+  const runnerIndex = skipWrapperOptions(tokens, commandIndex + 1);
+  const subcommand = tokens[runnerIndex] ?? "";
+  return subcommand === "x" || subcommand === "run"
     ? skipWrapperOptions(tokens, runnerIndex + 1)
     : runnerIndex;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
 export type CliMode = "all" | "changed" | "explicit" | "help";
-export type PackageManager = "npm" | "pnpm" | "yarn";
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 export type PackageManagerSelection = PackageManager | "auto";
 export type TestRunner = "vitest" | "jest";
 export type TestRunnerSelection = TestRunner | "auto";

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -142,7 +142,7 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--use-default-exclusions", "--use-default-exclusions=false"])).toThrow(
       "--use-default-exclusions can only be provided once"
     );
-    expect(() => parseCliArguments(["--package-manager"])).toThrow("--package-manager requires one of: auto, npm, pnpm, yarn");
+    expect(() => parseCliArguments(["--package-manager"])).toThrow("--package-manager requires one of: auto, npm, pnpm, yarn, bun");
     expect(() => parseCliArguments(["--test-runner"])).toThrow("--test-runner requires one of: auto, vitest, jest");
     expect(() => parseCliArguments(["--format"])).toThrow("--format requires one of: toon, json, text, junit, none");
     expect(() => parseCliArguments(["--threshold"])).toThrow("--threshold requires a finite number greater than 0");
@@ -151,8 +151,8 @@ describe("cli", () => {
     expect(() => parseCliArguments(["--exclude"])).toThrow("--exclude requires a path");
     expect(() => parseCliArguments(["--exclude-path-regex"])).toThrow("--exclude-path-regex requires a regex");
     expect(() => parseCliArguments(["--exclude-generated-marker"])).toThrow("--exclude-generated-marker requires a marker");
-    expect(() => parseCliArguments(["--package-manager", "bun"])).toThrow(
-      "--package-manager requires one of: auto, npm, pnpm, yarn"
+    expect(() => parseCliArguments(["--package-manager", "pip"])).toThrow(
+      "--package-manager requires one of: auto, npm, pnpm, yarn, bun"
     );
     expect(() => parseCliArguments(["--test-runner", "mocha"])).toThrow(
       "--test-runner requires one of: auto, vitest, jest"
@@ -183,6 +183,10 @@ describe("cli", () => {
       mode: "changed",
       threshold: 6
     });
+  });
+
+  it("accepts bun as an explicit package manager", () => {
+    expect(parseCliArguments(["--package-manager", "bun"]).packageManager).toBe("bun");
   });
 
   it("parses inline values for value options without consuming following file arguments", () => {

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -51,6 +51,33 @@ describe("coverage helpers", () => {
     });
   });
 
+  it("builds bun coverage commands through bun x", () => {
+    expect(buildCoverageCommand("bun", "vitest", "C:/tmp")).toEqual({
+      command: "bun",
+      args: [
+        "x",
+        "vitest",
+        "run",
+        "--coverage.enabled=true",
+        "--coverage.reporter=json",
+        "--coverage.reporter=text",
+        "--coverage.reportsDirectory=coverage"
+      ],
+      cwd: "C:/tmp",
+      packageManager: "bun",
+      testRunner: "vitest"
+    });
+    expect(buildCoverageCommand("bun", "jest", "C:/tmp").args).toEqual([
+      "x",
+      "jest",
+      "--coverage",
+      "--runInBand",
+      "--coverageReporters=json",
+      "--coverageReporters=text",
+      "--coverageDirectory=coverage"
+    ]);
+  });
+
   it("builds custom coverage directory arguments from the expected report path", () => {
     expect(buildCoverageCommand("pnpm", "vitest", "C:/tmp", "custom-coverage/coverage-final.json").args).toContain(
       "--coverage.reportsDirectory=custom-coverage"

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -91,21 +91,30 @@ describe("resolvePackageManager", () => {
         private: true,
         packageManager: "bun@1.2.0"
       }),
-      "packages/demo/package.json": '{"name":"demo","private":true}',
-      "packages/demo/bun.lock": ""
+      "packages/demo/package.json": '{"name":"demo","private":true}'
     });
 
     await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("bun");
 
-    const lockfileDir = await createTempDir("crap-package-manager-");
-    tempDirs.push(lockfileDir);
-    await writeProjectFiles(lockfileDir, {
+    const bunLockDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(bunLockDir);
+    await writeProjectFiles(bunLockDir, {
+      "package.json": '{"name":"root","private":true}',
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/bun.lock": ""
+    });
+
+    await expect(resolvePackageManager("auto", bunLockDir, `${bunLockDir}/packages/demo`)).resolves.toBe("bun");
+
+    const bunLockbDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(bunLockbDir);
+    await writeProjectFiles(bunLockbDir, {
       "package.json": '{"name":"root","private":true}',
       "packages/demo/package.json": '{"name":"demo","private":true}',
       "packages/demo/bun.lockb": ""
     });
 
-    await expect(resolvePackageManager("auto", lockfileDir, `${lockfileDir}/packages/demo`)).resolves.toBe("bun");
+    await expect(resolvePackageManager("auto", bunLockbDir, `${bunLockbDir}/packages/demo`)).resolves.toBe("bun");
   });
 
   it("prefers packageManager fields over lockfiles", async () => {

--- a/packages/core/test/moduleResolution.test.ts
+++ b/packages/core/test/moduleResolution.test.ts
@@ -82,6 +82,32 @@ describe("resolvePackageManager", () => {
     await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("yarn");
   });
 
+  it("detects bun from packageManager fields and lockfiles", async () => {
+    const tempDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        packageManager: "bun@1.2.0"
+      }),
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/bun.lock": ""
+    });
+
+    await expect(resolvePackageManager("auto", tempDir, `${tempDir}/packages/demo`)).resolves.toBe("bun");
+
+    const lockfileDir = await createTempDir("crap-package-manager-");
+    tempDirs.push(lockfileDir);
+    await writeProjectFiles(lockfileDir, {
+      "package.json": '{"name":"root","private":true}',
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/bun.lockb": ""
+    });
+
+    await expect(resolvePackageManager("auto", lockfileDir, `${lockfileDir}/packages/demo`)).resolves.toBe("bun");
+  });
+
   it("prefers packageManager fields over lockfiles", async () => {
     const tempDir = await createTempDir("crap-package-manager-");
     tempDirs.push(tempDir);
@@ -179,6 +205,10 @@ describe("resolveTestRunner", () => {
     const npxFlagDir = await createTempDir("crap-runner-");
     const yarnRunDir = await createTempDir("crap-runner-");
     const pnpmExecDir = await createTempDir("crap-runner-");
+    const bunXDir = await createTempDir("crap-runner-");
+    const bunRunDir = await createTempDir("crap-runner-");
+    const bunOptionDir = await createTempDir("crap-runner-");
+    const bunxDir = await createTempDir("crap-runner-");
     const nodeBinDir = await createTempDir("crap-runner-");
     const nodeRequireDir = await createTempDir("crap-runner-");
     const nodeLoaderDir = await createTempDir("crap-runner-");
@@ -194,6 +224,10 @@ describe("resolveTestRunner", () => {
       npxFlagDir,
       yarnRunDir,
       pnpmExecDir,
+      bunXDir,
+      bunRunDir,
+      bunOptionDir,
+      bunxDir,
       nodeBinDir,
       nodeRequireDir,
       nodeLoaderDir,
@@ -255,6 +289,42 @@ describe("resolveTestRunner", () => {
         private: true,
         scripts: {
           test: "pnpm exec vitest run"
+        }
+      })
+    });
+    await writeProjectFiles(bunXDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "bun x vitest run"
+        }
+      })
+    });
+    await writeProjectFiles(bunRunDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "bun run jest --runInBand"
+        }
+      })
+    });
+    await writeProjectFiles(bunOptionDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "bun --cwd packages/demo x vitest run"
+        }
+      })
+    });
+    await writeProjectFiles(bunxDir, {
+      "package.json": JSON.stringify({
+        name: "fixture",
+        private: true,
+        scripts: {
+          test: "bunx jest --runInBand"
         }
       })
     });
@@ -337,6 +407,10 @@ describe("resolveTestRunner", () => {
     await expect(resolveTestRunner("auto", npxFlagDir, npxFlagDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", yarnRunDir, yarnRunDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", pnpmExecDir, pnpmExecDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", bunXDir, bunXDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", bunRunDir, bunRunDir)).resolves.toBe("jest");
+    await expect(resolveTestRunner("auto", bunOptionDir, bunOptionDir)).resolves.toBe("vitest");
+    await expect(resolveTestRunner("auto", bunxDir, bunxDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", nodeBinDir, nodeBinDir)).resolves.toBe("vitest");
     await expect(resolveTestRunner("auto", nodeRequireDir, nodeRequireDir)).resolves.toBe("jest");
     await expect(resolveTestRunner("auto", nodeLoaderDir, nodeLoaderDir)).resolves.toBe("vitest");

--- a/spec.md
+++ b/spec.md
@@ -43,7 +43,7 @@ The tool shall support these forms:
 
 It shall also accept optional overrides:
 
-- `--package-manager auto|npm|pnpm|yarn`
+- `--package-manager auto|npm|pnpm|yarn|bun`
 - `--test-runner auto|vitest|jest`
 - `--threshold <finite-positive-number>`
 - `--format toon|json|text|junit|none`


### PR DESCRIPTION
## Summary
- add Bun as a supported package manager across CLI parsing, auto-detection, and coverage command construction
- recognize Bun runner wrappers such as `bun x`, `bun run`, and `bunx` when inferring Vitest or Jest from package scripts
- extend CLI, module-resolution, and coverage tests while keeping the repository CRAP gate green

## Testing
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #101