### PR TITLE
[codex] Fix #176 version policy audit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        node-version: ["22.12.0", "24.0.0"]
+        node-version: ["22.13.0", "24.0.0"]
 
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        node-version: ["22.12.0", "24.0.0"]
+        node-version: ["22.13.0", "24.0.0"]
 
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6615,7 +6615,7 @@
         "crap-typescript": "dist/bin.js"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.13.0"
       }
     },
     "packages/core": {
@@ -6628,7 +6628,7 @@
         "typescript": "^6.0.2"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.13.0"
       }
     },
     "packages/jest": {
@@ -6639,7 +6639,7 @@
         "@barney-media/crap-typescript-core": "^0.3.0"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.13.0"
       },
       "peerDependencies": {
         "jest": "^30.0.0"
@@ -6653,7 +6653,7 @@
         "@barney-media/crap-typescript-core": "^0.3.0"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.13.0"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/fabian-barney/crap-typescript/issues"
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.13.0"
   },
   "packageManager": "npm@11.14.1",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@barney-media/crap-typescript-core": "^0.3.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@toon-format/toon": "^2.1.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -42,7 +42,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@barney-media/crap-typescript-core": "^0.3.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -38,7 +38,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@barney-media/crap-typescript-core": "^0.3.0"


### PR DESCRIPTION
## Summary
- raise the declared Node support floor from `>=22.12.0` to `>=22.13.0` across the root package and all published workspaces
- update the CI build matrix lower bound from `22.12.0` to `22.13.0` so workflow coverage matches the manifest support floor
- regenerate `package-lock.json` after the engine-floor change

## Why
`eslint@10.4.0` requires Node `^20.19.0 || ^22.13.0 || >=24`, so the repo's previous `22.12.0` floor was below the toolchain's own supported range.

## Validation
- `npm install --package-lock-only`
- `npm run lint`
- `npm run build`
- `npm test`

Closes #176