### PR TITLE
Fix release tarball publish paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,10 @@ jobs:
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
-          npm publish "release-artifacts/barney-media-crap-typescript-core-${version}.tgz" --access public
-          npm publish "release-artifacts/barney-media-crap-typescript-${version}.tgz" --access public
-          npm publish "release-artifacts/barney-media-crap-typescript-vitest-${version}.tgz" --access public
-          npm publish "release-artifacts/barney-media-crap-typescript-jest-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-crap-typescript-core-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-crap-typescript-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-crap-typescript-vitest-${version}.tgz" --access public
+          npm publish "./release-artifacts/barney-media-crap-typescript-jest-${version}.tgz" --access public
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
## Summary
- prefix the release tarball paths with ./ so npm publish treats them as local files
- keep the fix scoped to the release workflow only

## Validation
- npm publish ./barney-media-crap-typescript-core-0.4.0.tgz --dry-run