### PR TITLE
Fix coverage path ambiguity

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -9,6 +9,7 @@ This matrix records which coverage-attribution shapes are verified by golden fix
 | Vitest-style Istanbul JSON with relative source paths | `tests/fixtures/compatibility-matrix/vitest-style-report` | Verifies normalized Istanbul JSON coverage with relative `path` values. |
 | Jest-style Istanbul JSON with absolute source paths | `tests/fixtures/compatibility-matrix/jest-style-report` | Verifies normalized Istanbul JSON coverage when the report record resolves to an absolute source path. |
 | Workspace coverage lookup across multiple packages | `tests/fixtures/workspace-project` | Verifies per-package coverage lookup and analysis across a workspace layout. |
+| Ambiguous suffix coverage paths | `tests/fixtures/compatibility-matrix/ambiguous-suffix-coverage` | Verifies suffix fallback reports `N/A` with a warning instead of selecting the first same-suffix coverage record. |
 | TSX parsing and attribution | `tests/fixtures/compatibility-matrix/tsx-component` | Verifies `.tsx` parsing and attribution to an expression-bodied component function. |
 | TSX-adjacent generic arrows | `tests/fixtures/compatibility-matrix/tsx-generic-arrows` | Verifies generic arrow parsing in `.tsx` files that also contain JSX syntax. |
 | Accessors | `tests/fixtures/compatibility-matrix/accessors` | Verifies getter and setter discovery, naming, and independent coverage attribution. |

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -71,11 +71,23 @@ interface FileAnalysisResult {
   warnings: string[];
 }
 
+interface FileCoverageResolution {
+  coverage: FileCoverage | undefined;
+  unknownReason: CoverageUnknownReason | null;
+  ambiguousMatchCount?: number;
+}
+
 interface LoadedCoverage {
   coverageByFile: Map<string, FileCoverage>;
+  coverageSourceRoot: string | null;
   unknownReason: CoverageUnknownReason | null;
   warnings: string[];
 }
