### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - No unreleased changes.
 
+## [0.4.1] - 2026-06-01
+
+### Changed
+
+- Updated CI and release tooling used by the release pipeline.
+
+### Fixed
+
+- Fixed ambiguous coverage source matching when multiple workspace paths share the same suffix.
+
 ## [0.4.0] - 2026-05-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crap-typescript-parent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crap-typescript-parent",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -6606,10 +6606,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/crap-typescript",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.0"
+        "@barney-media/crap-typescript-core": "^0.4.1"
       },
       "bin": {
         "crap-typescript": "dist/bin.js"
@@ -6620,7 +6620,7 @@
     },
     "packages/core": {
       "name": "@barney-media/crap-typescript-core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@toon-format/toon": "^2.1.0",
@@ -6633,10 +6633,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/crap-typescript-jest",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.0"
+        "@barney-media/crap-typescript-core": "^0.4.1"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -6647,10 +6647,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/crap-typescript-vitest",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.0"
+        "@barney-media/crap-typescript-core": "^0.4.1"
       },
       "engines": {
         "node": ">=22.13.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crap-typescript-parent",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CRAP metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for CRAP metric analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,6 +45,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.0"
+    "@barney-media/crap-typescript-core": "^0.4.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Core CRAP metric analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-jest",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Jest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,7 +45,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.0"
+    "@barney-media/crap-typescript-core": "^0.4.1"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-vitest",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Vitest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -41,7 +41,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.0"
+    "@barney-media/crap-typescript-core": "^0.4.1"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- Prepare v0.4.1 release metadata and changelog.
- Bump all workspace packages and internal @barney-media/crap-typescript-core ranges to 0.4.1.
- Document the coverage path ambiguity fix and release tooling updates.

## Validation
- npm ci
- npm run build
- npm run lint
- npm test
- npm run cognitive-typescript-check
- npm run crap-typescript-check
- node ./scripts/verify-release-version.mjs v0.4.1
- node ./scripts/render-release-notes.mjs v0.4.1
- npm pack --workspaces