### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - No unreleased changes.
 
+## [0.4.0] - 2026-05-24
+
+### Added
+
+- Added configurable source exclusions for generated or external TypeScript sources, including path globs, path regexes, function-name regexes, comment markers, and optional default exclusions.
+- Added deterministic report sorting, GitLab-compatible JUnit XML output, Bun package-manager detection, and stricter report-path containment and package-manager validation.
+- Added stronger CI and release validation coverage, including platform-matrix builds, lint enforcement, package-version verification, release-artifact assembly, and self-gate release checks.
+
+### Changed
+
+- Hardened changed-file analysis, coverage-report fallback behavior, and coverage-command diagnostics across Windows, macOS, and Linux workflows.
+- Expanded the CLI, core library, and Jest and Vitest adapters to handle richer parser diagnostics, constructor and optional-chaining cases, and clearer threshold and exit-code messaging.
+
+### Fixed
+
+- Fixed parse-span and source-position validation around malformed coverage input, fixture-backed compatibility cases, and container/body attribution edge cases.
+- Fixed reporter and release-note rendering behavior so empty or partial report artifacts fail early instead of silently generating invalid output.
+
 ## [0.3.0] - 2026-05-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crap-typescript-parent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crap-typescript-parent",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -6606,10 +6606,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/crap-typescript",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.3.0"
+        "@barney-media/crap-typescript-core": "^0.4.0"
       },
       "bin": {
         "crap-typescript": "dist/bin.js"
@@ -6620,7 +6620,7 @@
     },
     "packages/core": {
       "name": "@barney-media/crap-typescript-core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@toon-format/toon": "^2.1.0",
@@ -6633,10 +6633,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/crap-typescript-jest",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.3.0"
+        "@barney-media/crap-typescript-core": "^0.4.0"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -6647,10 +6647,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/crap-typescript-vitest",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.3.0"
+        "@barney-media/crap-typescript-core": "^0.4.0"
       },
       "engines": {
         "node": ">=22.13.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crap-typescript-parent",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CRAP metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CLI for CRAP metric analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,6 +45,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.3.0"
+    "@barney-media/crap-typescript-core": "^0.4.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Core CRAP metric analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-jest",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Jest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,7 +45,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.3.0"
+    "@barney-media/crap-typescript-core": "^0.4.0"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-vitest",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Vitest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -41,7 +41,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.3.0"
+    "@barney-media/crap-typescript-core": "^0.4.0"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- prepare the v0.4.0 release metadata and package versions
- promote the current merged mainline delta into the 2026-05-24 changelog entry
- keep the release branch limited to version/changelog updates only

## Validation
- npm ci
- npm run build
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- npm run verify-release-version -- v0.4.0
- npm run render-release-notes -- v0.4.0
- npm pack --workspaces