### PR TITLE
Align quality gate dependencies and defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6703,7 +6703,7 @@
       "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.1"
+        "@barney-media/crap-typescript-core": "^0.4.2"
       },
       "bin": {
         "crap-typescript": "dist/bin.js"
@@ -6730,7 +6730,7 @@
       "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.1"
+        "@barney-media/crap-typescript-core": "^0.4.2"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -6744,7 +6744,7 @@
       "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.1"
+        "@barney-media/crap-typescript-core": "^0.4.2"
       },
       "engines": {
         "node": ">=22.13.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.1"
+    "@barney-media/crap-typescript-core": "^0.4.2"
   }
 }

--- a/packages/core/src/analyzeProject.ts
+++ b/packages/core/src/analyzeProject.ts
@@ -5,7 +5,11 @@ import { coverageForMethods } from "./coverageAttribution.js";
 import { ensureCoverageReport, expectedCoveragePath } from "./coverage.js";
 import type { FileCoverage } from "./coverageUnits.js";
 import { calculateCrapScore, maxCrap } from "./crapScore.js";
-import { changedTypeScriptFilesUnderSourceRoots, expandExplicitPaths, findAllTypeScriptFilesUnderSourceRoots } from "./fileSelection.js";
+import {
+  changedTypeScriptFilesUnderSourceRoots,
+  expandExplicitPaths,
+  findAllTypeScriptFilesUnderSourceRoots
+} from "./fileSelection.js";
 import { CoverageReportParseError, parseCoverageReport } from "./istanbul.js";
 import { resolveModuleRoot } from "./moduleResolution.js";
 import { parseFileMethods } from "./parser.js";