+
+type SuffixCoverageResolution =
+  | { status: "matched"; coverage: FileCoverage }
+  | { status: "ambiguous"; matchCount: number }
+  | { status: "unmatched" };
 
 function createAnalyzeContext(options: AnalyzeProjectOptions): AnalyzeContext {
   return {
@@ -158,6 +170,7 @@ async function loadModuleCoverage(
   if (!coverageResult.coverageSourcePath || !coverageResult.coverageSourceRoot) {
     return {
       coverageByFile: new Map<string, FileCoverage>(),
+      coverageSourceRoot: null,
       unknownReason: "missing_report",
       warnings: [emitWarning(
         context.stderr,
@@ -169,6 +182,7 @@ async function loadModuleCoverage(
   try {
     return {
       coverageByFile: await parseCoverageReport(coverageResult.coverageSourcePath, coverageResult.coverageSourceRoot),
+      coverageSourceRoot: coverageResult.coverageSourceRoot,
       unknownReason: null,
       warnings: []
     };
@@ -178,6 +192,7 @@ async function loadModuleCoverage(
       : `Coverage report at ${coverageResult.coverageSourcePath} could not be parsed: ${(error as Error).message}`;
     return {
       coverageByFile: new Map<string, FileCoverage>(),
+      coverageSourceRoot: null,
       unknownReason: "unparseable_report",
       warnings: [emitWarning(
         context.stderr,
@@ -219,9 +234,23 @@ async function analyzeFile(
       )]
     };
   }
-  const fileCoverage = resolveFileCoverage(loadedCoverage.coverageByFile, filePath, relativePath, loadedCoverage.unknownReason);
-  const methodCoverage = coverageForMethods(descriptors, fileCoverage.coverage, fileCoverage.unknownReason ?? undefined);
+  const moduleRelativePath = toRelativePath(moduleRoot, filePath);
+  const fileCoverage = resolveFileCoverage(
+    loadedCoverage.coverageByFile,
+    filePath,
+    relativePath,
+    moduleRelativePath,
+    isModuleCoverageSource(loadedCoverage.coverageSourceRoot, moduleRoot),
+    loadedCoverage.unknownReason
+  );
   const warnings: string[] = [];
+  if (fileCoverage.unknownReason === "file_ambiguous") {
+    warnings.push(emitWarning(
+      context.stderr,
+      `Warning: Coverage for ${relativePath} matched ${fileCoverage.ambiguousMatchCount ?? 0} report entries by suffix. Coverage will be N/A.`
+    ));
+  }
+  const methodCoverage = coverageForMethods(descriptors, fileCoverage.coverage, fileCoverage.unknownReason ?? undefined);
   const metrics = descriptors.map((descriptor, index) =>
     toMetric(descriptor, methodCoverage[index]!, filePath, relativePath, moduleRoot, context.stderr, warnings)
   );
@@ -278,22 +307,88 @@ function resolveFileCoverage(
   coverageByFile: Map<string, FileCoverage>,
   filePath: string,
   relativePath: string,
+  moduleRelativePath: string,
+  includeModuleRelativeFallback: boolean,
   coverageUnavailableReason: CoverageUnknownReason | null
-): { coverage: FileCoverage | undefined; unknownReason: CoverageUnknownReason | null } {
+): FileCoverageResolution {
   const exact = coverageByFile.get(normalizePathForMatch(filePath));
   if (exact) {
-    return { coverage: exact, unknownReason: null };
+    return matchedFileCoverage(exact);
   }
 
-  const suffix = `/${relativePath.replace(/\\/g, "/").toLowerCase()}`;
-  for (const [candidatePath, coverage] of coverageByFile.entries()) {
-    if (candidatePath.endsWith(suffix)) {
-      return { coverage, unknownReason: null };
+  for (const fallbackPath of suffixFallbackPaths(relativePath, moduleRelativePath, includeModuleRelativeFallback)) {
+    const suffixCoverage = resolveFileCoverageFromSuffixMatch(resolveSuffixCoverage(coverageByFile, fallbackPath));
+    if (suffixCoverage) {
+      return suffixCoverage;
     }
   }
+
   return {
     coverage: undefined,
     unknownReason: coverageUnavailableReason ?? "file_unmatched"
+  };
+}
+
+function isModuleCoverageSource(coverageSourceRoot: string | null, moduleRoot: string): boolean {
+  return coverageSourceRoot !== null &&
+    normalizePathForMatch(coverageSourceRoot) === normalizePathForMatch(moduleRoot);
+}
+
+function suffixFallbackPaths(
+  relativePath: string,
+  moduleRelativePath: string,
+  includeModuleRelativeFallback: boolean
+): string[] {
+  if (!includeModuleRelativeFallback || moduleRelativePath === relativePath) {
+    return [relativePath];
+  }
+  return [relativePath, moduleRelativePath];
+}
+
+function resolveSuffixCoverage(
+  coverageByFile: Map<string, FileCoverage>,
+  relativePath: string
+): SuffixCoverageResolution {
+  const suffix = `/${relativePath.replace(/\\/g, "/").toLowerCase()}`;
+  const matches: FileCoverage[] = [];
+  for (const [candidatePath, coverage] of coverageByFile.entries()) {
+    if (candidatePath.endsWith(suffix)) {
+      matches.push(coverage);
+    }
+  }
+
+  if (matches.length === 1) {
+    return { status: "matched", coverage: matches[0]! };
+  }
+  if (matches.length > 1) {
+    return { status: "ambiguous", matchCount: matches.length };
+  }
+  return { status: "unmatched" };
+}
+
+function resolveFileCoverageFromSuffixMatch(match: SuffixCoverageResolution): FileCoverageResolution | null {
+  switch (match.status) {
+    case "matched":
+      return matchedFileCoverage(match.coverage);
+    case "ambiguous":
+      return ambiguousFileCoverage(match.matchCount);
+    case "unmatched":
+      return null;
+  }
+}
+
+function matchedFileCoverage(coverage: FileCoverage): FileCoverageResolution {
+  return {
+    coverage,
+    unknownReason: null
+  };
+}
+
+function ambiguousFileCoverage(matchCount: number): FileCoverageResolution {
+  return {
+    coverage: undefined,
+    unknownReason: "file_ambiguous",
+    ambiguousMatchCount: matchCount
   };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,6 +12,7 @@ export type CoverageStatus = "measured" | "structural_na" | "unknown";
 export type CoverageUnknownReason =
   | "missing_report"
   | "unparseable_report"
+  | "file_ambiguous"
   | "file_unmatched"
   | "fnmap_conflict"
   | "statement_unattributed"

--- a/packages/core/test/analysis.test.ts
+++ b/packages/core/test/analysis.test.ts
@@ -237,6 +237,145 @@ describe("analyzeProject", () => {
     expect(result.metrics[0]?.branchCoverage.unknownReason).toBe("file_unmatched");
   });
 
+  it("keeps exact coverage matches ahead of ambiguous suffix candidates", async () => {
+    const projectRoot = await createTempDir("crap-analysis-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/index.ts": coveredFunctionSource("target"),
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/index.ts": coveredFunctionReport("src/index.ts", 1),
+        "packages/a/src/index.ts": coveredFunctionReport("packages/a/src/index.ts", 0),
+        "packages/b/src/index.ts": coveredFunctionReport("packages/b/src/index.ts", 0)
+      })
+    });
+
+    const result = await analyzeProject({
+      projectRoot,
+      explicitPaths: ["src/index.ts"],
+      coverageMode: "existing-only"
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.metrics[0]?.coveragePercent).toBe(100);
+    expect(result.metrics[0]?.coverage.unknownReason).toBeNull();
+  });
+
+  it("uses a unique project-relative suffix match when exact coverage lookup misses", async () => {
+    const projectRoot = await createTempDir("crap-analysis-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/projectFallback.ts": coveredFunctionSource("projectFallback"),
+      "coverage/coverage-final.json": JSON.stringify({
+        "/rebased/workspace/src/projectFallback.ts": coveredFunctionReport(
+          "/rebased/workspace/src/projectFallback.ts",
+          1
+        )
+      })
+    });
+
+    const result = await analyzeProject({
+      projectRoot,
+      explicitPaths: ["src/projectFallback.ts"],
+      coverageMode: "existing-only"
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.metrics[0]?.coveragePercent).toBe(100);
+    expect(result.metrics[0]?.coverage.unknownReason).toBeNull();
+  });
+
+  it("uses a unique module-root-relative suffix match when project-relative lookup misses", async () => {
+    const projectRoot = await createTempDir("crap-analysis-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/src/moduleFallback.ts": coveredFunctionSource("moduleFallback"),
+      "packages/demo/coverage/coverage-final.json": JSON.stringify({
+        "/rebased/demo/src/moduleFallback.ts": coveredFunctionReport(
+          "/rebased/demo/src/moduleFallback.ts",
+          1
+        )
+      })
+    });
+
+    const result = await analyzeProject({
+      projectRoot,
+      explicitPaths: ["packages/demo/src/moduleFallback.ts"],
+      coverageMode: "existing-only"
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.metrics[0]?.coveragePercent).toBe(100);
+    expect(result.metrics[0]?.coverage.unknownReason).toBeNull();
+  });
+
+  it("does not apply module-root suffix fallback to project-level combined coverage reports", async () => {
+    const projectRoot = await createTempDir("crap-analysis-");
+    tempDirs.push(projectRoot);
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "packages/demo/package.json": '{"name":"demo","private":true}',
+      "packages/demo/src/index.ts": coveredFunctionSource("target"),
+      "coverage/coverage-final.json": JSON.stringify({
+        "/rebased/a/src/index.ts": coveredFunctionReport("/rebased/a/src/index.ts", 1),
+        "/rebased/b/src/index.ts": coveredFunctionReport("/rebased/b/src/index.ts", 0)
+      })
+    });
+
+    const result = await analyzeProject({
+      projectRoot,
+      explicitPaths: ["packages/demo/src/index.ts"],
+      coverageMode: "existing-only"
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.metrics[0]?.coveragePercent).toBeNull();
+    expect(result.metrics[0]?.coverage.unknownReason).toBe("file_unmatched");
+  });
+
+  it("warns and reports N/A coverage when suffix matching is ambiguous", async () => {
+    const projectRoot = await createTempDir("crap-analysis-");
+    tempDirs.push(projectRoot);
+    const warnings: string[] = [];
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "src/index.ts": `export function target(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}
+`,
+      "coverage/coverage-final.json": JSON.stringify({
+        "/rebased/a/src/index.ts": coveredFunctionReport("/rebased/a/src/index.ts", 1),
+        "/rebased/b/src/index.ts": coveredFunctionReport("/rebased/b/src/index.ts", 0)
+      })
+    });
+
+    const result = await analyzeProject({
+      projectRoot,
+      explicitPaths: ["src/index.ts"],
+      coverageMode: "existing-only",
+      stderr: {
+        write(chunk: string) {
+          warnings.push(chunk);
+        }
+      }
+    });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(warnings.join("")).toContain("src/index.ts");
+    expect(warnings.join("")).toContain("matched 2 report entries");
+    expect(result.metrics[0]?.coveragePercent).toBeNull();
+    expect(result.metrics[0]?.crapScore).toBeNull();
+    expect(result.metrics[0]?.coverage.unknownReason).toBe("file_ambiguous");
+    expect(result.metrics[0]?.statementCoverage.unknownReason).toBe("file_ambiguous");
+    expect(result.metrics[0]?.branchCoverage.unknownReason).toBe("file_ambiguous");
+  });
+
   it("warns and reports fnMap conflicts as unknown coverage", async () => {
     const projectRoot = await createTempDir("crap-analysis-");
     tempDirs.push(projectRoot);
@@ -327,3 +466,29 @@ describe("analyzeProject", () => {
     expect(result.metrics[0]?.coverage.unknownReason).toBe("fnmap_conflict");
   });
 });
+
+function coveredFunctionSource(name: string): string {
+  return `export function ${name}(): number {
+  return 1;
+}
+`;
+}
+
+function coveredFunctionReport(sourcePath: string, hits: number): Record<string, unknown> {
+  return {
+    path: sourcePath,
+    statementMap: {
+      "0": {
+        start: { line: 2, column: 2 },
+        end: { line: 2, column: 10 }
+      }
+    },
+    fnMap: {},
+    branchMap: {},
+    s: {
+      "0": hits
+    },
+    f: {},
+    b: {}
+  };
+}

--- a/packages/core/test/compatibilityMatrix.test.ts
+++ b/packages/core/test/compatibilityMatrix.test.ts
@@ -16,6 +16,7 @@ interface CompatibilityCase {
   name: string;
   fixture: string;
   pathMode?: "relative" | "absolute";
+  expectedWarnings?: string[];
   expectedSelectedFiles?: string[];
   expectedMetrics: ExpectedMetric[];
 }
@@ -45,7 +46,7 @@ describe("compatibility matrix", () => {
         coverageMode: "existing-only"
       });
 
-      expect(result.warnings).toEqual([]);
+      expect(result.warnings).toEqual(testCase.expectedWarnings ?? []);
 
       if (testCase.expectedSelectedFiles) {
         expect(result.selectedFiles.map((file) => path.relative(projectRoot, file).replace(/\\/g, "/"))).toEqual(

--- a/spec.md
+++ b/spec.md
@@ -157,6 +157,8 @@ Nested functions and class bodies shall not contribute to the enclosing function
 
 Coverage shall be attributed by matching the analyzed source file to an Istanbul coverage record and assigning statement and branch counters to function bodies.
 
+File coverage lookup shall first prefer exact normalized absolute-path agreement between the analyzed file and an Istanbul coverage record. If exact lookup misses, the analyzer may fall back to suffix matching, first with the project-relative source path and then with the module-root-relative source path when the coverage report is sourced from that module root. A suffix fallback shall be accepted only when exactly one coverage record matches. If multiple records match an attempted suffix, coverage for that analyzed file shall be reported as `N/A` and the analyzer shall emit a warning instead of selecting a record by report order.
+
 When Istanbul `fnMap` data is present for a file:
 
 - the analyzer shall first prefer exact body-span agreement between the TypeScript AST method body and the Istanbul function span
@@ -193,6 +195,7 @@ Unknown coverage includes cases such as:
 
 - missing coverage report
 - analyzed file not present in the report
+- multiple coverage records matching the analyzed file by suffix fallback
 - missing or unusable statement or branch attribution for a function that should have such coverage data
 - any zero-unit attribution where the analyzer cannot prove structural non-applicability
 

--- a/tests/fixtures/compatibility-matrix/ambiguous-suffix-coverage/coverage/coverage-final.json
+++ b/tests/fixtures/compatibility-matrix/ambiguous-suffix-coverage/coverage/coverage-final.json
@@ -1,0 +1,46 @@
+{
+  "/rebased/a/src/index.ts": {
+    "path": "/rebased/a/src/index.ts",
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 13
+        }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {},
+    "s": {
+      "0": 1
+    },
+    "f": {},
+    "b": {}
+  },
+  "/rebased/b/src/index.ts": {
+    "path": "/rebased/b/src/index.ts",
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 11
+        }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {},
+    "s": {
+      "0": 0
+    },
+    "f": {},
+    "b": {}
+  }
+}

--- a/tests/fixtures/compatibility-matrix/ambiguous-suffix-coverage/package.json
+++ b/tests/fixtures/compatibility-matrix/ambiguous-suffix-coverage/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ambiguous-suffix-coverage",
+  "private": true
+}

--- a/tests/fixtures/compatibility-matrix/ambiguous-suffix-coverage/src/index.ts
+++ b/tests/fixtures/compatibility-matrix/ambiguous-suffix-coverage/src/index.ts
@@ -1,0 +1,6 @@
+export function target(flag: boolean): number {
+  if (flag) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/fixtures/compatibility-matrix/matrix.json
+++ b/tests/fixtures/compatibility-matrix/matrix.json
@@ -44,6 +44,19 @@
       ]
     },
     {
+      "name": "ambiguous suffix coverage paths",
+      "fixture": "compatibility-matrix/ambiguous-suffix-coverage",
+      "expectedWarnings": [
+        "Warning: Coverage for src/index.ts matched 2 report entries by suffix. Coverage will be N/A."
+      ],
+      "expectedMetrics": [
+        {
+          "name": "target",
+          "coverage": null
+        }
+      ]
+    },
+    {
       "name": "TSX parsing",
       "fixture": "compatibility-matrix/tsx-component",
       "expectedMetrics": [


### PR DESCRIPTION
## Summary

- Keep exact coverage path matches as the first and strongest lookup path.
- Preserve safe suffix fallback, but accept it only when exactly one coverage record matches.
- Report ambiguous suffix matches as `N/A` via `file_ambiguous` and emit a warning instead of selecting the first report entry.
- Scope module-root-relative suffix fallback to module-sourced coverage reports so project-level combined reports do not create unrelated same-name ambiguity.
- Add focused regression tests plus a compatibility fixture and spec/matrix documentation for the final behavior.

## Validation

- `npm run build`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces`

Closes #111