### PR TITLE
Align threshold warnings with the default CRAP limit

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,6 +2,7 @@ export const CRAP_THRESHOLD = 8.0;
 export const COVERAGE_REPORT_RELATIVE_PATH = "coverage/coverage-final.json";
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No analyzable functions found.";
+const IMPLEMENTATION_TARGET_CRAP_THRESHOLD = 6.0;
 
 export function validateThreshold(value: number): number {
   if (!Number.isFinite(value) || value <= 0) {
@@ -21,7 +22,7 @@ export function thresholdWarning(value: number): string {
 }
 
 function thresholdRecommendation(): string {
-  return "Use 8.0 for hard gates, target 6.0 during implementation, and use the 8.0 default when in doubt.";
+  return `Use ${CRAP_THRESHOLD.toFixed(1)} for hard gates, target ${IMPLEMENTATION_TARGET_CRAP_THRESHOLD.toFixed(1)} during implementation, and use the ${CRAP_THRESHOLD.toFixed(1)} default when in doubt.`;
 }
 
 export const IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES = new Set([

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,5 +1,4 @@
 export const CRAP_THRESHOLD = 8.0;
-const TOO_LENIENT_THRESHOLD = 8.0;
 export const COVERAGE_REPORT_RELATIVE_PATH = "coverage/coverage-final.json";
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No analyzable functions found.";
@@ -15,8 +14,8 @@ export function thresholdWarning(value: number): string {
   if (value < 4.0) {
     return `Warning: CRAP threshold below 4.0 is likely too noisy. ${thresholdRecommendation()}`;
   }
-  if (value > TOO_LENIENT_THRESHOLD) {
-    return `Warning: CRAP threshold above ${TOO_LENIENT_THRESHOLD.toFixed(1)} is too lenient even for hard gates. ${thresholdRecommendation()}`;
+  if (value > CRAP_THRESHOLD) {
+    return `Warning: CRAP threshold above ${CRAP_THRESHOLD.toFixed(1)} is too lenient even for hard gates. ${thresholdRecommendation()}`;
   }
   return "";
 }

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { CRAP_THRESHOLD, thresholdWarning } from "../src/constants";
+
+describe("thresholdWarning", () => {
+  it("does not warn at the default threshold boundary", () => {
+    expect(thresholdWarning(CRAP_THRESHOLD)).toBe("");
+  });
+
+  it("warns when the threshold is above the default hard-gate threshold", () => {
+    expect(thresholdWarning(CRAP_THRESHOLD + 0.5)).toContain(
+      `CRAP threshold above ${CRAP_THRESHOLD.toFixed(1)} is too lenient`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remove the duplicate too-lenient threshold constant and reuse the canonical CRAP threshold
- keep threshold warning behavior unchanged while making the shared boundary explicit
- add focused tests for the default-boundary and above-boundary warning cases

## Verification
- npm run build
- npm test
- npm run crap-typescript-check

Closes #114