@@ -23,7 +27,11 @@ import type {
 export async function analyzeProject(options: AnalyzeProjectOptions = {}): Promise<AnalysisResult> {
   const context = createAnalyzeContext(options);
   const runWarnings = emitThresholdWarning(context.stderr, context.threshold);
-  const candidateFiles = await selectFiles(context.projectRoot, options.explicitPaths ?? [], options.changedOnly ?? false);
+  const candidateFiles = await selectFiles(
+    context.projectRoot,
+    options.explicitPaths ?? [],
+    options.changedOnly ?? false
+  );
   const exclusionResult = await filterSourceFiles(context.projectRoot, candidateFiles, options);
   const selectedFiles = exclusionResult.files;
   if (selectedFiles.length === 0) {
@@ -85,20 +93,24 @@ interface LoadedCoverage {
 }
 
 type SuffixCoverageResolution =
-  | { status: "matched"; coverage: FileCoverage }
-  | { status: "ambiguous"; matchCount: number }
-  | { status: "unmatched" };
+  { status: "matched"; coverage: FileCoverage } | { status: "ambiguous"; matchCount: number } | { status: "unmatched" };
 
 function createAnalyzeContext(options: AnalyzeProjectOptions): AnalyzeContext {
+  return {
+    ...createAnalyzeContextDefaults(options),
+    coverageReportPath: options.coverageReportPath,
+    executor: options.executor ?? new DefaultCommandExecutor(),
+    stderr: options.stderr
+  };
+}
+
+function createAnalyzeContextDefaults(options: AnalyzeProjectOptions) {
   return {
     projectRoot: path.resolve(options.projectRoot ?? process.cwd()),
     coverageMode: options.coverageMode ?? "auto",
     packageManager: options.packageManager ?? "auto",
     testRunner: options.testRunner ?? "auto",
-    threshold: validateThreshold(options.threshold ?? CRAP_THRESHOLD),
-    coverageReportPath: options.coverageReportPath,
-    executor: options.executor ?? new DefaultCommandExecutor(),
-    stderr: options.stderr
+    threshold: validateThreshold(options.threshold ?? CRAP_THRESHOLD)
   };
 }
 
@@ -130,7 +142,10 @@ async function groupFilesByModule(projectRoot: string, selectedFiles: string[]):
   return groupedByModule;
 }
 
-async function analyzeModules(groupedByModule: Map<string, string[]>, context: AnalyzeContext): Promise<ModuleAnalysisResult[]> {
+async function analyzeModules(
+  groupedByModule: Map<string, string[]>,
+  context: AnalyzeContext
+): Promise<ModuleAnalysisResult[]> {
   const results: ModuleAnalysisResult[] = [];
   for (const [moduleRoot, moduleFiles] of groupedByModule.entries()) {
     results.push(await analyzeModule(moduleRoot, moduleFiles, context));
@@ -172,10 +187,12 @@ async function loadModuleCoverage(
       coverageByFile: new Map<string, FileCoverage>(),
       coverageSourceRoot: null,
       unknownReason: "missing_report",
-      warnings: [emitWarning(
-        context.stderr,
-        `Warning: Coverage report not found at ${expectedCoveragePath(moduleRoot, context.coverageReportPath)}. Coverage will be N/A.`
-      )]
+      warnings: [
+        emitWarning(
+          context.stderr,
+          `Warning: Coverage report not found at ${expectedCoveragePath(moduleRoot, context.coverageReportPath)}. Coverage will be N/A.`
+        )
+      ]
     };
   }
 
@@ -187,17 +204,15 @@ async function loadModuleCoverage(
       warnings: []
     };
   } catch (error) {
-    const parseMessage = error instanceof CoverageReportParseError
-      ? error.message
-      : `Coverage report at ${coverageResult.coverageSourcePath} could not be parsed: ${(error as Error).message}`;
+    const parseMessage =
+      error instanceof CoverageReportParseError
+        ? error.message
+        : `Coverage report at ${coverageResult.coverageSourcePath} could not be parsed: ${(error as Error).message}`;
     return {
       coverageByFile: new Map<string, FileCoverage>(),
       coverageSourceRoot: null,
       unknownReason: "unparseable_report",
-      warnings: [emitWarning(
-        context.stderr,
-        `Warning: ${parseMessage}. Coverage will be N/A.`
-      )]
+      warnings: [emitWarning(context.stderr, `Warning: ${parseMessage}. Coverage will be N/A.`)]
     };
   }
 }
@@ -228,10 +243,12 @@ async function analyzeFile(
   } catch (error) {
     return {
       metrics: [],
-      warnings: [emitWarning(
-        context.stderr,
-        `Warning: Could not parse ${relativePath}: ${(error as Error).message}. Skipping file.`
-      )]
+      warnings: [
+        emitWarning(
+          context.stderr,
+          `Warning: Could not parse ${relativePath}: ${(error as Error).message}. Skipping file.`
+        )
+      ]
     };
   }
   const moduleRelativePath = toRelativePath(moduleRoot, filePath);
@@ -245,12 +262,18 @@ async function analyzeFile(
   );
   const warnings: string[] = [];
   if (fileCoverage.unknownReason === "file_ambiguous") {
-    warnings.push(emitWarning(
-      context.stderr,
-      `Warning: Coverage for ${relativePath} matched ${fileCoverage.ambiguousMatchCount ?? 0} report entries by suffix. Coverage will be N/A.`
-    ));
+    warnings.push(
+      emitWarning(
+        context.stderr,
+        `Warning: Coverage for ${relativePath} matched ${fileCoverage.ambiguousMatchCount ?? 0} report entries by suffix. Coverage will be N/A.`
+      )
+    );
   }
-  const methodCoverage = coverageForMethods(descriptors, fileCoverage.coverage, fileCoverage.unknownReason ?? undefined);
+  const methodCoverage = coverageForMethods(
+    descriptors,
+    fileCoverage.coverage,
+    fileCoverage.unknownReason ?? undefined
+  );
   const metrics = descriptors.map((descriptor, index) =>
     toMetric(descriptor, methodCoverage[index]!, filePath, relativePath, moduleRoot, context.stderr, warnings)
   );
@@ -269,10 +292,12 @@ function toMetric(
 ): MethodMetrics {
   const coveragePercent = coverage.coverage.percent;
   if (coverage.coverage.unknownReason === "fnmap_conflict") {
-    warnings.push(emitWarning(
-      stderr,
-      `Warning: Function coverage metadata in ${relativePath} could not be matched unambiguously for ${descriptor.displayName}. Coverage will be N/A.`
-    ));
+    warnings.push(
+      emitWarning(
+        stderr,
+        `Warning: Function coverage metadata in ${relativePath} could not be matched unambiguously for ${descriptor.displayName}. Coverage will be N/A.`
+      )
+    );
   }
 
   return {
@@ -289,11 +314,7 @@ function toMetric(
   };
 }
 
-async function selectFiles(
-  projectRoot: string,
-  explicitPaths: string[],
-  changedOnly: boolean
-): Promise<string[]> {
+async function selectFiles(projectRoot: string, explicitPaths: string[], changedOnly: boolean): Promise<string[]> {
   if (changedOnly) {
     return changedTypeScriptFilesUnderSourceRoots(projectRoot);
   }
@@ -330,8 +351,7 @@ function resolveFileCoverage(
 }
 
 function isModuleCoverageSource(coverageSourceRoot: string | null, moduleRoot: string): boolean {
-  return coverageSourceRoot !== null &&
-    normalizePathForMatch(coverageSourceRoot) === normalizePathForMatch(moduleRoot);
+  return coverageSourceRoot !== null && normalizePathForMatch(coverageSourceRoot) === normalizePathForMatch(moduleRoot);
 }
 
 function suffixFallbackPaths(

--- a/packages/core/src/coverageAttribution.ts
+++ b/packages/core/src/coverageAttribution.ts
@@ -69,10 +69,7 @@ function buildAttributableMethods(
   });
 }
 
-function matchFunctionCoverage(
-  method: MethodDescriptor,
-  functions: FunctionCoverageUnit[]
-): MatchOutcome {
+function matchFunctionCoverage(method: MethodDescriptor, functions: FunctionCoverageUnit[]): MatchOutcome {
   return resolveMatchOutcome([
     matchByCandidateSpans(method.bodySpan, functions),
     matchByContainingSpan(method.bodySpan, functions),
@@ -82,9 +79,7 @@ function matchFunctionCoverage(
 
 function fnMapMatchSpans(methodSpan: SourceSpan): SourceSpan[] {
   const normalized = normalizeMethodSpanForFnMap(methodSpan);
-  return spansEqual(methodSpan, normalized)
-    ? [methodSpan]
-    : [methodSpan, normalized];
+  return spansEqual(methodSpan, normalized) ? [methodSpan] : [methodSpan, normalized];
 }
 
 function matchByCandidateSpans(methodSpan: SourceSpan, functions: FunctionCoverageUnit[]): MatchOutcome {
@@ -95,7 +90,9 @@ function matchByCandidateSpans(methodSpan: SourceSpan, functions: FunctionCovera
     }
 
     const lineAlignedMatch = uniqueMatchOutcome(
-      functions.filter((entry) => spansShareBoundaryLines(entry.span, candidateSpan) && spansOverlap(entry.span, candidateSpan))
+      functions.filter(
+        (entry) => spansShareBoundaryLines(entry.span, candidateSpan) && spansOverlap(entry.span, candidateSpan)
+      )
     );
     if (lineAlignedMatch !== undefined) {
       return lineAlignedMatch;
@@ -106,7 +103,9 @@ function matchByCandidateSpans(methodSpan: SourceSpan, functions: FunctionCovera
 }
 
 function matchByContainingSpan(methodSpan: SourceSpan, functions: FunctionCoverageUnit[]): MatchOutcome {
-  return uniqueMatchOutcome(functions.filter((entry) => spanContains(entry.span, normalizeMethodSpanForFnMap(methodSpan))));
+  return uniqueMatchOutcome(
+    functions.filter((entry) => spanContains(entry.span, normalizeMethodSpanForFnMap(methodSpan)))
+  );
 }
 
 function matchByDeclaration(method: MethodDescriptor, functions: FunctionCoverageUnit[]): MatchOutcome {
@@ -141,13 +140,10 @@ function findOwningMethodIndex(methods: AttributableMethod[], span: SourceSpan):
 
   for (let index = 0; index < methods.length; index += 1) {
     const method = methods[index]!;
-    if (method.fnMapConflict) {
+    if (!isCandidateMethod(method, span)) {
       continue;
     }
-    if (!spanContains(method.span, span) && !spanContainsPosition(method.span, span.startLine, span.startColumn)) {
-      continue;
-    }
-    if (bestMatch === null || spanContains(methods[bestMatch]!.span, method.span)) {
+    if (isPreferredMethod(methods, bestMatch, index)) {
       bestMatch = index;
     }
   }
@@ -155,26 +151,32 @@ function findOwningMethodIndex(methods: AttributableMethod[], span: SourceSpan):
   return bestMatch;
 }
 
+function isCandidateMethod(method: AttributableMethod, span: SourceSpan): boolean {
+  if (method.fnMapConflict) {
+    return false;
+  }
+  return spanContains(method.span, span) || spanContainsPosition(method.span, span.startLine, span.startColumn);
+}
+
+function isPreferredMethod(methods: AttributableMethod[], bestMatch: number | null, candidateIndex: number): boolean {
+  return bestMatch === null || spanContains(methods[bestMatch]!.span, methods[candidateIndex]!.span);
+}
+
 function spanContains(container: SourceSpan, candidate: SourceSpan): boolean {
-  return comparePosition(
-    container.startLine,
-    container.startColumn,
-    candidate.startLine,
-    candidate.startColumn
-  ) <= 0 && comparePosition(candidate.endLine, candidate.endColumn, container.endLine, container.endColumn) <= 0;
+  return (
+    comparePosition(container.startLine, container.startColumn, candidate.startLine, candidate.startColumn) <= 0 &&
+    comparePosition(candidate.endLine, candidate.endColumn, container.endLine, container.endColumn) <= 0
+  );
 }
 
 function spanContainsPosition(span: SourceSpan, line: number, column: number): boolean {
-  return comparePosition(span.startLine, span.startColumn, line, column) <= 0 &&
-    comparePosition(line, column, span.endLine, span.endColumn) < 0;
+  return (
+    comparePosition(span.startLine, span.startColumn, line, column) <= 0 &&
+    comparePosition(line, column, span.endLine, span.endColumn) < 0
+  );
 }
 
-function comparePosition(
-  leftLine: number,
-  leftColumn: number,
-  rightLine: number,
-  rightColumn: number
-): number {
+function comparePosition(leftLine: number, leftColumn: number, rightLine: number, rightColumn: number): number {
   if (leftLine !== rightLine) {
     return leftLine - rightLine;
   }
@@ -182,20 +184,23 @@ function comparePosition(
 }
 
 function spansEqual(left: SourceSpan, right: SourceSpan): boolean {
-  return left.startLine === right.startLine &&
+  return (
+    left.startLine === right.startLine &&
     left.startColumn === right.startColumn &&
     left.endLine === right.endLine &&
-    left.endColumn === right.endColumn;
+    left.endColumn === right.endColumn
+  );
 }
 
 function spansShareBoundaryLines(left: SourceSpan, right: SourceSpan): boolean {
-  return left.startLine === right.startLine &&
-    left.endLine === right.endLine;
+  return left.startLine === right.startLine && left.endLine === right.endLine;
 }
 
 function spansOverlap(left: SourceSpan, right: SourceSpan): boolean {
-  return comparePosition(left.startLine, left.startColumn, right.endLine, right.endColumn) < 0 &&
-    comparePosition(right.startLine, right.startColumn, left.endLine, left.endColumn) < 0;
+  return (
+    comparePosition(left.startLine, left.startColumn, right.endLine, right.endColumn) < 0 &&
+    comparePosition(right.startLine, right.startColumn, left.endLine, left.endColumn) < 0
+  );
 }
 
 function matchesMethodDeclaration(entry: FunctionCoverageUnit, method: MethodDescriptor): boolean {

--- a/packages/core/src/istanbul.ts
+++ b/packages/core/src/istanbul.ts
@@ -30,10 +30,7 @@ export class CoverageReportParseError extends Error {
   }
 }
 
-export async function parseCoverageReport(
-  reportPath: string,
-  sourceRoot: string
-): Promise<Map<string, FileCoverage>> {
+export async function parseCoverageReport(reportPath: string, sourceRoot: string): Promise<Map<string, FileCoverage>> {
   const raw = parseCoverageJson(reportPath, await readFile(reportPath, "utf8"));
   const report = isRecord(raw) ? raw : {};
   const records = new Map<string, FileCoverage>();
@@ -68,15 +65,22 @@ function parseStatements(statementMapValue: unknown, hitsValue: unknown): Statem
 
   const statements: StatementCoverageUnit[] = [];
   for (const [key, locationValue] of Object.entries(statementMapValue)) {
-    const hits = parseFiniteNumber(hitsValue[key]);
-    const span = parseSpan(locationValue);
-    if (hits === null || span === null) {
-      continue;
+    const statement = parseStatementEntry(locationValue, hitsValue[key]);
+    if (statement) {
+      statements.push(statement);
     }
-    statements.push({ span, hits });
   }
 
   return deduplicateStatements(statements);
+}
+
+function parseStatementEntry(locationValue: unknown, hitsValue: unknown): StatementCoverageUnit | null {
+  const hits = parseFiniteNumber(hitsValue);
+  if (hits === null) {
+    return null;
+  }
+  const span = parseSpan(locationValue);
+  return span === null ? null : { span, hits };
 }
 
 function parseBranches(branchMapValue: unknown, hitsValue: unknown): BranchCoverageUnit[] {
@@ -109,9 +113,7 @@ function parseCoverageEntry(
     return null;
   }
 
-  const resolved = isAbsolutePath(sourcePath)
-    ? sourcePath
-    : path.resolve(sourceRoot, sourcePath);
+  const resolved = isAbsolutePath(sourcePath) ? sourcePath : path.resolve(sourceRoot, sourcePath);
   return {
     normalizedPath: normalizePathForMatch(resolved),
     coverage: {
@@ -214,9 +216,7 @@ function parsePosition(value: unknown): { line: number; column: number } | null 
     return null;
   }
 
-  const column = value.column === null || value.column === undefined
-    ? MAX_COLUMN
-    : parseColumnNumber(value.column);
+  const column = value.column === null || value.column === undefined ? MAX_COLUMN : parseColumnNumber(value.column);
   if (column === null) {
     return null;
   }
@@ -229,9 +229,7 @@ function parseHitArray(value: unknown): number[] {
     return [];
   }
 
-  return value
-    .map((entry) => parseFiniteNumber(entry))
-    .filter((entry): entry is number => entry !== null);
+  return value.map((entry) => parseFiniteNumber(entry)).filter((entry): entry is number => entry !== null);
 }
 
 function parseFiniteNumber(value: unknown): number | null {
@@ -293,12 +291,7 @@ function deduplicateFunctions(functions: FunctionCoverageUnit[]): FunctionCovera
 }
 
 function stringifySpan(span: SourceSpan): string {
-  return [
-    span.startLine,
-    span.startColumn,
-    span.endLine,
-    span.endColumn
-  ].join(":");
+  return [span.startLine, span.startColumn, span.endLine, span.endColumn].join(":");
 }
 
 function isRecord(value: unknown): value is JsonRecord {
@@ -319,9 +312,7 @@ function toBranchCoverageUnit(branchValue: unknown, hitsValue: unknown): BranchC
 }
 
 function resolveBranchSpan(branchValue: JsonRecord): SourceSpan | null {
-  return parseSpan(branchValue.loc) ??
-    parseFirstLocation(branchValue.locations) ??
-    parseLineSpan(branchValue.line);
+  return parseSpan(branchValue.loc) ?? parseFirstLocation(branchValue.locations) ?? parseLineSpan(branchValue.line);
 }
 
 function resolveFunctionEntry(entryValue: unknown): FunctionCoverageUnit | null {
@@ -333,9 +324,15 @@ function resolveFunctionEntry(entryValue: unknown): FunctionCoverageUnit | null 
   if (!resolved) {
     return null;
   }
+  return createFunctionCoverageUnit(entryValue, resolved);
+}
+
+function createFunctionCoverageUnit(
+  entryValue: JsonRecord,
+  resolved: { span: SourceSpan; source: FunctionSpanSource }
+): FunctionCoverageUnit {
   const declarationStart = resolveDeclarationStart(entryValue);
   const name = typeof entryValue.name === "string" ? entryValue.name : undefined;
-
   return {
     span: resolved.span,
     spanSource: resolved.source,
@@ -344,7 +341,9 @@ function resolveFunctionEntry(entryValue: unknown): FunctionCoverageUnit | null 
   };
 }
 
-function resolveFunctionSpanWithSource(entryValue: JsonRecord): { span: SourceSpan; source: FunctionSpanSource } | null {
+function resolveFunctionSpanWithSource(
+  entryValue: JsonRecord
+): { span: SourceSpan; source: FunctionSpanSource } | null {
   const loc = parseSpan(entryValue.loc);
   if (loc) {
     return { span: loc, source: "loc" };
@@ -423,12 +422,7 @@ function firstNonZeroComparison(comparisons: number[]): number {
   return comparisons.find((comparison) => comparison !== 0) ?? 0;
 }
 
-function comparePosition(
-  leftLine: number,
-  leftColumn: number,
-  rightLine: number,
-  rightColumn: number
-): number {
+function comparePosition(leftLine: number, leftColumn: number, rightLine: number, rightColumn: number): number {
   if (leftLine !== rightLine) {
     return leftLine - rightLine;
   }

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -112,14 +112,21 @@ const DESCRIPTOR_BUILDERS: DescriptorBuilder[] = [
 ];
 
 function descriptorFromFunctionDeclaration(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
-  if (!ts.isFunctionDeclaration(node) || !node.body) {
+  if (!ts.isFunctionDeclaration(node)) {
     return null;
   }
-  const functionName = node.name?.text ?? inferFunctionDeclarationName(node);
+  if (!node.body) {
+    return null;
+  }
+  const functionName = functionDeclarationName(node);
   if (!functionName) {
     return null;
   }
   return buildMethodDescriptor(functionName, findContainerName(node), node, node.body, sourceFile);
+}
+
+function functionDeclarationName(node: ts.FunctionDeclaration): string | null {
+  return node.name?.text ?? inferFunctionDeclarationName(node);
 }
 
 function descriptorFromMethodDeclaration(node: ts.Node, sourceFile: ts.SourceFile): MethodDescriptor | null {
@@ -169,7 +176,8 @@ function buildMethodDescriptor(
   sourceFile: ts.SourceFile
 ): MethodDescriptor {
   const startLine = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-  const endLine = sourceFile.getLineAndCharacterOfPosition(Math.max(bodyNode.end - 1, bodyNode.getStart(sourceFile))).line + 1;
+  const endLine =
+    sourceFile.getLineAndCharacterOfPosition(Math.max(bodyNode.end - 1, bodyNode.getStart(sourceFile))).line + 1;
   return {
     functionName,
     containerName,
@@ -242,7 +250,11 @@ function assignedNameFromBinaryExpression(
   parent: ts.Node,
   node: ts.FunctionExpression | ts.ArrowFunction
 ): { name: string; containerName: string | null } | null {
-  if (ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken && parent.right === node) {
+  if (
+    ts.isBinaryExpression(parent) &&
+    parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    parent.right === node
+  ) {
     return assignmentTarget(parent.left);
   }
   return null;
@@ -439,9 +451,7 @@ function toDisplayName(containerName: string | null, functionName: string): stri
   if (!containerName) {
     return functionName;
   }
-  return functionName.startsWith("[")
-    ? `${containerName}${functionName}`
-    : `${containerName}.${functionName}`;
+  return functionName.startsWith("[") ? `${containerName}${functionName}` : `${containerName}.${functionName}`;
 }
 
 function propertyName(name: ts.PropertyName): string {
@@ -515,8 +525,7 @@ function isNestedBoundary(node: ts.Node): boolean {
 }
 
 function isProvablyNonExecutableDeclarationStatement(statement: ts.Statement): boolean {
-  return ts.isInterfaceDeclaration(statement) ||
-    ts.isTypeAliasDeclaration(statement);
+  return ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement);
 }
 
 function complexityContribution(node: ts.Node): number {
@@ -543,8 +552,10 @@ function hasBranchSyntax(node: ts.Node): boolean {
 }
 
 function hasOwnOptionalChainToken(node: ts.Node): boolean {
-  return (ts.isPropertyAccessChain(node) || ts.isElementAccessChain(node) || ts.isCallChain(node)) &&
-    node.questionDotToken !== undefined;
+  return (
+    (ts.isPropertyAccessChain(node) || ts.isElementAccessChain(node) || ts.isCallChain(node)) &&
+    node.questionDotToken !== undefined
+  );
 }
 
 function isAssignmentExpression(node: ts.Node): node is ts.BinaryExpression {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -99,16 +99,10 @@ export function sortMetrics(metrics: MethodMetrics[]): MethodMetrics[] {
 }
 
 function compareCrapScores(left: number | null, right: number | null): number {
-  if (left === null && right !== null) {
-    return 1;
+  if (left === null) {
+    return right === null ? 0 : 1;
   }
-  if (left !== null && right === null) {
-    return -1;
-  }
-  if (left !== null && right !== null) {
-    return right - left;
-  }
-  return 0;
+  return right === null ? -1 : right - left;
 }
 
 function compareReportText(left: string, right: string): number {
@@ -285,16 +279,12 @@ function coverageKind(metric: MethodMetrics): CoverageKind {
 }
 
 function measuredCoverageKind(statementCoverage: CoverageMetric, branchCoverage: CoverageMetric): CoverageKind {
-  if (statementCoverage.status === "measured" && branchCoverage.status === "measured") {
-    return branchCoverage.percent! < statementCoverage.percent! ? "branch" : "stmt";
+  const statementMeasured = statementCoverage.status === "measured";
+  const branchMeasured = branchCoverage.status === "measured";
+  if (statementMeasured) {
+    return branchMeasured ? (branchCoverage.percent! < statementCoverage.percent! ? "branch" : "stmt") : "stmt";
   }
-  if (statementCoverage.status === "measured") {
-    return "stmt";
-  }
-  if (branchCoverage.status === "measured") {
-    return "branch";
-  }
-  return "stmt";
+  return branchMeasured ? "branch" : "stmt";
 }
 
 function formatNullableNumber(value: number | null): string {

--- a/packages/core/src/sourceExclusions.ts
+++ b/packages/core/src/sourceExclusions.ts
@@ -107,18 +107,26 @@ function createEffectiveOptions(options: AnalyzeProjectOptions): EffectiveExclus
   const useDefaultExclusions = options.useDefaultExclusions ?? true;
   return {
     useDefaultExclusions,
+    ...createUserExclusionRules(options),
+    defaultPathGlobs: createDefaultPathRules(useDefaultExclusions),
+    defaultGeneratedMarkers: createDefaultGeneratedMarkers(useDefaultExclusions)
+  };
+}
+
+function createUserExclusionRules(options: AnalyzeProjectOptions) {
+  return {
     userPathGlobs: (options.excludes ?? []).map((glob) => pathGlobRule("user", glob)),
     userPathRegexes: (options.excludePathRegexes ?? []).map((regex) => pathRegexRule("user", regex)),
-    userGeneratedMarkers: (options.excludeGeneratedMarkers ?? []).map((marker) =>
-      markerRule("user", marker)
-    ),
-    defaultPathGlobs: useDefaultExclusions
-      ? DEFAULT_PATH_GLOBS.map((glob) => pathGlobRule("default", glob))
-      : [],
-    defaultGeneratedMarkers: useDefaultExclusions
-      ? DEFAULT_GENERATED_MARKERS.map((marker) => markerRule("default", marker))
-      : []
+    userGeneratedMarkers: (options.excludeGeneratedMarkers ?? []).map((marker) => markerRule("user", marker))
   };
+}
+
+function createDefaultPathRules(enabled: boolean): PathGlobRule[] {
+  return enabled ? DEFAULT_PATH_GLOBS.map((glob) => pathGlobRule("default", glob)) : [];
+}
+
+function createDefaultGeneratedMarkers(enabled: boolean): ExclusionReason[] {
+  return enabled ? DEFAULT_GENERATED_MARKERS.map((marker) => markerRule("default", marker)) : [];
 }
 
 async function exclusionReason(
@@ -126,23 +134,21 @@ async function exclusionReason(
   relativePath: string,
   options: EffectiveExclusionOptions
 ): Promise<ExclusionReason | null> {
-  return pathExclusionReason(relativePath, options)
-    ?? await generatedMarkerExclusionReason(filePath, options);
+  return pathExclusionReason(relativePath, options) ?? (await generatedMarkerExclusionReason(filePath, options));
 }
 
-function pathExclusionReason(
-  relativePath: string,
-  options: EffectiveExclusionOptions
-): ExclusionReason | null {
+function pathExclusionReason(relativePath: string, options: EffectiveExclusionOptions): ExclusionReason | null {
   if (options.useDefaultExclusions) {
     const directoryReason = generatedDirectoryReason(relativePath);
     if (directoryReason) {
       return directoryReason;
     }
   }
-  return firstMatchingPathGlob(relativePath, options.defaultPathGlobs)
-    ?? firstMatchingPathGlob(relativePath, options.userPathGlobs)
-    ?? firstMatchingPathRegex(relativePath, options.userPathRegexes);
+  return (
+    firstMatchingPathGlob(relativePath, options.defaultPathGlobs) ??
+    firstMatchingPathGlob(relativePath, options.userPathGlobs) ??
+    firstMatchingPathRegex(relativePath, options.userPathRegexes)
+  );
 }
 
 function generatedDirectoryReason(relativePath: string): ExclusionReason | null {
@@ -252,9 +258,7 @@ function readHeaderStep(sourceText: string, startIndex: number, finalChunk: bool
   if (!comment) {
     return doneHeaderStep(true);
   }
-  return comment.complete
-    ? { done: false, comment }
-    : doneHeaderStep(false);
+  return comment.complete ? { done: false, comment } : doneHeaderStep(false);
 }
 
 function doneHeaderStep(complete: boolean): HeaderStep {
@@ -406,7 +410,9 @@ function recordReason(reasons: Map<string, SourceExclusionReasonCount>, reason: 
 }
 
 function compareReasonCounts(left: SourceExclusionReasonCount, right: SourceExclusionReasonCount): number {
-  return left.source.localeCompare(right.source)
-    || left.kind.localeCompare(right.kind)
-    || left.rule.localeCompare(right.rule);
+  return (
+    left.source.localeCompare(right.source) ||
+    left.kind.localeCompare(right.kind) ||
+    left.rule.localeCompare(right.rule)
+  );
 }

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -101,6 +101,51 @@ describe("coverage helpers", () => {
     );
   });
 
+  it("ignores malformed entries and normalizes relative and absolute source paths", async () => {
+    const projectRoot = await createTempDir("crap-coverage-");
+    tempDirs.push(projectRoot);
+    const absoluteSourcePath = path.join(projectRoot, "src", "absolute.ts");
+    await writeProjectFiles(projectRoot, {
+      "package.json": '{"name":"fixture","private":true}',
+      "coverage/coverage-final.json": JSON.stringify({
+        "src/fallback.ts": {
+          statementMap: {},
+          branchMap: {},
+          fnMap: {},
+          s: {},
+          b: {},
+          f: {}
+        },
+        "empty-path": {
+          path: "",
+          statementMap: {},
+          branchMap: {},
+          fnMap: {},
+          s: {},
+          b: {},
+          f: {}
+        },
+        "absolute-key": {
+          path: absoluteSourcePath,
+          statementMap: {},
+          branchMap: {},
+          fnMap: {},
+          s: {},
+          b: {},
+          f: {}
+        },
+        invalid: null
+      })
+    });
+
+    const coverage = await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot);
+    const expectedPaths = [path.resolve(projectRoot, "src", "fallback.ts"), absoluteSourcePath].map((filePath) =>
+      filePath.replace(/\\/g, "/").toLowerCase()
+    );
+
+    expect([...coverage.keys()].sort()).toEqual(expectedPaths.sort());
+  });
+
   it("computes function coverage as the minimum of statement and branch coverage", async () => {
     const projectRoot = await createTempDir("crap-coverage-");
     tempDirs.push(projectRoot);
@@ -462,9 +507,7 @@ export function enumDeclOnly(): void {
             hits: [1, 1]
           }
         ],
-        functions: [
-          { span: method.bodySpan }
-        ]
+        functions: [{ span: method.bodySpan }]
       }).map(summarizeMethodCoverage)
     ).toEqual([
       {
@@ -502,9 +545,7 @@ export function enumDeclOnly(): void {
             hits: [1, 1]
           }
         ],
-        functions: [
-          { span: { startLine: 1, startColumn: 0, endLine: 6, endColumn: 1 } }
-        ]
+        functions: [{ span: { startLine: 1, startColumn: 0, endLine: 6, endColumn: 1 } }]
       }).map(summarizeMethodCoverage)
     ).toEqual([
       {
@@ -902,13 +943,9 @@ export function enumDeclOnly(): void {
     const methods = await parseFileMethods(path.join(projectRoot, "src", "sample.ts"));
     expect(
       coverageForMethods(methods, {
-        statements: [
-          { span: { startLine: 1, startColumn: 39, endLine: 1, endColumn: 51 }, hits: 1 }
-        ],
+        statements: [{ span: { startLine: 1, startColumn: 39, endLine: 1, endColumn: 51 }, hits: 1 }],
         branches: [],
-        functions: [
-          { span: { startLine: 1, startColumn: 0, endLine: 1, endColumn: 10 } }
-        ]
+        functions: [{ span: { startLine: 1, startColumn: 0, endLine: 1, endColumn: 10 } }]
       }).map(summarizeMethodCoverage)
     ).toEqual([
       {
@@ -978,7 +1015,9 @@ export function enumDeclOnly(): void {
       })
     });
 
-    const [fileCoverage] = (await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)).values();
+    const [fileCoverage] = (
+      await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)
+    ).values();
     expect(fileCoverage.statements).toEqual([
       {
         span: {
@@ -1091,7 +1130,9 @@ export function enumDeclOnly(): void {
       })
     });
 
-    const [fileCoverage] = (await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)).values();
+    const [fileCoverage] = (
+      await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)
+    ).values();
 
     expect(fileCoverage.statements).toEqual([
       {
@@ -1170,7 +1211,9 @@ export function enumDeclOnly(): void {
       })
     });
 
-    const [fileCoverage] = (await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)).values();
+    const [fileCoverage] = (
+      await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)
+    ).values();
 
     expect(fileCoverage.statements).toEqual([]);
     expect(fileCoverage.branches).toEqual([]);
@@ -1225,7 +1268,9 @@ export function enumDeclOnly(): void {
       })
     });
 
-    const [fileCoverage] = (await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)).values();
+    const [fileCoverage] = (
+      await parseCoverageReport(path.join(projectRoot, "coverage", "coverage-final.json"), projectRoot)
+    ).values();
 
     expect(fileCoverage.functions).toEqual([
       {
@@ -1262,11 +1307,11 @@ function summarizeMethodCoverage(coverage: {
   };
 }
 
-function summarizeMetric(metric: {
+function summarizeMetric(metric: { percent: number | null; status: string; unknownReason: string | null }): {
   percent: number | null;
   status: string;
-  unknownReason: string | null;
-}): { percent: number | null; status: string; reason: string | null } {
+  reason: string | null;
+} {
   return {
     percent: metric.percent === null ? null : Number(metric.percent.toFixed(1)),
     status: metric.status,

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -68,11 +68,36 @@ describe("runCommand", () => {
   });
 
   it("falls back when the configured default timeout is negative", async () => {
+    vi.useFakeTimers();
     vi.stubEnv("CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS", "-1");
+    const kill = vi.fn();
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: (signal: string) => boolean;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = kill.mockReturnValue(true);
+    vi.doMock("node:child_process", () => ({
+      spawn: vi.fn(() => child)
+    }));
 
-    await expect(
-      runCommand(process.execPath, ["-e", "setTimeout(() => {}, 1000)"], process.cwd(), { timeoutMs: 1 })
-    ).rejects.toThrow("Command timed out after 1ms");
+    try {
+      vi.resetModules();
+      const { runCommand: runMockedCommand } = await import("../src/utils");
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const result = runMockedCommand("never-closes", [], process.cwd());
+      const rejection = expect(result).rejects.toThrow("Command timed out after 300000ms");
+
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 300_000);
+      await vi.advanceTimersByTimeAsync(300_000);
+      await rejection;
+      expect(kill).toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      child.emit("close", 0);
+      vi.useRealTimers();
+    }
   });
 
   it("bounds captured stdout and stderr", async () => {

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -67,6 +67,14 @@ describe("runCommand", () => {
     expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 
+  it("falls back when the configured default timeout is negative", async () => {
+    vi.stubEnv("CRAP_TYPESCRIPT_COMMAND_TIMEOUT_MS", "-1");
+
+    await expect(
+      runCommand(process.execPath, ["-e", "setTimeout(() => {}, 1000)"], process.cwd(), { timeoutMs: 1 })
+    ).rejects.toThrow("Command timed out after 1ms");
+  });
+
   it("bounds captured stdout and stderr", async () => {
     const result = await runCommand(
       process.execPath,
@@ -83,33 +91,26 @@ describe("runCommand", () => {
 
   it("rejects when truncated output is not allowed", async () => {
     await expect(
-      runCommand(
-        process.execPath,
-        ["-e", "process.stdout.write('abcdef')"],
-        process.cwd(),
-        { maxBufferBytes: 3, rejectOnTruncatedOutput: true }
-      )
+      runCommand(process.execPath, ["-e", "process.stdout.write('abcdef')"], process.cwd(), {
+        maxBufferBytes: 3,
+        rejectOnTruncatedOutput: true
+      })
     ).rejects.toThrow("Command output exceeded 3 bytes:");
   });
 
   it("normalizes negative command buffer limits before diagnostics", async () => {
     await expect(
-      runCommand(
-        process.execPath,
-        ["-e", "process.stdout.write('x')"],
-        process.cwd(),
-        { maxBufferBytes: -1, rejectOnTruncatedOutput: true }
-      )
+      runCommand(process.execPath, ["-e", "process.stdout.write('x')"], process.cwd(), {
+        maxBufferBytes: -1,
+        rejectOnTruncatedOutput: true
+      })
     ).rejects.toThrow("Command output exceeded 0 bytes:");
   });
 
   it("returns raw bounded output without mutation when truncated", async () => {
-    const emptyResult = await runCommand(
-      process.execPath,
-      ["-e", "process.stdout.write('abc')"],
-      process.cwd(),
-      { maxBufferBytes: 0 }
-    );
+    const emptyResult = await runCommand(process.execPath, ["-e", "process.stdout.write('abc')"], process.cwd(), {
+      maxBufferBytes: 0
+    });
     const newlineResult = await runCommand(
       process.execPath,
       ["-e", "process.stdout.write('abc\\ndef')"],

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -45,7 +45,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.1"
+    "@barney-media/crap-typescript-core": "^0.4.2"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -41,7 +41,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.1"
+    "@barney-media/crap-typescript-core": "^0.4.2"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -10,10 +10,13 @@ import type {
   Writer
 } from "@barney-media/crap-typescript-core";
 
-type VitestReporterEntry = string | [string, unknown] | {
-  onTestRunEnd?: () => Promise<void>;
-  onFinishedReportCoverage?: () => Promise<void>;
-};
+type VitestReporterEntry =
+  | string
+  | [string, unknown]
+  | {
+      onTestRunEnd?: () => Promise<void>;
+      onFinishedReportCoverage?: () => Promise<void>;
+    };
 type VitestConfig = Record<string, unknown> & {
   test?: Record<string, unknown> & {
     coverage?: Record<string, unknown> & {
@@ -25,6 +28,8 @@ type VitestConfig = Record<string, unknown> & {
     reporters?: VitestReporterEntry[] | VitestReporterEntry;
   };
 };
+type VitestTestConfig = NonNullable<VitestConfig["test"]>;
+type VitestCoverageConfig = NonNullable<VitestTestConfig["coverage"]>;
 
 export interface CrapTypescriptVitestOptions {
   projectRoot?: string;
@@ -73,12 +78,7 @@ export class CrapTypescriptVitestReporter {
         stderr: options.stderr
       });
 
-      await writeReporterReports(
-        result.metrics,
-        result.sourceExclusionAudit,
-        options,
-        elapsedSecondsSince(startedAt)
-      );
+      await writeReporterReports(result.metrics, result.sourceExclusionAudit, options, elapsedSecondsSince(startedAt));
       if (result.thresholdExceeded) {
         const error = `CRAP threshold exceeded: ${result.maxCrap.toFixed(1)} > ${result.threshold.toFixed(1)}`;
         options.stderr.write(`${error}\n`);
@@ -99,26 +99,43 @@ export function withCrapTypescriptVitest(
   const coverage = testConfig.coverage ?? {};
   const coverageEnabled = coverage.enabled ?? true;
   const coverageReporters = ensureReporterEntries(asArray(coverage.reporter), "json", "text");
-  const reporters = ensureDefaultReporter(asArray(testConfig.reporters));
   const coverageReportPath = options.coverageReportPath ?? buildCoverageReportPath(coverage.reportsDirectory);
-  if (coverageEnabled) {
-    reporters.push(new CrapTypescriptVitestReporter(reporterOptions(options, coverageReportPath)));
-  }
 
   return {
     ...config,
     test: {
       ...testConfig,
-      coverage: {
-        ...coverage,
-        enabled: coverageEnabled,
-        provider: coverage.provider ?? "v8",
-        reporter: coverageReporters,
-        reportsDirectory: coverage.reportsDirectory ?? "coverage"
-      },
-      reporters
+      coverage: configuredCoverage(coverage, coverageEnabled, coverageReporters),
+      reporters: configuredReporters(testConfig.reporters, coverageEnabled, options, coverageReportPath)
     }
   };
+}
+
+function configuredCoverage(
+  coverage: VitestCoverageConfig,
+  coverageEnabled: boolean,
+  coverageReporters: Array<string | [string, unknown]>
+): VitestCoverageConfig {
+  return {
+    ...coverage,
+    enabled: coverageEnabled,
+    provider: coverage.provider ?? "v8",
+    reporter: coverageReporters,
+    reportsDirectory: coverage.reportsDirectory ?? "coverage"
+  };
+}
+
+function configuredReporters(
+  existing: VitestTestConfig["reporters"],
+  coverageEnabled: boolean,
+  options: CrapTypescriptVitestOptions,
+  coverageReportPath: string
+): VitestReporterEntry[] {
+  const reporters = ensureDefaultReporter(asArray(existing));
+  if (coverageEnabled) {
+    reporters.push(new CrapTypescriptVitestReporter(reporterOptions(options, coverageReportPath)));
+  }
+  return reporters;
 }
 
 function asArray<T>(value: T | T[] | undefined): T[] {
@@ -173,9 +190,7 @@ function configuredFormat(options: CrapTypescriptVitestOptions): ReportFormat {
 }
 
 function configuredJunitReport(options: CrapTypescriptVitestOptions, coverageReportPath: string): string {
-  return options.junitReport === undefined
-    ? buildJunitReportFromCoverage(coverageReportPath)
-    : options.junitReport;
+  return options.junitReport === undefined ? buildJunitReportFromCoverage(coverageReportPath) : options.junitReport;
 }
 
 function toError(error: unknown): Error {
@@ -284,12 +299,16 @@ async function writeReporterReports(
   }
 
   if (options.junit) {
-    await writeReportFile(options.projectRoot, options.junitReport, formatAnalysisReport(metrics, {
-      format: "junit",
-      threshold: options.threshold,
-      elapsedSeconds,
-      sourceExclusionAudit
-    }));
+    await writeReportFile(
+      options.projectRoot,
+      options.junitReport,
+      formatAnalysisReport(metrics, {
+        format: "junit",
+        threshold: options.threshold,
+        elapsedSeconds,
+        sourceExclusionAudit
+      })
+    );
   }
 }
 

--- a/scripts/run-cognitive-typescript-gate.mjs
+++ b/scripts/run-cognitive-typescript-gate.mjs
@@ -13,7 +13,7 @@ if (targets.length === 0) {
 const gateArguments = [
   "exec",
   "--yes",
-  "--package=@barney-media/cognitive-typescript@0.1.1",
+  "--package=@barney-media/cognitive-typescript@0.2.2",
   "--",
   "cognitive-typescript",
   ...targets.map((target) => resolve(target))

--- a/vitest.crap.config.ts
+++ b/vitest.crap.config.ts
@@ -5,6 +5,5 @@ import baseConfig from "./vitest.config";
 export default withCrapTypescriptVitest(baseConfig, {
   packageManager: "npm",
   paths: ["packages"],
-  projectRoot: process.cwd(),
-  threshold: 8.0
+  projectRoot: process.cwd()
 });


### PR DESCRIPTION
Closes #195

## Implementation
- Updated the CLI, Jest, and Vitest workspace ranges to @barney-media/crap-typescript-core ^0.4.2 and regenerated package-lock.json.
- Upgraded the cognitive-typescript gate to @barney-media/cognitive-typescript 0.2.2.
- Removed the root Vitest CRAP threshold override so CRAP 6.0 and cognitive 15 defaults apply.
- Added bounded internal quality-gate refactoring and focused coverage so the requested CRAP 6.0 default is green without changing public APIs.

## Review focus
- Verify only dependency ranges, gate defaults, and behavior-preserving quality plumbing changed.
- Confirm Node >=22.13.0, Apache-2.0 metadata, and no transitive dependency drift.

## Validation
- npm ci
- npm run build
- npm run lint (isolated CI workspace; local validation excluded pre-existing .claude worktree copies)
- npm test: 236 tests passed
- npm run cognitive-typescript-check: threshold 15
- npm run crap-typescript-check: threshold 6.0
- npm run pack
- git diff --check
- Prettier check passed for all changed files

## Residual risk
- No public TypeScript interfaces, runtime APIs, package versions, or release metadata changed.