### PR TITLE
Record elapsed JUnit suite times

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -583,5 +583,5 @@ function writeCliThresholdStatus(
 }
 
 function elapsedSecondsSince(startedAt: number): number {
-  return Math.max(0, (performance.now() - startedAt) / 1000);
+  return Math.max(0.001, (performance.now() - startedAt) / 1000);
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -455,7 +456,15 @@ export async function runCli(
     return 1;
   }
 
-  return handleCliResult(await analyzeCliProject(parsed, projectRoot, stdout, stderr), parsed, projectRoot, stdout, stderr);
+  const startedAt = performance.now();
+  return handleCliResult(
+    await analyzeCliProject(parsed, projectRoot, stdout, stderr),
+    parsed,
+    projectRoot,
+    stdout,
+    stderr,
+    elapsedSecondsSince(startedAt)
+  );
 }
 
 function parseCliInputs(args: string[], stdout: Writer, stderr: Writer): CliArguments | number {
@@ -500,14 +509,15 @@ async function handleCliResult(
   parsed: CliArguments,
   projectRoot: string,
   stdout: Writer,
-  stderr: Writer
+  stderr: Writer,
+  elapsedSeconds: number
 ): Promise<number> {
   if (!result) {
     return 1;
   }
 
   try {
-    await writeCliReports(result, parsed, projectRoot, stdout);
+    await writeCliReports(result, parsed, projectRoot, stdout, elapsedSeconds);
   } catch (error) {
     writeLine(stderr, (error as Error).message);
     return 1;
@@ -520,7 +530,8 @@ async function writeCliReports(
   result: Awaited<ReturnType<typeof analyzeProject>>,
   parsed: CliArguments,
   projectRoot: string,
-  stdout: Writer
+  stdout: Writer,
+  elapsedSeconds: number
 ): Promise<void> {
   const primaryReport = formatAnalysisReport(result.metrics, {
     format: parsed.format,
@@ -528,6 +539,7 @@ async function writeCliReports(
     threshold: result.threshold,
     failuresOnly: parsed.failuresOnly,
     omitRedundancy: parsed.omitRedundancy,
+    elapsedSeconds,
     sourceExclusionAudit: result.sourceExclusionAudit
   });
   if (parsed.output) {
@@ -540,6 +552,7 @@ async function writeCliReports(
     await writeReportFile(projectRoot, parsed.junitReport, formatAnalysisReport(result.metrics, {
       format: "junit",
       threshold: result.threshold,
+      elapsedSeconds,
       sourceExclusionAudit: result.sourceExclusionAudit
     }));
   }
@@ -567,4 +580,8 @@ function writeCliThresholdStatus(
   }
   writeLine(stderr, `CRAP threshold exceeded: ${formatNumber(result.maxCrap)} > ${formatNumber(result.threshold)}`);
   return 2;
+}
+
+function elapsedSecondsSince(startedAt: number): number {
+  return Math.max(0, (performance.now() - startedAt) / 1000);
 }

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -51,6 +51,7 @@ export interface FormatAnalysisReportOptions {
   threshold?: number;
   failuresOnly?: boolean;
   omitRedundancy?: boolean;
+  elapsedSeconds?: number;
   sourceExclusionAudit?: SourceExclusionAudit;
   includeExclusionAudit?: boolean;
 }
@@ -152,6 +153,9 @@ export function formatAnalysisReport(metrics: MethodMetrics[], options: FormatAn
 
   const resolvedOptions = resolveFormatOptions(options);
   const report = buildPrimaryAnalysisReport(metrics, threshold, options.format, resolvedOptions);
+  if (options.format === "junit") {
+    return formatJunitReport(report as AnalysisReport, resolvedOptions.omitRedundancy, options.elapsedSeconds);
+  }
   return REPORT_FORMATTERS[options.format](
     report,
     resolvedOptions.omitRedundancy
@@ -231,8 +235,8 @@ export function formatTextReport(report: SerializableReport, agent = false): str
   return [...summary, ...sourceExclusionLines, "", headerLine, separator, ...body].join("\n") + "\n";
 }
 
-export function formatJunitReport(report: AnalysisReport, omitRedundancy = false): string {
-  return `${formatXmlDeclaration()}\n${createXmlBuilder().build(toJunitXml(report, omitRedundancy)).trimEnd()}\n`;
+export function formatJunitReport(report: AnalysisReport, omitRedundancy = false, elapsedSeconds = 0): string {
+  return `${formatXmlDeclaration()}\n${createXmlBuilder().build(toJunitXml(report, omitRedundancy, elapsedSeconds)).trimEnd()}\n`;
 }
 
 function toMethodReportEntry(metric: MethodMetrics, threshold: number): MethodReportEntry {
@@ -354,8 +358,9 @@ function createXmlBuilder(): XMLBuilder {
   });
 }
 
-function toJunitXml(report: AnalysisReport, omitRedundancy: boolean): XmlNode {
+function toJunitXml(report: AnalysisReport, omitRedundancy: boolean, elapsedSeconds: number): XmlNode {
   const counts = countJunitMethodStatuses(report.methods);
+  const suiteTime = formatElapsedSeconds(elapsedSeconds);
   const testsuite: XmlNode = {
     "@_name": "crap-typescript",
     "@_status": report.status,
@@ -363,7 +368,7 @@ function toJunitXml(report: AnalysisReport, omitRedundancy: boolean): XmlNode {
     "@_failures": counts.failures,
     "@_skipped": counts.skipped,
     "@_errors": 0,
-    "@_time": 0,
+    "@_time": suiteTime,
     properties: {
       property: [
         toXmlProperty("threshold", formatNumber(report.threshold)),
@@ -383,10 +388,17 @@ function toJunitXml(report: AnalysisReport, omitRedundancy: boolean): XmlNode {
       "@_failures": counts.failures,
       "@_skipped": counts.skipped,
       "@_errors": 0,
-      "@_time": 0,
+      "@_time": suiteTime,
       testsuite
     }
   };
+}
+
+function formatElapsedSeconds(elapsedSeconds: number): string | number {
+  if (!(elapsedSeconds > 0)) {
+    return 0;
+  }
+  return Math.max(elapsedSeconds, 0.001).toFixed(3);
 }
 
 function optionalSourceExclusions(sourceExclusionAudit: SourceExclusionAudit | undefined): {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -667,6 +667,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(junit).toContain('name="safe:1"');
     expect(junit).toContain('name="risky:5"');
     expect(junit).toContain('name="sourceExclusions.candidateFiles" value="2"');
+    expect(Number.parseFloat(junit.match(/<testsuites [^>]*time="([^"]+)"/)?.[1] ?? "0")).toBeGreaterThan(0);
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
 
     const overrideStdout = new StringWriter();

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, symlink } from "node:fs/promises";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { parseCliArguments, runCli } from "../src/cli";
 import { createTempDir, disposeTempDir, readText, StringWriter, writeProjectFiles } from "./testUtils";
@@ -9,6 +9,7 @@ import { createTempDir, disposeTempDir, readText, StringWriter, writeProjectFile
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(tempDirs.splice(0).map(disposeTempDir));
 });
 
@@ -815,6 +816,27 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(junit).toContain('name="safe:1"');
     expect(junit).toContain('name="risky:5"');
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
+  });
+
+  it("writes a minimum non-zero JUnit suite time when the analysis completes within one clock tick", async () => {
+    const projectRoot = await createTempDir("crap-cli-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": "{}"
+    });
+    vi.spyOn(performance, "now").mockReturnValue(1_000);
+
+    const exitCode = await runCli(
+      ["--format", "none", "--junit-report", "reports/crap.xml"],
+      projectRoot,
+      new StringWriter(),
+      new StringWriter()
+    );
+    const junit = await readText(`${projectRoot}/reports/crap.xml`);
+
+    expect(exitCode).toBe(0);
+    expect(junit).toContain('time="0.001"');
   });
 
   it("omits redundant primary status fields and writes full JUnit sidecars", async () => {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -692,6 +692,14 @@ describe("report formatting", () => {
     expect(output).toContain("Source: src/sample.ts:1-3");
   });
 
+  it("formats JUnit suite times from elapsed seconds without changing testcase times", () => {
+    const output = formatJunitReport(buildAnalysisReport([metric()]), false, 1.2345);
+
+    expect(output).toContain('<testsuites name="crap-typescript" tests="1" failures="0" skipped="0" errors="0" time="1.234">');
+    expect(output).toContain('<testsuite name="crap-typescript" status="passed" tests="1" failures="0" skipped="0" errors="0" time="1.234">');
+    expect(output).toContain('<testcase classname="src/sample.ts" name="safe:1" file="src/sample.ts" time="0" line="1">');
+  });
+
   it("formats empty JUnit reports without testcase elements", () => {
     const output = formatJunitReport(buildAnalysisReport([]));
 

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -402,5 +402,5 @@ function buildJunitReportFromCoverage(coverageReportPath: string): string {
 }
 
 function elapsedSecondsSince(startedAt: number): number {
-  return Math.max(0, (performance.now() - startedAt) / 1000);
+  return Math.max(0.001, (performance.now() - startedAt) / 1000);
 }

--- a/packages/jest/src/reporter.ts
+++ b/packages/jest/src/reporter.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { access, mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -89,6 +90,7 @@ export default class CrapTypescriptJestReporter {
   private async finalize(): Promise<void> {
     try {
       const options = resolveReporterOptions(this.options);
+      const startedAt = performance.now();
       await validateReporterReportPaths(options);
       await waitForCoverageReport(options);
       const result = await analyzeProject({
@@ -108,7 +110,12 @@ export default class CrapTypescriptJestReporter {
         stderr: options.stderr
       });
 
-      await writeReporterReports(result.metrics, result.sourceExclusionAudit, options);
+      await writeReporterReports(
+        result.metrics,
+        result.sourceExclusionAudit,
+        options,
+        elapsedSecondsSince(startedAt)
+      );
       if (result.thresholdExceeded) {
         this.error = createThresholdExceededError(result.maxCrap, result.threshold);
         options.stderr.write(`${this.error.message}\n`);
@@ -349,7 +356,8 @@ function resolveOutputWriters(
 async function writeReporterReports(
   metrics: Awaited<ReturnType<typeof analyzeProject>>["metrics"],
   sourceExclusionAudit: SourceExclusionAudit,
-  options: ResolvedReporterOptions
+  options: ResolvedReporterOptions,
+  elapsedSeconds: number
 ): Promise<void> {
   const primaryReport = formatAnalysisReport(metrics, {
     format: options.format,
@@ -357,6 +365,7 @@ async function writeReporterReports(
     threshold: options.threshold,
     failuresOnly: options.failuresOnly,
     omitRedundancy: options.omitRedundancy,
+    elapsedSeconds,
     sourceExclusionAudit
   });
   if (options.output) {
@@ -369,6 +378,7 @@ async function writeReporterReports(
     await writeReportFile(options.projectRoot, options.junitReport, formatAnalysisReport(metrics, {
       format: "junit",
       threshold: options.threshold,
+      elapsedSeconds,
       sourceExclusionAudit
     }));
   }
@@ -389,4 +399,8 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
 
 function buildJunitReportFromCoverage(coverageReportPath: string): string {
   return `${path.dirname(coverageReportPath).replace(/\\/g, "/")}/crap-typescript-junit.xml`;
+}
+
+function elapsedSecondsSince(startedAt: number): number {
+  return Math.max(0, (performance.now() - startedAt) / 1000);
 }

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -555,6 +555,7 @@ describe("CrapTypescriptJestReporter", () => {
     expect(junit).toContain('name="risky:5"');
     expect(junit).toContain('<property name="status" value="passed"/>');
     expect(junit).toContain('<property name="status" value="failed"/>');
+    expect(Number.parseFloat(junit.match(/<testsuite [^>]*time="([^"]+)"/)?.[1] ?? "0")).toBeGreaterThan(0);
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
     expect(process.exitCode).toBe(2);
   });

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -560,6 +560,22 @@ describe("CrapTypescriptJestReporter", () => {
     expect(process.exitCode).toBe(2);
   });
 
+  it("writes a minimum non-zero JUnit suite time when finalize completes within one clock tick", async () => {
+    const projectRoot = await createTempDir("crap-jest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": "{}"
+    });
+    vi.spyOn(performance, "now").mockReturnValue(1_000);
+
+    const { reporter } = await finalizeWithOptions(projectRoot, {});
+    const junit = await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`);
+
+    expect(junit).toContain('time="0.001"');
+    expect(reporter.getLastError()).toBeUndefined();
+  });
+
   it("supports agent defaults and disabled JUnit output", async () => {
     const projectRoot = await createTempDir("crap-jest-reporter-");
     tempDirs.push(projectRoot);

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -53,6 +54,7 @@ export class CrapTypescriptVitestReporter {
   async onFinishedReportCoverage(): Promise<void> {
     const options = resolveReporterOptions(this.options);
     try {
+      const startedAt = performance.now();
       await validateReporterReportPaths(options);
       const result = await analyzeProject({
         projectRoot: options.projectRoot,
@@ -71,7 +73,12 @@ export class CrapTypescriptVitestReporter {
         stderr: options.stderr
       });
 
-      await writeReporterReports(result.metrics, result.sourceExclusionAudit, options);
+      await writeReporterReports(
+        result.metrics,
+        result.sourceExclusionAudit,
+        options,
+        elapsedSecondsSince(startedAt)
+      );
       if (result.thresholdExceeded) {
         const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${result.threshold.toFixed(1)}`;
         options.stderr.write(`${error}\n`);
@@ -258,7 +265,8 @@ function resolveJunitReport(options: CrapTypescriptVitestOptions): string {
 async function writeReporterReports(
   metrics: Awaited<ReturnType<typeof analyzeProject>>["metrics"],
   sourceExclusionAudit: SourceExclusionAudit,
-  options: ResolvedReporterOptions
+  options: ResolvedReporterOptions,
+  elapsedSeconds: number
 ): Promise<void> {
   const primaryReport = formatAnalysisReport(metrics, {
     format: options.format,
@@ -266,6 +274,7 @@ async function writeReporterReports(
     threshold: options.threshold,
     failuresOnly: options.failuresOnly,
     omitRedundancy: options.omitRedundancy,
+    elapsedSeconds,
     sourceExclusionAudit
   });
   if (options.output) {
@@ -278,6 +287,7 @@ async function writeReporterReports(
     await writeReportFile(options.projectRoot, options.junitReport, formatAnalysisReport(metrics, {
       format: "junit",
       threshold: options.threshold,
+      elapsedSeconds,
       sourceExclusionAudit
     }));
   }
@@ -298,4 +308,8 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
 
 function buildJunitReportFromCoverage(coverageReportPath: string | undefined): string {
   return `${path.dirname(coverageReportPath ?? "coverage/coverage-final.json").replace(/\\/g, "/")}/crap-typescript-junit.xml`;
+}
+
+function elapsedSecondsSince(startedAt: number): number {
+  return Math.max(0, (performance.now() - startedAt) / 1000);
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -311,5 +311,5 @@ function buildJunitReportFromCoverage(coverageReportPath: string | undefined): s
 }
 
 function elapsedSecondsSince(startedAt: number): number {
-  return Math.max(0, (performance.now() - startedAt) / 1000);
+  return Math.max(0.001, (performance.now() - startedAt) / 1000);
 }

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, symlink } from "node:fs/promises";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   StringWriter,
@@ -21,6 +21,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   process.exitCode = originalExitCode;
   await Promise.all(tempDirs.splice(0).map(disposeTempDir));
 });
@@ -433,6 +434,22 @@ describe("CrapTypescriptVitestReporter", () => {
     expect(stdout.toString()).toContain('<testsuite name="crap-typescript" status="passed" tests="0" failures="0" skipped="0" errors="0"');
     expect(Number.parseFloat(stdout.toString().match(/<testsuite [^>]*time="([^"]+)"/)?.[1] ?? "0")).toBeGreaterThan(0);
     expect(stdout.toString()).not.toContain('<property name="status"');
+    expect(stderr.toString()).toBe("");
+    expect(process.exitCode).toBe(originalExitCode);
+  });
+
+  it("writes a minimum non-zero JUnit suite time when reporting completes within one clock tick", async () => {
+    const projectRoot = await createTempDir("crap-vitest-reporter-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}'
+    });
+    vi.spyOn(performance, "now").mockReturnValue(1_000);
+
+    const { stderr } = await finishWithOptions(projectRoot, {});
+    const junit = await readText(`${projectRoot}/coverage/crap-typescript-junit.xml`);
+
+    expect(junit).toContain('time="0.001"');
     expect(stderr.toString()).toBe("");
     expect(process.exitCode).toBe(originalExitCode);
   });

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -430,7 +430,8 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await expect(reporter.onFinishedReportCoverage()).resolves.toBeUndefined();
 
-    expect(stdout.toString()).toContain('<testsuite name="crap-typescript" status="passed" tests="0" failures="0" skipped="0" errors="0" time="0">');
+    expect(stdout.toString()).toContain('<testsuite name="crap-typescript" status="passed" tests="0" failures="0" skipped="0" errors="0"');
+    expect(Number.parseFloat(stdout.toString().match(/<testsuite [^>]*time="([^"]+)"/)?.[1] ?? "0")).toBeGreaterThan(0);
     expect(stdout.toString()).not.toContain('<property name="status"');
     expect(stderr.toString()).toBe("");
     expect(process.exitCode).toBe(originalExitCode);


### PR DESCRIPTION
## Summary
- propagate elapsed runtime into CLI, Jest, and Vitest JUnit report generation
- write non-zero suite-level JUnit `time` values while leaving testcase times unchanged
- add focused coverage for core formatting plus CLI, Jest, and Vitest reporter output

## Testing
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #121