### PR TITLE
Prune build output roots during source discovery

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -25,8 +25,28 @@ function thresholdRecommendation(): string {
   return "Use 8.0 for hard gates, target 6.0 during implementation, and use the 8.0 default when in doubt.";
 }
 
+export const IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES = new Set([
+  ".git",
+  ".next",
+  ".nuxt",
+  ".svelte-kit",
+  ".turbo",
+  ".vite",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+  "target"
+]);
+
 export const IGNORED_DIRECTORIES = new Set([
   ".git",
+  ".next",
+  ".nuxt",
+  ".svelte-kit",
+  ".turbo",
+  ".vite",
   "coverage",
   "dist",
   "node_modules"

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -2,10 +2,11 @@ import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 import { IGNORED_DIRECTORIES, IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES } from "./constants.js";
-import { runCommand, toRelativePath } from "./utils.js";
+import { normalizeSlashes, runCommand, toRelativePath } from "./utils.js";
 
 const ANALYZABLE_EXTENSIONS = [".ts", ".tsx"];
 const TEST_FILE_MARKERS = [".test.", ".spec."];
+const BUILD_OUTPUT_SOURCE_ROOT_SEGMENTS = new Set(["build", "out", "target"]);
 const EXCLUDED_PATH_SEGMENTS = [
   "/__tests__/",
   "/.next/",
@@ -67,6 +68,9 @@ export function isAnalyzableFile(filePath: string): boolean {
     return false;
   }
   if (containsAny(baseName, TEST_FILE_MARKERS)) {
+    return false;
+  }
+  if (isGeneratedSourceRootPath(normalized)) {
     return false;
   }
   if (containsAny(`/${normalized}`, EXCLUDED_PATH_SEGMENTS)) {
@@ -139,6 +143,32 @@ function hasAnySuffix(value: string, suffixes: string[]): boolean {
   return suffixes.some((suffix) => value.endsWith(suffix));
 }
 
+function isGeneratedSourceRootPath(normalizedPath: string): boolean {
+  const segments = normalizedPath.split("/").filter(Boolean);
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    if (BUILD_OUTPUT_SOURCE_ROOT_SEGMENTS.has(segments[index]!) && segments[index + 1] === "src") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldSkipSourceRootDiscoveryDirectory(directoryPath: string): boolean {
+  const baseName = path.basename(directoryPath).toLowerCase();
+  if (!IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES.has(baseName)) {
+    return false;
+  }
+  if (!BUILD_OUTPUT_SOURCE_ROOT_SEGMENTS.has(baseName)) {
+    return true;
+  }
+  return !hasSourceAncestor(directoryPath);
+}
+
+function hasSourceAncestor(directoryPath: string): boolean {
+  const normalized = normalizeSlashes(path.resolve(directoryPath)).toLowerCase();
+  return normalized.split("/").filter(Boolean).slice(0, -1).includes("src");
+}
+
 async function walkForSourceRoots(
   currentDir: string,
   onSourceRoot: (sourceRoot: string) => Promise<void>
@@ -148,10 +178,10 @@ async function walkForSourceRoots(
     if (!entry.isDirectory()) {
       continue;
     }
-    if (IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES.has(entry.name)) {
+    const absolutePath = path.join(currentDir, entry.name);
+    if (shouldSkipSourceRootDiscoveryDirectory(absolutePath)) {
       continue;
     }
-    const absolutePath = path.join(currentDir, entry.name);
     if (entry.name === "src") {
       await onSourceRoot(absolutePath);
       continue;
@@ -181,11 +211,11 @@ async function walkSourceTree(
 }
 
 async function expandDirectoryPath(directoryPath: string, files: Set<string>): Promise<void> {
-  if (IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES.has(path.basename(directoryPath))) {
+  if (shouldSkipSourceRootDiscoveryDirectory(directoryPath)) {
     return;
   }
 
-  if (path.basename(directoryPath).toLowerCase() === "src") {
+  if (path.basename(directoryPath).toLowerCase() === "src" || hasSourceAncestor(directoryPath)) {
     await walkSourceTree(directoryPath, async (filePath) => {
       files.add(path.resolve(filePath));
     });

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -1,12 +1,22 @@
 import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
-import { IGNORED_DIRECTORIES } from "./constants.js";
+import { IGNORED_DIRECTORIES, IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES } from "./constants.js";
 import { runCommand, toRelativePath } from "./utils.js";
 
 const ANALYZABLE_EXTENSIONS = [".ts", ".tsx"];
 const TEST_FILE_MARKERS = [".test.", ".spec."];
-const EXCLUDED_PATH_SEGMENTS = ["/__tests__/", "/dist/", "/coverage/", "/node_modules/"];
+const EXCLUDED_PATH_SEGMENTS = [
+  "/__tests__/",
+  "/.next/",
+  "/.nuxt/",
+  "/.svelte-kit/",
+  "/.turbo/",
+  "/.vite/",
+  "/dist/",
+  "/coverage/",
+  "/node_modules/"
+];
 
 export async function findAllTypeScriptFilesUnderSourceRoots(projectRoot: string): Promise<string[]> {
   const files = new Set<string>();
@@ -138,7 +148,7 @@ async function walkForSourceRoots(
     if (!entry.isDirectory()) {
       continue;
     }
-    if (IGNORED_DIRECTORIES.has(entry.name)) {
+    if (IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES.has(entry.name)) {
       continue;
     }
     const absolutePath = path.join(currentDir, entry.name);
@@ -171,6 +181,10 @@ async function walkSourceTree(
 }
 
 async function expandDirectoryPath(directoryPath: string, files: Set<string>): Promise<void> {
+  if (IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES.has(path.basename(directoryPath))) {
+    return;
+  }
+
   if (path.basename(directoryPath).toLowerCase() === "src") {
     await walkSourceTree(directoryPath, async (filePath) => {
       files.add(path.resolve(filePath));

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -202,7 +202,7 @@ async function walkSourceTree(
   for (const entry of entries) {
     const absolutePath = path.join(currentDir, entry.name);
     if (entry.isDirectory()) {
-      if (IGNORED_DIRECTORIES.has(entry.name)) {
+      if (IGNORED_DIRECTORIES.has(entry.name.toLowerCase())) {
         continue;
       }
       await walkSourceTree(absolutePath, onFile);

--- a/packages/core/src/fileSelection.ts
+++ b/packages/core/src/fileSelection.ts
@@ -146,7 +146,11 @@ function hasAnySuffix(value: string, suffixes: string[]): boolean {
 function isGeneratedSourceRootPath(normalizedPath: string): boolean {
   const segments = normalizedPath.split("/").filter(Boolean);
   for (let index = 0; index < segments.length - 1; index += 1) {
-    if (BUILD_OUTPUT_SOURCE_ROOT_SEGMENTS.has(segments[index]!) && segments[index + 1] === "src") {
+    if (
+      BUILD_OUTPUT_SOURCE_ROOT_SEGMENTS.has(segments[index]!)
+      && segments[index + 1] === "src"
+      && !segments.slice(0, index).includes("src")
+    ) {
       return true;
     }
   }
@@ -182,7 +186,7 @@ async function walkForSourceRoots(
     if (shouldSkipSourceRootDiscoveryDirectory(absolutePath)) {
       continue;
     }
-    if (entry.name === "src") {
+    if (entry.name.toLowerCase() === "src") {
       await onSourceRoot(absolutePath);
       continue;
     }

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -79,6 +79,8 @@ describe("file selection", () => {
       "src/app.ts": "export const app = 1;",
       "src/nested/util.ts": "export const util = 1;",
       "src/__tests__/ignored.ts": "export const ignored = 1;",
+      "src/.next/ignored.ts": "export const ignored = 1;",
+      "src/.vite/ignored.ts": "export const ignored = 1;",
       "src/coverage/ignored.ts": "export const ignored = 1;",
       "src/dist/ignored.ts": "export const ignored = 1;",
       "src/node_modules/ignored.ts": "export const ignored = 1;"
@@ -88,6 +90,30 @@ describe("file selection", () => {
     expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
       "src/app.ts",
       "src/nested/util.ts"
+    ]);
+  });
+
+  it("skips build-output roots during source-root discovery without excluding src/build source folders", async () => {
+    const tempDir = await createTempDir("crap-files-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/app.ts": "export const app = 1;",
+      "src/build/handwritten.ts": "export const handwritten = 1;",
+      "packages/demo/build/src/generated.ts": "export const generated = 1;",
+      "packages/demo/out/src/generated.ts": "export const generated = 1;",
+      "packages/demo/target/src/generated.ts": "export const generated = 1;",
+      "packages/demo/.next/src/generated.ts": "export const generated = 1;",
+      "packages/demo/.nuxt/src/generated.ts": "export const generated = 1;",
+      "packages/demo/.svelte-kit/src/generated.ts": "export const generated = 1;",
+      "packages/demo/.turbo/src/generated.ts": "export const generated = 1;",
+      "packages/demo/.vite/src/generated.ts": "export const generated = 1;"
+    });
+
+    const files = await findAllTypeScriptFilesUnderSourceRoots(tempDir);
+    expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
+      "src/app.ts",
+      "src/build/handwritten.ts"
     ]);
   });
 
@@ -152,16 +178,26 @@ describe("file selection", () => {
     ]);
   });
 
-  it("filters declaration, test, dist, coverage, and node_modules paths from analyzable files", () => {
+  it("filters declaration, test, and generated-output paths from analyzable files", () => {
     expect(isAnalyzableFile("C:/repo/src/app.ts")).toBe(true);
     expect(isAnalyzableFile("C:/repo/src/component.tsx")).toBe(true);
     expect(isAnalyzableFile("C:/repo/src/types.d.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/src/app.spec.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/src/app.test.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/src/__tests__/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/.next/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/.nuxt/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/.svelte-kit/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/.turbo/app.ts")).toBe(false);
+    expect(isAnalyzableFile("C:/repo/.vite/app.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/dist/app.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/coverage/app.ts")).toBe(false);
     expect(isAnalyzableFile("C:/repo/node_modules/pkg/index.ts")).toBe(false);
+    expect(isAnalyzableFile(".next/app.ts")).toBe(false);
+    expect(isAnalyzableFile(".nuxt/app.ts")).toBe(false);
+    expect(isAnalyzableFile(".svelte-kit/app.ts")).toBe(false);
+    expect(isAnalyzableFile(".turbo/app.ts")).toBe(false);
+    expect(isAnalyzableFile(".vite/app.ts")).toBe(false);
     expect(isAnalyzableFile("dist/app.ts")).toBe(false);
     expect(isAnalyzableFile("coverage/app.ts")).toBe(false);
     expect(isAnalyzableFile("node_modules/pkg/index.ts")).toBe(false);
@@ -170,6 +206,18 @@ describe("file selection", () => {
     expect(isAnalyzableFile(path.join(filesystemRoot, "dist", "app.ts"))).toBe(false);
     expect(isAnalyzableFile(path.join(filesystemRoot, "coverage", "app.ts"))).toBe(false);
     expect(isAnalyzableFile(path.join(filesystemRoot, "node_modules", "pkg", "index.ts"))).toBe(false);
+  });
+
+  it("does not expand explicit build-output directories that would only contain generated source roots", async () => {
+    const tempDir = await createTempDir("crap-files-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"fixture","private":true}',
+      "packages/demo/build/src/generated.ts": "export const generated = 1;",
+      "packages/demo/out/src/generated.ts": "export const generated = 1;"
+    });
+
+    await expect(expandExplicitPaths(tempDir, ["packages/demo/build", "packages/demo/out"])).resolves.toEqual([]);
   });
 
   it("ignores deleted and non-source changes and reports git errors clearly", async () => {

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -15,6 +15,7 @@ import { createTempDir, disposeTempDir, initGitRepository, runProcess, writeProj
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.doUnmock("node:fs/promises");
   vi.doUnmock("../src/utils");
   vi.resetModules();
   await Promise.all(tempDirs.splice(0).map(disposeTempDir));
@@ -131,6 +132,35 @@ describe("file selection", () => {
     expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
       "packages/demo/Src/component.ts"
     ]);
+  });
+
+  it("does not descend into mixed-case ignored directories inside source trees", async () => {
+    vi.resetModules();
+    const repoRoot = path.join(process.cwd(), "mock-repo");
+    const srcRoot = path.join(repoRoot, "src");
+    const mixedCaseIgnored = path.join(srcRoot, "Node_Modules");
+    const readdir = vi.fn(async (currentDir: string) => {
+      if (currentDir === repoRoot) {
+        return [dirEntry("src", "directory")];
+      }
+      if (currentDir === srcRoot) {
+        return [
+          dirEntry("Node_Modules", "directory"),
+          dirEntry("app.ts", "file")
+        ];
+      }
+      if (currentDir === mixedCaseIgnored) {
+        throw new Error("walkSourceTree descended into a mixed-case ignored directory");
+      }
+      return [];
+    });
+    vi.doMock("node:fs/promises", () => ({ readdir }));
+
+    const { findAllTypeScriptFilesUnderSourceRoots: findFiles } = await import("../src/fileSelection");
+    const files = await findFiles(repoRoot);
+
+    expect(files).toEqual([path.join(srcRoot, "app.ts")]);
+    expect(readdir).not.toHaveBeenCalledWith(mixedCaseIgnored, { withFileTypes: true });
   });
 
   it("finds changed TypeScript files under src trees from git status", async () => {
@@ -311,3 +341,15 @@ describe("file selection", () => {
     });
   });
 });
+
+function dirEntry(name: string, type: "directory" | "file"): {
+  name: string;
+  isDirectory(): boolean;
+  isFile(): boolean;
+} {
+  return {
+    name,
+    isDirectory: () => type === "directory",
+    isFile: () => type === "file"
+  };
+}

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -213,11 +213,36 @@ describe("file selection", () => {
     tempDirs.push(tempDir);
     await writeProjectFiles(tempDir, {
       "package.json": '{"name":"fixture","private":true}',
+      "src/build/handwritten.ts": "export const handwritten = 1;",
       "packages/demo/build/src/generated.ts": "export const generated = 1;",
       "packages/demo/out/src/generated.ts": "export const generated = 1;"
     });
 
     await expect(expandExplicitPaths(tempDir, ["packages/demo/build", "packages/demo/out"])).resolves.toEqual([]);
+    await expect(expandExplicitPaths(tempDir, ["src/build"])).resolves.toEqual([
+      path.join(tempDir, "src", "build", "handwritten.ts")
+    ]);
+  });
+
+  it("ignores changed files under generated build-output src roots while keeping src/build files", async () => {
+    const tempDir = await createTempDir("crap-files-");
+    tempDirs.push(tempDir);
+    await initGitRepository(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/build/handwritten.ts": "export const handwritten = 1;\n",
+      "packages/demo/build/src/generated.ts": "export const generated = 1;\n"
+    });
+    await runProcess("git", ["add", "."], tempDir);
+    await runProcess("git", ["commit", "-m", "initial"], tempDir);
+
+    await writeFile(path.join(tempDir, "src", "build", "handwritten.ts"), "export const handwritten = 2;\n", "utf8");
+    await writeFile(path.join(tempDir, "packages", "demo", "build", "src", "generated.ts"), "export const generated = 2;\n", "utf8");
+
+    const files = await changedTypeScriptFilesUnderSourceRoots(tempDir);
+    expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
+      "src/build/handwritten.ts"
+    ]);
   });
 
   it("ignores deleted and non-source changes and reports git errors clearly", async () => {

--- a/packages/core/test/fileSelection.test.ts
+++ b/packages/core/test/fileSelection.test.ts
@@ -100,6 +100,7 @@ describe("file selection", () => {
       "package.json": '{"name":"fixture","private":true}',
       "src/app.ts": "export const app = 1;",
       "src/build/handwritten.ts": "export const handwritten = 1;",
+      "src/build/src/nested.ts": "export const nested = 1;",
       "packages/demo/build/src/generated.ts": "export const generated = 1;",
       "packages/demo/out/src/generated.ts": "export const generated = 1;",
       "packages/demo/target/src/generated.ts": "export const generated = 1;",
@@ -113,7 +114,22 @@ describe("file selection", () => {
     const files = await findAllTypeScriptFilesUnderSourceRoots(tempDir);
     expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
       "src/app.ts",
-      "src/build/handwritten.ts"
+      "src/build/handwritten.ts",
+      "src/build/src/nested.ts"
+    ]);
+  });
+
+  it("discovers mixed-case src directories", async () => {
+    const tempDir = await createTempDir("crap-files-");
+    tempDirs.push(tempDir);
+    await writeProjectFiles(tempDir, {
+      "package.json": '{"name":"fixture","private":true}',
+      "packages/demo/Src/component.ts": "export const component = 1;"
+    });
+
+    const files = await findAllTypeScriptFilesUnderSourceRoots(tempDir);
+    expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
+      "packages/demo/Src/component.ts"
     ]);
   });
 
@@ -231,17 +247,20 @@ describe("file selection", () => {
     await writeProjectFiles(tempDir, {
       "package.json": '{"name":"fixture","private":true}',
       "src/build/handwritten.ts": "export const handwritten = 1;\n",
+      "src/build/src/nested.ts": "export const nested = 1;\n",
       "packages/demo/build/src/generated.ts": "export const generated = 1;\n"
     });
     await runProcess("git", ["add", "."], tempDir);
     await runProcess("git", ["commit", "-m", "initial"], tempDir);
 
     await writeFile(path.join(tempDir, "src", "build", "handwritten.ts"), "export const handwritten = 2;\n", "utf8");
+    await writeFile(path.join(tempDir, "src", "build", "src", "nested.ts"), "export const nested = 2;\n", "utf8");
     await writeFile(path.join(tempDir, "packages", "demo", "build", "src", "generated.ts"), "export const generated = 2;\n", "utf8");
 
     const files = await changedTypeScriptFilesUnderSourceRoots(tempDir);
     expect(files.map((file) => path.relative(tempDir, file).replace(/\\/g, "/"))).toEqual([
-      "src/build/handwritten.ts"
+      "src/build/handwritten.ts",
+      "src/build/src/nested.ts"
     ]);
   });
 


### PR DESCRIPTION
## Summary
- skip common build-output roots such as `build`, `out`, `target`, `.next`, `.nuxt`, `.svelte-kit`, `.turbo`, and `.vite` during source-root discovery
- keep `src/build/**` analyzable so handwritten source folders are not dropped just because they share a common output-style name
- extend file-selection coverage for nested ignored directories, generated build roots, and explicit directory expansion

## Testing
- `npm test`
- `npm run build`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`

Closes #115