### PR TITLE
chore(deps): update compatible npm tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -59,7 +59,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -71,7 +71,7 @@ jobs:
         run: npm test
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.node-version }}
           path: coverage
@@ -94,7 +94,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -120,7 +120,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -149,7 +149,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -158,7 +158,7 @@ jobs:
         run: npm run build
 
       - name: Download coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-ubuntu-latest-24.0.0
           path: coverage
@@ -184,7 +184,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
         run: npm run build
 
       - name: Download coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: coverage-ubuntu-latest-24.0.0
           path: coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -93,7 +93,7 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -119,7 +119,7 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -148,7 +148,7 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies
@@ -183,7 +183,7 @@ jobs:
           node-version: 24.0.0
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           cache: npm
 
       - name: Set up npm 11.14.1
-        run: npm install --global npm@11.14.1
+        run: npm install --global npm@11.15.0
 
       - name: Install dependencies
         run: npm ci
@@ -56,7 +56,7 @@ jobs:
           cp release-notes.md release-artifacts/release-notes.md
 
       - name: Upload publish artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-artifacts
           path: release-artifacts/
@@ -78,7 +78,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Download publish artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-artifacts
           path: release-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "24"
           cache: npm
 
-      - name: Set up npm 11.14.1
+      - name: Set up npm 11.15.0
         run: npm install --global npm@11.15.0
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Download publish artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: release-artifacts
           path: release-artifacts

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "packageManager": "npm@11.14.1",
+  "packageManager": "npm@11.15.0",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
Closes #181## Summary- Updates npm packageManager/workflow installer and artifact actions.- Preserves Node >=22.13.0 and leaves test fixture manifests unchanged.## Validation- npx npm@11.15.0 ci; npx npm@11.15.0 run build; npx npm@11.15.0 test; npx npm@11.15.0 run lint; npx npm@11.15.0 run pack.## Review Notes- Dependency-only change; no public runtime floor was raised.- Latest-compatible versions were selected over latest-absolute releases when framework or runtime constraints required it.