### PR TITLE
Validate Istanbul source positions

### DIFF
--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -68,7 +68,7 @@ function parseStatements(statementMapValue: unknown, hitsValue: unknown): Statem
 
   const statements: StatementCoverageUnit[] = [];
   for (const [key, locationValue] of Object.entries(statementMapValue)) {
-    const hits = parseInteger(hitsValue[key]);
+    const hits = parseFiniteNumber(hitsValue[key]);
     const span = parseSpan(locationValue);
     if (hits === null || span === null) {
       continue;
@@ -169,7 +169,7 @@ function parseFirstLocation(value: unknown): SourceSpan | null {
 }
 
 function parseLineSpan(value: unknown): SourceSpan | null {
-  const line = parseInteger(value);
+  const line = parseLineNumber(value);
   if (line === null) {
     return null;
   }
@@ -206,14 +206,14 @@ function parsePosition(value: unknown): { line: number; column: number } | null 
     return null;
   }
 
-  const line = parseInteger(value.line);
+  const line = parseLineNumber(value.line);
   if (line === null) {
     return null;
   }
 
   const column = value.column === null || value.column === undefined
     ? MAX_COLUMN
-    : parseInteger(value.column);
+    : parseColumnNumber(value.column);
   if (column === null) {
     return null;
   }
@@ -227,12 +227,26 @@ function parseHitArray(value: unknown): number[] {
   }
 
   return value
-    .map((entry) => parseInteger(entry))
+    .map((entry) => parseFiniteNumber(entry))
     .filter((entry): entry is number => entry !== null);
 }
 
-function parseInteger(value: unknown): number | null {
+function parseFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseLineNumber(value: unknown): number | null {
+  const parsed = parseInteger(value);
+  return parsed !== null && parsed >= 1 ? parsed : null;
+}
+
+function parseColumnNumber(value: unknown): number | null {
+  const parsed = parseInteger(value);
+  return parsed !== null && parsed >= 0 ? parsed : null;
+}
+
+function parseInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) ? value : null;
 }
 
 function deduplicateStatements(statements: StatementCoverageUnit[]): StatementCoverageUnit[] {

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -1000,6 +1000,108 @@ export function enumDeclOnly(): void {
     ]);
   });
 
+  it("rejects non-integer source positions while preserving finite hit counts", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/sample.ts": {
+          path: "src/sample.ts",
+          statementMap: {
+            "0": {
+              start: { line: 2, column: 2 },
+              end: { line: 2, column: 19 }
+            },
+            "1": {
+              start: { line: 3.5, column: 2 },
+              end: { line: 3, column: 19 }
+            },
+            "2": {
+              start: { line: 4, column: -1 },
+              end: { line: 4, column: 19 }
+            }
+          },
+          branchMap: {
+            "0": {
+              line: 6,
+              locations: [
+                {
+                  start: { line: 6, column: 2 },
+                  end: { line: 8, column: 3 }
+                }
+              ]
+            },
+            "1": {
+              line: 6.5
+            }
+          },
+          fnMap: {
+            "0": {
+              line: 1
+            },
+            "1": {
+              line: -1
+            },
+            "2": {
+              decl: {
+                start: { line: 1, column: -1 },
+                end: { line: 6, column: 1 }
+              }
+            }
+          },
+          s: {
+            "0": 1.5,
+            "1": 2,
+            "2": 3
+          },
+          b: {
+            "0": [1, 0.5],
+            "1": [2]
+          },
+          f: {}
+        }
+      })
+    });
+
+    const [fileCoverage] = (await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)).values();
+
+    expect(fileCoverage.statements).toEqual([
+      {
+        span: {
+          startLine: 2,
+          startColumn: 2,
+          endLine: 2,
+          endColumn: 19
+        },
+        hits: 1.5
+      }
+    ]);
+    expect(fileCoverage.branches).toEqual([
+      {
+        span: {
+          startLine: 6,
+          startColumn: 2,
+          endLine: 8,
+          endColumn: 3
+        },
+        hits: [1, 0.5]
+      }
+    ]);
+    expect(fileCoverage.functions).toEqual([
+      {
+        declarationStart: undefined,
+        span: {
+          startLine: 1,
+          startColumn: 0,
+          endLine: 1,
+          endColumn: Number.MAX_SAFE_INTEGER
+        },
+        spanSource: "line"
+      }
+    ]);
+  });
+
   it("prefers the most specific loc span when duplicate fnMap entries share an identity", async () => {
     const projectRoot = await createTempDir("crap-coverage-");
     tempDirs.push(projectRoot);


### PR DESCRIPTION
## Summary
- tighten Istanbul source position parsing so lines must be positive integers and columns must be non-negative integers
- keep finite hit counts accepted for statement and branch execution counts
- add regression coverage showing malformed source positions are discarded without rejecting valid fractional hit counts

## Testing
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #98