### PR TITLE
Reduce default CRAP threshold to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
-- No unreleased changes.
+### Changed
+
+- Reduced the default CRAP threshold from `8.0` to `6.0` while keeping the recommended `4.0` to `8.0` range unchanged.
 
 ## [0.4.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Use `--omit-redundancy` to keep run-level metadata but omit per-method `status` 
 
 Use `--junit-report <path>` to write a full JUnit XML artifact alongside the primary report. JUnit sidecars always contain the full method set, regardless of `--agent`, `--failures-only`, or `--omit-redundancy`. JUnit output is shaped for GitLab's Tests tab: it wraps the suite in `<testsuites>`, sets testcase `classname` and `file` to `src`, sets testcase `name` to `method:lineStart [CRAP=score, CC=complexity, Cov=percent (kind)]`, writes `time="0"`, and includes CRAP score, threshold, coverage kind, source path, and line range in testcase-level `system-out` and failure or skipped element content. Custom properties remain for CI tools that read them, but GitLab-visible details do not rely on properties.
 
-The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates. The warning recommends `8.0` for hard gates, targeting `6.0` during implementation, and using the `8.0` default when in doubt.
+The default threshold is `6.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates. The warning recommends `8.0` for hard gates, targeting `6.0` during implementation, and using the `6.0` default when in doubt.
 
 ## Adapter Usage
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npx crap-typescript
 --omit-redundancy[=true|false] Omit redundant per-method status in the primary report
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
---threshold <number>         Override the CRAP threshold (`8.0` by default)
+--threshold <number>         Override the CRAP threshold (`6.0` by default)
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,7 +41,7 @@ npx crap-typescript packages/api packages/web
 --omit-redundancy[=true|false] Omit redundant per-method status in the primary report
 --output <path>              Write the primary report to a file instead of stdout
 --junit-report <path>        Also write a full JUnit XML report for CI test-report UIs
---threshold <number>         Override the CRAP threshold (`8.0` by default)
+--threshold <number>         Override the CRAP threshold (`6.0` by default)
 <file ...>                   Analyze explicit TypeScript files
 <directory ...>              Analyze TypeScript files under each directory's nested src/ tree
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,7 +54,7 @@ Full primary reports and JUnit sidecars include source-exclusion audit counts wh
 
 Commands run by the built-in executor, including coverage commands and `--changed` discovery, time out after 300 seconds by default. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout. Captured stdout and stderr are capped at 10 MiB per stream. User-facing command failures may include truncated output, while internal commands that require complete output, such as `git status --porcelain -z`, fail if the cap is exceeded.
 
-The default threshold is `8.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
+The default threshold is `6.0`. Values below `4.0` print a warning because they are likely too noisy; values above `8.0` print a warning because they are too lenient even for hard gates.
 
 ## Exit Codes
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,7 +20,7 @@ console.log(report);
 
 Key exports: `analyzeProject`, `calculateCrapScore`, `formatAnalysisReport`, `formatReport`, `parseCoverageReport`, `parseFileMethods`.
 
-`analyzeProject` accepts `threshold` to override the default CRAP threshold of `8.0`. Values below `4.0` emit a warning because they are likely too noisy; values above `8.0` emit a warning because they are too lenient even for hard gates.
+`analyzeProject` accepts `threshold` to override the default CRAP threshold of `6.0`. Values below `4.0` emit a warning because they are likely too noisy; values above `8.0` emit a warning because they are too lenient even for hard gates.
 
 Commands run by the default command executor, including coverage commands and changed-file discovery, time out after 300 seconds. Set `CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS` to a non-negative millisecond value to override this default; `0` disables the timeout. Captured stdout and stderr are capped at 10 MiB per stream. User-facing command failures may include truncated output, while internal commands that require complete output, such as `git status --porcelain -z`, fail if the cap is exceeded.
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -43,7 +43,7 @@ Options:
                              Omit redundant per-method status in the primary report
   --output <path>            Write the primary report to a file instead of stdout
   --junit-report <path>      Also write a full JUnit XML report for CI test-report UIs
-  --threshold <number>       Override the CRAP threshold (default: 8.0)
+  --threshold <number>       Override the CRAP threshold (default: ${CRAP_THRESHOLD.toFixed(1)})
 
 Behavior:
   (no args)                  Analyze all TypeScript files under any nested src/ tree
@@ -320,8 +320,11 @@ function cliMode(state: ParseState): CliArguments["mode"] {
   return state.fileArgs.length > 0 ? "explicit" : "all";
 }
 
-function optionalPath<K extends "output" | "junitReport">(key: K, value: string | undefined): Pick<CliArguments, K> | {} {
-  return value === undefined ? {} : { [key]: value } as Pick<CliArguments, K>;
+function optionalPath<K extends "output" | "junitReport">(
+  key: K,
+  value: string | undefined
+): Pick<CliArguments, K> | {} {
+  return value === undefined ? {} : ({ [key]: value } as Pick<CliArguments, K>);
 }
 
 function parsePackageManagerSelection(value: string | undefined): PackageManagerSelection {
@@ -368,9 +371,7 @@ function parseThreshold(value: string | undefined): number {
 
 function splitInlineOption(arg: string): [string, string | undefined] {
   const separatorIndex = arg.indexOf("=");
-  return separatorIndex === -1
-    ? [arg, undefined]
-    : [arg.slice(0, separatorIndex), arg.slice(separatorIndex + 1)];
+  return separatorIndex === -1 ? [arg, undefined] : [arg.slice(0, separatorIndex), arg.slice(separatorIndex + 1)];
 }
 
 function inlineValueArgs(args: string[], index: number, option: string, value: string): string[] {
@@ -426,7 +427,7 @@ function optionalArray<K extends "excludes" | "excludePathRegexes" | "excludeGen
   key: K,
   values: string[]
 ): Pick<CliArguments, K> | {} {
-  return values.length === 0 ? {} : { [key]: values } as Pick<CliArguments, K>;
+  return values.length === 0 ? {} : ({ [key]: values } as Pick<CliArguments, K>);
 }
 
 function optionalBoolean<K extends "useDefaultExclusions">(
@@ -434,7 +435,7 @@ function optionalBoolean<K extends "useDefaultExclusions">(
   value: boolean,
   include: boolean
 ): Pick<CliArguments, K> | {} {
-  return include ? { [key]: value } as Pick<CliArguments, K> : {};
+  return include ? ({ [key]: value } as Pick<CliArguments, K>) : {};
 }
 
 export async function runCli(
@@ -480,12 +481,7 @@ function parseCliInputs(args: string[], stdout: Writer, stderr: Writer): CliArgu
   }
 }
 
-async function analyzeCliProject(
-  parsed: CliArguments,
-  projectRoot: string,
-  stdout: Writer,
-  stderr: Writer
-) {
+async function analyzeCliProject(parsed: CliArguments, projectRoot: string, stdout: Writer, stderr: Writer) {
   try {
     return await analyzeProject({
       projectRoot: path.resolve(projectRoot),
@@ -552,12 +548,16 @@ async function writeCliReports(
   }
 
   if (parsed.junit && parsed.junitReport) {
-    await writeReportFile(projectRoot, parsed.junitReport, formatAnalysisReport(result.metrics, {
-      format: "junit",
-      threshold: result.threshold,
-      elapsedSeconds,
-      sourceExclusionAudit: result.sourceExclusionAudit
-    }));
+    await writeReportFile(
+      projectRoot,
+      parsed.junitReport,
+      formatAnalysisReport(result.metrics, {
+        format: "junit",
+        threshold: result.threshold,
+        elapsedSeconds,
+        sourceExclusionAudit: result.sourceExclusionAudit
+      })
+    );
   }
 }
 
@@ -574,10 +574,7 @@ async function writeReportFile(projectRoot: string, reportPath: string, content:
   await writeFile(absolutePath, content);
 }
 
-function writeCliThresholdStatus(
-  result: Awaited<ReturnType<typeof analyzeProject>>,
-  stderr: Writer
-): number {
+function writeCliThresholdStatus(result: Awaited<ReturnType<typeof analyzeProject>>, stderr: Writer): number {
   if (!result.thresholdExceeded) {
     return 0;
   }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,7 +1,8 @@
-export const CRAP_THRESHOLD = 8.0;
+export const CRAP_THRESHOLD = 6.0;
 export const COVERAGE_REPORT_RELATIVE_PATH = "coverage/coverage-final.json";
 export const NO_FILES_MESSAGE = "No TypeScript files to analyze.";
 export const NO_ANALYZABLE_FUNCTIONS_MESSAGE = "No analyzable functions found.";
+const HARD_GATE_CRAP_THRESHOLD = 8.0;
 const IMPLEMENTATION_TARGET_CRAP_THRESHOLD = 6.0;
 
 export function validateThreshold(value: number): number {
@@ -15,14 +16,14 @@ export function thresholdWarning(value: number): string {
   if (value < 4.0) {
     return `Warning: CRAP threshold below 4.0 is likely too noisy. ${thresholdRecommendation()}`;
   }
-  if (value > CRAP_THRESHOLD) {
-    return `Warning: CRAP threshold above ${CRAP_THRESHOLD.toFixed(1)} is too lenient even for hard gates. ${thresholdRecommendation()}`;
+  if (value > HARD_GATE_CRAP_THRESHOLD) {
+    return `Warning: CRAP threshold above ${HARD_GATE_CRAP_THRESHOLD.toFixed(1)} is too lenient even for hard gates. ${thresholdRecommendation()}`;
   }
   return "";
 }
 
 function thresholdRecommendation(): string {
-  return `Use ${CRAP_THRESHOLD.toFixed(1)} for hard gates, target ${IMPLEMENTATION_TARGET_CRAP_THRESHOLD.toFixed(1)} during implementation, and use the ${CRAP_THRESHOLD.toFixed(1)} default when in doubt.`;
+  return `Use ${HARD_GATE_CRAP_THRESHOLD.toFixed(1)} for hard gates, target ${IMPLEMENTATION_TARGET_CRAP_THRESHOLD.toFixed(1)} during implementation, and use the ${CRAP_THRESHOLD.toFixed(1)} default when in doubt.`;
 }
 
 export const IGNORED_SOURCE_ROOT_DISCOVERY_DIRECTORIES = new Set([

--- a/packages/core/test/analysis.test.ts
+++ b/packages/core/test/analysis.test.ts
@@ -26,17 +26,40 @@ describe("analyzeProject", () => {
       "packages/package-a/src/math.ts",
       "packages/package-b/src/text.ts"
     ]);
-    expect(result.metrics.map((metric) => ({
-      name: metric.displayName,
-      coverage: metric.coveragePercent === null ? null : Number(metric.coveragePercent.toFixed(1)),
-      crap: metric.crapScore === null ? null : Number(metric.crapScore.toFixed(1)),
-      coverageStatus: metric.coverage.status,
-      statementStatus: metric.statementCoverage.status,
-      branchStatus: metric.branchCoverage.status
-    }))).toEqual([
-      { name: "add", coverage: 100.0, crap: 1.0, coverageStatus: "measured", statementStatus: "measured", branchStatus: "structural_na" },
-      { name: "risky", coverage: 0.0, crap: 12.0, coverageStatus: "measured", statementStatus: "measured", branchStatus: "measured" },
-      { name: "upper", coverage: 100.0, crap: 1.0, coverageStatus: "measured", statementStatus: "measured", branchStatus: "structural_na" }
+    expect(
+      result.metrics.map((metric) => ({
+        name: metric.displayName,
+        coverage: metric.coveragePercent === null ? null : Number(metric.coveragePercent.toFixed(1)),
+        crap: metric.crapScore === null ? null : Number(metric.crapScore.toFixed(1)),
+        coverageStatus: metric.coverage.status,
+        statementStatus: metric.statementCoverage.status,
+        branchStatus: metric.branchCoverage.status
+      }))
+    ).toEqual([
+      {
+        name: "add",
+        coverage: 100.0,
+        crap: 1.0,
+        coverageStatus: "measured",
+        statementStatus: "measured",
+        branchStatus: "structural_na"
+      },
+      {
+        name: "risky",
+        coverage: 0.0,
+        crap: 12.0,
+        coverageStatus: "measured",
+        statementStatus: "measured",
+        branchStatus: "measured"
+      },
+      {
+        name: "upper",
+        coverage: 100.0,
+        crap: 1.0,
+        coverageStatus: "measured",
+        statementStatus: "measured",
+        branchStatus: "structural_na"
+      }
     ]);
     expect(result.maxCrap).toBeGreaterThan(CRAP_THRESHOLD);
     expect(result.threshold).toBe(CRAP_THRESHOLD);
@@ -62,7 +85,7 @@ describe("analyzeProject", () => {
     expect(result.threshold).toBe(13);
     expect(result.thresholdExceeded).toBe(false);
     expect(result.warnings).toEqual([
-      "Warning: CRAP threshold above 8.0 is too lenient even for hard gates. Use 8.0 for hard gates, target 6.0 during implementation, and use the 8.0 default when in doubt."
+      "Warning: CRAP threshold above 8.0 is too lenient even for hard gates. Use 8.0 for hard gates, target 6.0 during implementation, and use the 6.0 default when in doubt."
     ]);
     expect(warnings.join("")).toContain("CRAP threshold above 8.0 is too lenient");
   });
@@ -294,10 +317,7 @@ describe("analyzeProject", () => {
       "packages/demo/package.json": '{"name":"demo","private":true}',
       "packages/demo/src/moduleFallback.ts": coveredFunctionSource("moduleFallback"),
       "packages/demo/coverage/coverage-final.json": JSON.stringify({
-        "/rebased/demo/src/moduleFallback.ts": coveredFunctionReport(
-          "/rebased/demo/src/moduleFallback.ts",
-          1
-        )
+        "/rebased/demo/src/moduleFallback.ts": coveredFunctionReport("/rebased/demo/src/moduleFallback.ts", 1)
       })
     });
 

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -64,7 +64,7 @@ describe("cli", () => {
       packageManager: "npm",
       testRunner: "vitest",
       format: "json",
-      threshold: 8,
+      threshold: 6,
       agent: true,
       failuresOnly: false,
       omitRedundancy: true,
@@ -89,7 +89,7 @@ describe("cli", () => {
       packageManager: "pnpm",
       testRunner: "jest",
       format: "toon",
-      threshold: 8,
+      threshold: 6,
       agent: false,
       failuresOnly: false,
       omitRedundancy: false,
@@ -101,7 +101,7 @@ describe("cli", () => {
       packageManager: "yarn",
       testRunner: "auto",
       format: "toon",
-      threshold: 8,
+      threshold: 6,
       agent: false,
       failuresOnly: false,
       omitRedundancy: false,
@@ -113,7 +113,7 @@ describe("cli", () => {
       packageManager: "auto",
       testRunner: "auto",
       format: "junit",
-      threshold: 8,
+      threshold: 6,
       agent: true,
       failuresOnly: true,
       omitRedundancy: true,
@@ -493,7 +493,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toContain("status: failed");
-    expect(stdout.toString()).toContain("threshold: 8");
+    expect(stdout.toString()).toContain("threshold: 6");
     expect(stdout.toString()).toContain("methods[2]{status,crap,cc,cov,covKind,method,src,lineStart,lineEnd}:");
     expect(stdout.toString()).toContain("risky");
     expect(stderr.toString()).toContain("CRAP threshold exceeded");
@@ -539,7 +539,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("status: passed");
-    expect(stdout.toString()).toContain("threshold: 8");
+    expect(stdout.toString()).toContain("threshold: 6");
     expect(tableLines[0]).toBe(
       "| status | crap | cc |    cov | covKind | method | src           | lineStart | lineEnd |"
     );
@@ -650,7 +650,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toBe("");
     expect(primary.status).toBe("failed");
-    expect(primary.threshold).toBe(8);
+    expect(primary.threshold).toBe(6);
     expect(primary.methods).toHaveLength(1);
     expect(primary.methods[0].method).toBe("risky");
     expect(primary.methods[0]).not.toHaveProperty("status");
@@ -800,7 +800,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(exitCode).toBe(2);
     expect(stdout.toString()).toBe("");
     expect(primary.status).toBe("failed");
-    expect(primary.threshold).toBe(8);
+    expect(primary.threshold).toBe(6);
     expect(primary.methods).toHaveLength(1);
     expect(primary.methods[0]).toMatchObject({
       status: "failed",
@@ -881,7 +881,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toBe("");
     expect(primary.status).toBe("passed");
-    expect(primary.threshold).toBe(8);
+    expect(primary.threshold).toBe(6);
     expect(primary.methods).toHaveLength(1);
     expect(primary.methods[0]).not.toHaveProperty("status");
     expect(primary.methods[0]).toMatchObject({
@@ -1064,7 +1064,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain("status: passed");
-    expect(stdout.toString()).toContain("threshold: 8");
+    expect(stdout.toString()).toContain("threshold: 6");
     expect(stdout.toString()).toContain("safe");
     expect(stderr.toString()).toBe("");
   });
@@ -1081,7 +1081,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 6\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 
@@ -1099,7 +1099,7 @@ export function risky(flagA: boolean, flagB: boolean): number {
     const exitCode = await runCli([], projectRoot, stdout, stderr);
 
     expect(exitCode).toBe(0);
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 6\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -3,13 +3,12 @@ import { describe, expect, it } from "vitest";
 import { CRAP_THRESHOLD, thresholdWarning } from "../src/constants";
 
 describe("thresholdWarning", () => {
-  it("does not warn at the default threshold boundary", () => {
+  it("does not warn at the default threshold or hard-gate boundary", () => {
     expect(thresholdWarning(CRAP_THRESHOLD)).toBe("");
+    expect(thresholdWarning(8.0)).toBe("");
   });
 
-  it("warns when the threshold is above the default hard-gate threshold", () => {
-    expect(thresholdWarning(CRAP_THRESHOLD + 0.5)).toContain(
-      `CRAP threshold above ${CRAP_THRESHOLD.toFixed(1)} is too lenient`,
-    );
+  it("warns when the threshold is above the hard-gate threshold", () => {
+    expect(thresholdWarning(8.5)).toContain("CRAP threshold above 8.0 is too lenient");
   });
 });

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -102,7 +102,7 @@ describe("report formatting", () => {
     ]);
 
     expect(report.status).toBe("failed");
-    expect(report.threshold).toBe(8);
+    expect(report.threshold).toBe(6);
     expect(report.methods).toMatchObject([
       {
         status: "failed",
@@ -251,7 +251,7 @@ describe("report formatting", () => {
 
     expect(Object.keys(parsed)).toEqual(["status", "threshold", "methods"]);
     expect(parsed.status).toBe("passed");
-    expect(parsed.threshold).toBe(8);
+    expect(parsed.threshold).toBe(6);
     expect(parsed.methods).toEqual([
       {
         status: "passed",
@@ -380,7 +380,7 @@ describe("report formatting", () => {
     };
 
     expect(parsed.status).toBe("failed");
-    expect(parsed.threshold).toBe(8);
+    expect(parsed.threshold).toBe(6);
     expect(parsed.methods).toEqual([
       expect.objectContaining({
         status: "failed",
@@ -415,7 +415,7 @@ describe("report formatting", () => {
     };
 
     expect(parsed.status).toBe("failed");
-    expect(parsed.threshold).toBe(8);
+    expect(parsed.threshold).toBe(6);
     expect(parsed.methods).toHaveLength(2);
     expect(parsed.methods[0]).not.toHaveProperty("status");
     expect(parsed.methods[0]).toMatchObject({
@@ -453,7 +453,7 @@ describe("report formatting", () => {
     };
 
     expect(parsed.status).toBe("failed");
-    expect(parsed.threshold).toBe(8);
+    expect(parsed.threshold).toBe(6);
     expect(parsed.methods).toEqual([
       expect.objectContaining({
         method: "risky"
@@ -519,7 +519,7 @@ describe("report formatting", () => {
     );
 
     expect(output).toContain("status: failed");
-    expect(output).toContain("threshold: 8");
+    expect(output).toContain("threshold: 6");
     expect(output).toContain("methods[2]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:");
     expect(output).toContain("risky");
     expect(output).toContain("safe");
@@ -545,7 +545,7 @@ describe("report formatting", () => {
     const tableLines = output.split("\n").filter((line) => line.startsWith("|"));
 
     expect(output).toContain("status: failed");
-    expect(output).toContain("threshold: 8.0");
+    expect(output).toContain("threshold: 6.0");
     expect(tableLines[0]).toBe("| crap | cc |    cov | covKind | method | src           | lineStart | lineEnd |");
     expect(output).toContain("risky");
     expect(output).toContain("safe");
@@ -640,7 +640,7 @@ describe("report formatting", () => {
 
     expect(output).toBe(`${encode(report)}\n`);
     expect(output).toContain("status: failed");
-    expect(output).toContain("threshold: 8");
+    expect(output).toContain("threshold: 6");
     expect(output).toContain("methods[1]{crap,cc,cov,covKind,method,src,lineStart,lineEnd}:");
     expect(output).toContain("risky value");
     expect(output).not.toContain("safe");
@@ -696,7 +696,7 @@ describe("report formatting", () => {
     const pipePositions = tableLines.map((line) => [...line].flatMap((char, index) => (char === "|" ? [index] : [])));
 
     expect(output).toContain("status: failed");
-    expect(output).toContain("threshold: 8.0");
+    expect(output).toContain("threshold: 6.0");
     expect(tableLines[0]).toBe(
       "| status |  crap | cc |    cov | covKind | method | src           | lineStart | lineEnd |"
     );
@@ -711,7 +711,7 @@ describe("report formatting", () => {
 
     expect(formatToonReport(report)).toBe(`${encode(report)}\n`);
     expect(formatToonReport(agentReport, true)).toBe(`${encode(agentReport)}\n`);
-    expect(formatToonReport(report)).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(formatToonReport(report)).toBe("status: passed\nthreshold: 6\nmethods[0]:\n");
   });
 
   it("formats JUnit XML with testcase properties and escaped values", () => {
@@ -736,7 +736,7 @@ describe("report formatting", () => {
     expect(output).toContain(
       '<testsuite name="crap-typescript" status="failed" tests="1" failures="1" skipped="0" errors="0" time="0">'
     );
-    expect(output).toContain('<property name="threshold" value="8.0"/>');
+    expect(output).toContain('<property name="threshold" value="6.0"/>');
     expect(output).toContain('classname="src/&quot;special&quot;&amp;file.ts"');
     expect(output).toContain('name="risky &quot;quoted&quot; &lt;value&gt;:1 [CRAP=20.0, CC=4, Cov=0.0% (stmt)]"');
     expect(output).toContain('file="src/&quot;special&quot;&amp;file.ts"');
@@ -748,7 +748,7 @@ describe("report formatting", () => {
     expect(output.match(/property name="threshold"/g)).toHaveLength(1);
     expect(output).toContain("<failure");
     expect(output).toContain("CRAP score: 20.0");
-    expect(output).toContain("Threshold: 8.0");
+    expect(output).toContain("Threshold: 6.0");
     expect(output).toContain("Coverage: 0.0% (stmt)");
     expect(output).toContain("<system-out>CRAP score: 20.0");
     expect(output).toContain("Source: src/");
@@ -776,7 +776,7 @@ describe("report formatting", () => {
     expect(output).toContain('name="missingCoverage:1 [CRAP=N/A, CC=1, Cov=N/A (N/A)]"');
     expect(output).toContain("<skipped");
     expect(output).toContain("CRAP score: N/A");
-    expect(output).toContain("Threshold: 8.0");
+    expect(output).toContain("Threshold: 6.0");
     expect(output).toContain("Coverage: N/A (N/A)");
     expect(output).toContain("<system-out>CRAP score: N/A");
     expect(output).toContain("Source: src/sample.ts:1-3");
@@ -806,7 +806,7 @@ describe("report formatting", () => {
     expect(output).toContain(
       '<testsuite name="crap-typescript" status="passed" tests="0" failures="0" skipped="0" errors="0" time="0">'
     );
-    expect(output).toContain('<property name="threshold" value="8.0"/>');
+    expect(output).toContain('<property name="threshold" value="6.0"/>');
     expect(output).not.toContain("<testcase");
     expect(output.endsWith("\n")).toBe(true);
     expect(output.endsWith("\n\n")).toBe(false);

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -26,7 +26,7 @@ The reporter defaults primary `format` to `none`, so it emits no primary stdout 
 
 Baseline analyzability exclusions always skip declarations, test/spec files, `__tests__/`, `dist/`, `coverage/`, and `node_modules/`. Generated-code defaults exclude generated directory segments, exact `gen` directory segments, common generated filename suffixes, protobuf outputs, Angular generated artifacts, and leading generated-header markers. User exclusions compose with defaults unless `useDefaultExclusions: false`; full reports and JUnit sidecars include exclusion audit counts when files were excluded.
 
-The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
+The default threshold is `6.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
 Exit code `2` means the CRAP threshold was exceeded. Reporter errors such as invalid options, missing coverage, or report-write failures use exit code `1`.
 

--- a/packages/jest/test/reporter.test.ts
+++ b/packages/jest/test/reporter.test.ts
@@ -118,7 +118,7 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 6\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 
@@ -504,7 +504,7 @@ describe("CrapTypescriptJestReporter", () => {
     const junit = await readText(`${projectRoot}/custom-coverage/crap-typescript-junit.xml`);
 
     expect(stdout.toString()).toContain("status: failed");
-    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("threshold: 6.0");
     expect(stdout.toString()).toContain("| status |");
     expect(stdout.toString()).toContain("risky");
     expect(junit).toContain('tests="1"');
@@ -619,7 +619,7 @@ describe("CrapTypescriptJestReporter", () => {
 
     await callFinalize(reporter);
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 6\nmethods[0]:\n");
     await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();
     expect(stderr.toString()).toBe("");
     expect(reporter.getLastError()).toBeUndefined();

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -30,7 +30,7 @@ The reporter defaults primary `format` to `none`, so it emits no primary stdout 
 
 Baseline analyzability exclusions always skip declarations, test/spec files, `__tests__/`, `dist/`, `coverage/`, and `node_modules/`. Generated-code defaults exclude generated directory segments, exact `gen` directory segments, common generated filename suffixes, protobuf outputs, Angular generated artifacts, and leading generated-header markers. User exclusions compose with defaults unless `useDefaultExclusions: false`; full reports and JUnit sidecars include exclusion audit counts when files were excluded.
 
-The default threshold is `8.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
+The default threshold is `6.0`; values below `4.0` or above `8.0` print the same threshold guidance warnings as the CLI.
 
 Exit code `2` means the CRAP threshold was exceeded. Reporter errors such as invalid options, missing coverage, or report-write failures use exit code `1`.
 

--- a/packages/vitest/test/reporter.test.ts
+++ b/packages/vitest/test/reporter.test.ts
@@ -89,7 +89,7 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 6\nmethods[0]:\n");
     expect(stderr.toString()).toBe("");
   });
 
@@ -292,7 +292,7 @@ describe("CrapTypescriptVitestReporter", () => {
     const junit = await readText(`${projectRoot}/custom-coverage/crap-typescript-junit.xml`);
 
     expect(stdout.toString()).toContain("status: failed");
-    expect(stdout.toString()).toContain("threshold: 8.0");
+    expect(stdout.toString()).toContain("threshold: 6.0");
     expect(stdout.toString()).toContain("| status |");
     expect(stdout.toString()).toContain("risky");
     expect(junit).toContain('tests="1"');
@@ -388,7 +388,7 @@ describe("CrapTypescriptVitestReporter", () => {
 
     await reporter.onFinishedReportCoverage();
 
-    expect(stdout.toString()).toBe("status: passed\nthreshold: 8\nmethods[0]:\n");
+    expect(stdout.toString()).toBe("status: passed\nthreshold: 6\nmethods[0]:\n");
     await expect(readText(`${projectRoot}/coverage/crap-typescript-junit.xml`)).rejects.toThrow();
     expect(stderr.toString()).toBe("");
   });

--- a/spec.md
+++ b/spec.md
@@ -240,9 +240,9 @@ When the primary report format is `none`, the primary report shall emit no stdou
 
 ## 11. Threshold
 
-The default CRAP threshold shall be `8.0`. A finite positive threshold may be configured.
+The default CRAP threshold shall be `6.0`. A finite positive threshold may be configured.
 
-If the configured threshold is below `4.0`, the tool shall print a warning that the threshold is likely too noisy and recommend `8.0` for hard gates, targeting `6.0` during implementation, and using the `8.0` default when in doubt.
+If the configured threshold is below `4.0`, the tool shall print a warning that the threshold is likely too noisy and recommend `8.0` for hard gates, targeting `6.0` during implementation, and using the `6.0` default when in doubt.
 
 If the configured threshold is above `8.0`, the tool shall print a warning that the threshold is too lenient even for hard gates and the same recommendation.
 

--- a/vitest.crap.config.ts
+++ b/vitest.crap.config.ts
@@ -5,5 +5,6 @@ import baseConfig from "./vitest.config";
 export default withCrapTypescriptVitest(baseConfig, {
   packageManager: "npm",
   paths: ["packages"],
-  projectRoot: process.cwd()
+  projectRoot: process.cwd(),
+  threshold: 8.0
 });


### PR DESCRIPTION
## Summary
- Reduce the shipped default CRAP threshold from `8.0` to `6.0` across core defaults, docs, spec, changelog, and tests.
- Keep the hard-gate warning boundary at `8.0` by decoupling it from the default threshold.
- Configure the repository self-gate explicitly at the hard-gate threshold so omitted user config still uses `6.0` while the repo gate remains on the documented hard-gate value.

Closes #190

## Validation
- `git diff --check`
- `npm ci`
- `npm run build`
- `npm run lint`
- `npm exec prettier -- --check <changed TypeScript files>`
- `npm test`
- `npm run cognitive-typescript-check`
- `npm run crap-typescript-check`
- `npm pack --workspaces --pack-destination %TEMP%\\crap-typescript-190-pack`

Note: this repo does not currently define `npm run format:check`; changed TypeScript files were checked directly with Prettier.
