### PR TITLE
Fix #175 align CI stage families and quality gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
 
       - name: Install dependencies
         run: npm ci
@@ -74,8 +74,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
 
       - name: Download dependencies
         uses: actions/download-artifact@v4
@@ -115,8 +115,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
 
       - name: Download dependencies
         uses: actions/download-artifact@v4
@@ -144,8 +144,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
 
       - name: Download dependencies
         uses: actions/download-artifact@v4
@@ -179,8 +179,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
 
       - name: Download dependencies
         uses: actions/download-artifact@v4
@@ -220,8 +220,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+      - name: Set up npm 11.6.2
+        run: npm install --global npm@11.6.2
 
       - name: Download dependencies
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Set up npm 11.6.2
-        run: npm install --global npm@11.6.2
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Install dependencies
         run: npm ci
@@ -58,8 +58,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Set up npm 11.6.2
-        run: npm install --global npm@11.6.2
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Install dependencies
         run: npm ci
@@ -93,8 +93,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.6.2
-        run: npm install --global npm@11.6.2
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Install dependencies
         run: npm ci
@@ -119,8 +119,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.6.2
-        run: npm install --global npm@11.6.2
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Install dependencies
         run: npm ci
@@ -148,8 +148,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.6.2
-        run: npm install --global npm@11.6.2
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Install dependencies
         run: npm ci
@@ -183,8 +183,8 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.6.2
-        run: npm install --global npm@11.6.2
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Upload dependencies
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-modules-${{ matrix.os }}-${{ matrix.node-version }}
-          path: node_modules
-          if-no-files-found: error
-
       - name: Upload build outputs
         uses: actions/upload-artifact@v4
         with:
@@ -77,11 +70,8 @@ jobs:
       - name: Set up npm 11.6.2
         run: npm install --global npm@11.6.2
 
-      - name: Download dependencies
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules-${{ matrix.os }}-${{ matrix.node-version }}
-          path: node_modules
+      - name: Install dependencies
+        run: npm ci
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
@@ -118,11 +108,8 @@ jobs:
       - name: Set up npm 11.6.2
         run: npm install --global npm@11.6.2
 
-      - name: Download dependencies
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules-ubuntu-latest-24.0.0
-          path: node_modules
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run lint
         run: npm run lint
@@ -147,11 +134,8 @@ jobs:
       - name: Set up npm 11.6.2
         run: npm install --global npm@11.6.2
 
-      - name: Download dependencies
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules-ubuntu-latest-24.0.0
-          path: node_modules
+      - name: Install dependencies
+        run: npm ci
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
@@ -182,11 +166,8 @@ jobs:
       - name: Set up npm 11.6.2
         run: npm install --global npm@11.6.2
 
-      - name: Download dependencies
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules-ubuntu-latest-24.0.0
-          path: node_modules
+      - name: Install dependencies
+        run: npm ci
 
       - name: Download build outputs
         uses: actions/download-artifact@v4
@@ -223,11 +204,8 @@ jobs:
       - name: Set up npm 11.6.2
         run: npm install --global npm@11.6.2
 
-      - name: Download dependencies
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules-ubuntu-latest-24.0.0
-          path: node_modules
+      - name: Install dependencies
+        run: npm ci
 
       - name: Download build outputs
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,12 @@ permissions:
 
 jobs:
   build:
