### PR TITLE
Restructure CI matrix and verification graph

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,36 @@ permissions:
 
 jobs:
   build:
-    name: build (Node ${{ matrix.node-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: build / build-${{ matrix.os }}-${{ matrix.node }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-        node-version: ["22.13.0", "24.0.0"]
+        include:
+          - os: windows
+            runner: windows-latest
+            node: node22
+            node-version: "22.13.0"
+          - os: windows
+            runner: windows-latest
+            node: node24
+            node-version: "24.0.0"
+          - os: macos
+            runner: macos-latest
+            node: node22
+            node-version: "22.13.0"
+          - os: macos
+            runner: macos-latest
+            node: node24
+            node-version: "24.0.0"
+          - os: ubuntu
+            runner: ubuntu-latest
+            node: node22
+            node-version: "22.13.0"
+          - os: ubuntu
+            runner: ubuntu-latest
+            node: node24
+            node-version: "24.0.0"
 
     steps:
       - name: Checkout
@@ -38,15 +61,38 @@ jobs:
         run: npm run build
 
   test-unit:
-    name: test / unit (Node ${{ matrix.node-version }}, ${{ matrix.os }})
+    name: test / test-unit-${{ matrix.os }}-${{ matrix.node }}
     needs:
       - build
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-        node-version: ["22.13.0", "24.0.0"]
+        include:
+          - os: windows
+            runner: windows-latest
+            node: node22
+            node-version: "22.13.0"
+          - os: windows
+            runner: windows-latest
+            node: node24
+            node-version: "24.0.0"
+          - os: macos
+            runner: macos-latest
+            node: node22
+            node-version: "22.13.0"
+          - os: macos
+            runner: macos-latest
+            node: node24
+            node-version: "24.0.0"
+          - os: ubuntu
+            runner: ubuntu-latest
+            node: node22
+            node-version: "22.13.0"
+          - os: ubuntu
+            runner: ubuntu-latest
+            node: node24
+            node-version: "24.0.0"
 
     steps:
       - name: Checkout
@@ -73,7 +119,7 @@ jobs:
       - name: Upload coverage
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.node-version }}
+          name: coverage-${{ matrix.runner }}-${{ matrix.node-version }}
           path: coverage
           if-no-files-found: error
 
@@ -81,7 +127,7 @@ jobs:
     name: verify / lint
     runs-on: ubuntu-latest
     needs:
-      - build
+      - workspace-packages
 
     steps:
       - name: Checkout
@@ -102,11 +148,10 @@ jobs:
       - name: Run lint
         run: npm run lint
 
-  package:
-    name: package
+  workspace-packages:
+    name: package / workspace-packages
     runs-on: ubuntu-latest
     needs:
-      - build
       - test-unit
 
     steps:
@@ -131,12 +176,11 @@ jobs:
       - name: Verify workspace packages
         run: npm pack --workspaces
 
-  quality-crap-crap-typescript:
-    name: verify / quality-crap-crap-typescript
+  quality-crap:
+    name: verify / quality-crap
     runs-on: ubuntu-latest
     needs:
-      - build
-      - test-unit
+      - workspace-packages
 
     steps:
       - name: Checkout
@@ -166,12 +210,11 @@ jobs:
       - name: Run crap-typescript gate
         run: npm run crap-typescript-check
 
-  quality-cognitive-crap-typescript:
-    name: verify / quality-cognitive-crap-typescript
+  quality-cognitive:
+    name: verify / quality-cognitive
     runs-on: ubuntu-latest
     needs:
-      - build
-      - test-unit
+      - workspace-packages
 
     steps:
       - name: Checkout
@@ -194,18 +237,3 @@ jobs:
 
       - name: Run cognitive-typescript gate
         run: npm run cognitive-typescript-check
-
-  quality-crap-compat:
-    name: crap-typescript Gate
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    needs:
-      - quality-crap-crap-typescript
-
-    steps:
-      - name: Fail when the CRAP gate failed
-        if: ${{ needs.quality-crap-crap-typescript.result != 'success' }}
-        run: exit 1
-
-      - name: Confirm legacy CRAP gate
-        run: echo "CRAP gate succeeded."


### PR DESCRIPTION
Closes #184

## Implementation scope
- Reworked build and unit-test matrices around labelled OS and Node values, producing the six requested build and six requested test job names.
- Preserved runners, Node versions, npm command versions, action versions, commands, and coverage artifact names.
- Enforced build -> test -> workspace-packages -> verify with explicit needs edges and renamed verification jobs to the requested names.
- Removed the obsolete standalone crap-typescript Gate compatibility job.

## Review focus
- Confirm matrix labels resolve to the exact requested job names and runner/version pairs.
- Confirm the needs graph is linear and coverage artifact names remain compatible.
- Confirm no commands or action versions changed.

## Validation
- npm ci
- npm run build
- npm run lint (repository-scoped rerun; local .claude worktrees make the unscoped command traverse generated copies)
- npm test: 236 tests passed
- npm run cognitive-typescript-check: threshold 15 passed
- npm run crap-typescript-check: threshold 6.0 passed
- npm run pack
- git diff --check
- Prettier check for .github/workflows/build.yml

## Residual risk
- GitHub Actions itself will provide the authoritative matrix expansion and check-name validation on the clean hosted runners; local actionlint was unavailable.