### PR TITLE
Audit and resolve release-note review finding

### DIFF
--- a/packages/core/test/releaseNotes.test.ts
+++ b/packages/core/test/releaseNotes.test.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const renderReleaseNotesScript = path.resolve(process.cwd(), "scripts/render-release-notes.mjs");
+
+describe("render-release-notes", () => {
+  it("selects the stable section after a prerelease section with the same base header", () => {
+    const temporaryDirectory = mkdtempSync(path.join(tmpdir(), "render-release-notes-"));
+
+    try {
+      writeFileSync(
+        path.join(temporaryDirectory, "CHANGELOG.md"),
+        ["## [0.2.2] - prerelease", "", "prerelease notes", "", "## [0.2.2]", "", "stable notes", ""].join("\n")
+      );
+
+      const result = spawnSync(process.execPath, [renderReleaseNotesScript, "0.2.2"], {
+        cwd: temporaryDirectory,
+        encoding: "utf8"
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("stable notes\n");
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/releaseNotes.test.ts
+++ b/packages/core/test/releaseNotes.test.ts
@@ -13,7 +13,9 @@ describe("render-release-notes", () => {
     try {
       writeFileSync(
         path.join(temporaryDirectory, "CHANGELOG.md"),
-        ["## [0.2.2] - prerelease", "", "prerelease notes", "", "## [0.2.2]", "", "stable notes", ""].join("\n")
+        ["## [0.2.2] - prerelease", "", "prerelease notes", "", "## [0.2.2] - 2026-04-10", "", "stable notes", ""].join(
+          "\n"
+        )
       );
 
       const environment = { ...process.env };

--- a/packages/core/test/releaseNotes.test.ts
+++ b/packages/core/test/releaseNotes.test.ts
@@ -16,9 +16,13 @@ describe("render-release-notes", () => {
         ["## [0.2.2] - prerelease", "", "prerelease notes", "", "## [0.2.2]", "", "stable notes", ""].join("\n")
       );
 
+      const environment = { ...process.env };
+      delete environment.GITHUB_REF_NAME;
+
       const result = spawnSync(process.execPath, [renderReleaseNotesScript, "0.2.2"], {
         cwd: temporaryDirectory,
-        encoding: "utf8"
+        encoding: "utf8",
+        env: environment
       });
 
       expect(result.status).toBe(0);

--- a/scripts/render-release-notes.mjs
+++ b/scripts/render-release-notes.mjs
@@ -10,7 +10,9 @@ const expectedVersion = tagRef.startsWith("v") ? tagRef.slice(1) : tagRef;
 const changelog = await readFile(path.resolve("CHANGELOG.md"), "utf8");
 const lines = changelog.replace(/\r\n/g, "\n").split("\n");
 const sectionHeader = `## [${expectedVersion}]`;
-const startIndex = lines.findIndex((line) => line.startsWith(sectionHeader));
+const escapedSectionHeader = sectionHeader.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const sectionHeaderPattern = new RegExp(`^${escapedSectionHeader}(?: - \\d{4}-\\d{2}-\\d{2})?$`);
+const startIndex = lines.findIndex((line) => sectionHeaderPattern.test(line));
 
 if (startIndex === -1) {
   throw new Error(`CHANGELOG.md does not contain a section for ${expectedVersion}.`);


### PR DESCRIPTION
Closes #193

## Implementation scope
- Changed release-note section selection to require the exact stable version header, while preserving the documented dated changelog header format.
- Added a focused regression test proving a prerelease-labelled section before the stable section cannot be selected by prefix matching.
- Prepared the audit evidence for PR #34 (invalid for current main because merged PR #36 captures and restores process.exitCode) and PR #42 (valid and fixed here). Original review-thread replies and resolution will be completed after merge.

## Review focus
- Confirm exact version boundaries reject prerelease/suffix collisions and dated stable headers remain supported.
- Confirm the subprocess regression test exercises the release-note command from an isolated changelog.
- Confirm no public APIs or release metadata change.

## Validation
- npm ci
- npm run build
- npm run lint (repository-scoped rerun; local .claude worktrees make the unscoped command traverse generated copies)
- npm test: 237 tests passed
- Focused release-note regression test passed
- npm run render-release-notes -- v0.4.2 passed
- npm run cognitive-typescript-check: threshold 15 passed
- npm run crap-typescript-check: threshold 6.0 passed
- npm run pack
- git diff --check
- Prettier checks for changed files

## Residual risk
- The renderer now accepts exact headers and the repository’s YYYY-MM-DD suffix only; other undocumented header suffixes are intentionally rejected.