-    name: Build and Test (Node ${{ matrix.node-version }}, ${{ matrix.os }})
+    name: build (Node ${{ matrix.node-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         node-version: ["22.12.0", "24.0.0"]
 
     steps:
@@ -34,106 +34,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint sources
-        run: npm run lint
-
-      - name: Build packages
+      - name: Build
         run: npm run build
 
-      - name: Run tests
-        run: npm test
-
-      - name: Verify workspace packages
-        run: npm pack --workspaces
-
-  ubuntu-build-node-22:
-    name: Build and Test (Node 22.12.0, ubuntu-latest)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Node 22.12.0
-        uses: actions/setup-node@v6
+      - name: Upload dependencies
+        uses: actions/upload-artifact@v4
         with:
-          node-version: 22.12.0
-          cache: npm
+          name: node-modules-${{ matrix.os }}-${{ matrix.node-version }}
+          path: node_modules
+          if-no-files-found: error
 
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint sources
-        run: npm run lint
-
-      - name: Build packages
-        run: npm run build
-
-      - name: Run tests
-        run: npm test
-
-      - name: Verify workspace packages
-        run: npm pack --workspaces
-
-      - name: Save crap-typescript gate workspace
-        uses: actions/cache/save@v4
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
         with:
+          name: build-output-${{ matrix.os }}-${{ matrix.node-version }}
           path: |
-            node_modules
             packages/*/dist
             packages/*/.tsbuildinfo
-          key: crap-typescript-gate-ubuntu-22.12.0-${{ github.sha }}
+          if-no-files-found: error
 
-  ubuntu-build-node-24:
-    name: Build and Test (Node 24.0.0, ubuntu-latest)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Node 24.0.0
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.0.0
-          cache: npm
-
-      - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint sources
-        run: npm run lint
-
-      - name: Build packages
-        run: npm run build
-
-      - name: Run tests
-        run: npm test
-
-      - name: Verify workspace packages
-        run: npm pack --workspaces
-
-      - name: Save crap-typescript gate workspace
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            node_modules
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          key: crap-typescript-gate-ubuntu-24.0.0-${{ github.sha }}
-
-  cognitive-typescript-gate:
-    name: cognitive-typescript Gate (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
+  test-unit:
+    name: test / unit (Node ${{ matrix.node-version }}, ${{ matrix.os }})
+    needs:
+      - build
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
         node-version: ["22.12.0", "24.0.0"]
 
     steps:
@@ -149,40 +77,33 @@ jobs:
       - name: Set up npm 11.14.1
         run: npm install --global npm@11.14.1
 
-      - name: Run cognitive-typescript gate
-        run: node ./scripts/run-cognitive-typescript-gate.mjs packages
-
-  crap-typescript-gate-node-22:
-    name: crap-typescript Gate (Node 22.12.0)
-    runs-on: ubuntu-latest
-    needs: [ubuntu-build-node-22]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Node 22.12.0
-        uses: actions/setup-node@v6
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
         with:
-          node-version: 22.12.0
+          name: node-modules-${{ matrix.os }}-${{ matrix.node-version }}
+          path: node_modules
 
-      - name: Restore prepared workspace
-        uses: actions/cache/restore@v4
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            node_modules
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          key: crap-typescript-gate-ubuntu-22.12.0-${{ github.sha }}
-          fail-on-cache-miss: true
+          name: build-output-${{ matrix.os }}-${{ matrix.node-version }}
+          path: .
 
-      - name: Run crap-typescript gate
-        run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
+      - name: Run unit tests
+        run: npm test
 
-  crap-typescript-gate-node-24:
-    name: crap-typescript Gate (Node 24.0.0)
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.node-version }}
+          path: coverage
+          if-no-files-found: error
+
+  lint:
+    name: verify / lint
     runs-on: ubuntu-latest
-    needs: [ubuntu-build-node-24]
+    needs:
+      - build
 
     steps:
       - name: Checkout
@@ -192,31 +113,127 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.0.0
+          cache: npm
 
-      - name: Restore prepared workspace
-        uses: actions/cache/restore@v4
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            node_modules
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          key: crap-typescript-gate-ubuntu-24.0.0-${{ github.sha }}
-          fail-on-cache-miss: true
+          name: node-modules-ubuntu-latest-24.0.0
+          path: node_modules
 
-      - name: Run crap-typescript gate
-        run: node ./node_modules/vitest/vitest.mjs run --config vitest.crap.config.ts
+      - name: Run lint
+        run: npm run lint
 
-  crap-typescript-gate-required:
-    name: crap-typescript Gate
+  package:
+    name: package
     runs-on: ubuntu-latest
-    needs: [crap-typescript-gate-node-22, crap-typescript-gate-node-24]
-    if: ${{ always() }}
+    needs:
+      - build
+      - test-unit
 
     steps:
-      - name: Require the matrix CRAP gate to pass
-        shell: bash
-        run: |
-          if [ "${{ needs.crap-typescript-gate-node-22.result }}" != "success" ] || [ "${{ needs.crap-typescript-gate-node-24.result }}" != "success" ]; then
-            echo "The matrix crap-typescript gate did not complete successfully." >&2
-            exit 1
-          fi
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node 24.0.0
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.0.0
+          cache: npm
+
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-ubuntu-latest-24.0.0
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output-ubuntu-latest-24.0.0
+          path: .
+
+      - name: Verify workspace packages
+        run: npm pack --workspaces
+
+  quality-crap-crap-typescript:
+    name: verify / quality-crap-crap-typescript
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node 24.0.0
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.0.0
+          cache: npm
+
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-ubuntu-latest-24.0.0
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output-ubuntu-latest-24.0.0
+          path: .
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-ubuntu-latest-24.0.0
+          path: coverage
+
+      - name: Run crap-typescript gate
+        run: npm run crap-typescript-check
+
+  quality-cognitive-crap-typescript:
+    name: verify / quality-cognitive-crap-typescript
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node 24.0.0
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.0.0
+          cache: npm
+
+      - name: Set up npm 11.14.1
+        run: npm install --global npm@11.14.1
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules-ubuntu-latest-24.0.0
+          path: node_modules
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output-ubuntu-latest-24.0.0
+          path: .
+
+      - name: Run cognitive-typescript gate
+        run: npm run cognitive-typescript-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,3 +194,18 @@ jobs:
 
       - name: Run cognitive-typescript gate
         run: npm run cognitive-typescript-check
+
+  quality-crap-compat:
+    name: crap-typescript Gate
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - quality-crap-crap-typescript
+
+    steps:
+      - name: Fail when the CRAP gate failed
+        if: ${{ needs.quality-crap-crap-typescript.result != 'success' }}
+        run: exit 1
+
+      - name: Confirm legacy CRAP gate
+        run: echo "CRAP gate succeeded."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Upload build outputs
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-output-${{ matrix.os }}-${{ matrix.node-version }}
-          path: |
-            packages/*/dist
-            packages/*/.tsbuildinfo
-          if-no-files-found: error
-
   test-unit:
     name: test / unit (Node ${{ matrix.node-version }}, ${{ matrix.os }})
     needs:
@@ -73,11 +64,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output-${{ matrix.os }}-${{ matrix.node-version }}
-          path: .
+      - name: Build
+        run: npm run build
 
       - name: Run unit tests
         run: npm test
@@ -137,11 +125,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output-ubuntu-latest-24.0.0
-          path: .
+      - name: Build
+        run: npm run build
 
       - name: Verify workspace packages
         run: npm pack --workspaces
@@ -169,11 +154,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output-ubuntu-latest-24.0.0
-          path: .
+      - name: Build
+        run: npm run build
 
       - name: Download coverage
         uses: actions/download-artifact@v4
@@ -207,11 +189,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build outputs
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output-ubuntu-latest-24.0.0
-          path: .
+      - name: Build
+        run: npm run build
 
       - name: Run cognitive-typescript gate
         run: npm run cognitive-typescript-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Render release notes
         run: node ./scripts/render-release-notes.mjs "${GITHUB_REF_NAME}" > release-notes.md
 
-      - name: Run build and tests
+      - name: Build workspace packages
+        run: npm run build
+
+      - name: Run tests
         run: npm test
 
       - name: Run cognitive-typescript gate
@@ -49,7 +52,6 @@ jobs:
       - name: Build publish artifacts
         run: |
           mkdir -p release-artifacts
-          npm run build
           npm pack --workspaces --pack-destination release-artifacts
           cp release-notes.md release-artifacts/release-notes.md
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -513,27 +514,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1738,6 +1718,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2237,6 +2218,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2374,6 +2356,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2645,6 +2628,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3046,6 +3030,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3904,6 +3889,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -6024,6 +6010,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6169,6 +6156,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6246,6 +6234,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -514,6 +513,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1718,7 +1738,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -2218,7 +2237,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2356,7 +2374,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2628,7 +2645,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3030,7 +3046,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3889,7 +3904,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -6010,7 +6024,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6156,7 +6169,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6234,7 +6246,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "build": "tsc -b packages/core packages/cli packages/vitest packages/jest",
     "lint": "eslint .",
     "cognitive-typescript-check": "node ./scripts/run-cognitive-typescript-gate.mjs packages",
-    "crap-typescript-check": "npm run build && vitest run --config vitest.crap.config.ts",
-    "test": "npm run build && vitest run",
+    "crap-typescript-check": "vitest run --config vitest.crap.config.ts",
+    "test": "vitest run --coverage.enabled true",
     "pack": "npm pack --workspaces",
     "render-release-notes": "node ./scripts/render-release-notes.mjs",
     "verify-release-version": "node ./scripts/verify-release-version.mjs"


### PR DESCRIPTION
## Summary - align the Node workflow to stage-family job names - split CRAP and cognitive checks into dedicated jobs - reuse installed dependencies, build outputs, and coverage across jobs  ## Validation - ran build, test, CRAP, and cognitive npm commands locally in workflow order 

Closes #175