### PR TITLE
Prepare and harden v0.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,23 @@ jobs:
           name: release-artifacts
           path: release-artifacts
 
+      - name: Create GitHub release draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            is_draft="$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq .isDraft)"
+            if [[ "${is_draft}" != "true" ]]; then
+              echo "A published GitHub release already exists for ${GITHUB_REF_NAME}; refusing to republish."
+              exit 1
+            fi
+            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-artifacts/release-notes.md --draft
+          else
+            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-artifacts/release-notes.md --draft --verify-tag
+          fi
+
       - name: Publish packages
         run: |
           set -euo pipefail
@@ -92,13 +109,9 @@ jobs:
           npm publish "./release-artifacts/barney-media-crap-typescript-vitest-${version}.tgz" --access public
           npm publish "./release-artifacts/barney-media-crap-typescript-jest-${version}.tgz" --access public
 
-      - name: Create GitHub release
+      - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-artifacts/release-notes.md
-          else
-            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-artifacts/release-notes.md
-          fi
+          gh release edit "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file release-artifacts/release-notes.md --draft=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+- No unreleased changes.
+
+## [0.5.0] - 2026-08-09
+
 ### Changed
 
 - Reduced the default CRAP threshold from `8.0` to `6.0` while keeping the recommended `4.0` to `8.0` range unchanged.
+- Updated compatible runtime and development dependency ranges and lockfile versions.
+- Hardened the release workflow to draft the GitHub release before npm publication and promote it only after
+  all packages succeed.
 
 ## [0.4.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ The Jest adapter defaults primary `format` to `none`, so it emits no primary std
 
 ## Release
 
-Update `CHANGELOG.md` with the tagged version entry before releasing. Tag `v<version>` from `main` after the build workflow is green. The tag-triggered release workflow verifies the package versions, renders the GitHub release notes from `CHANGELOG.md`, publishes the four npm packages, and creates the GitHub release.
+Update `CHANGELOG.md` with the tagged version entry before releasing. Tag `v<version>` from `main` after the
+build workflow is green. The tag-triggered release workflow verifies the package versions, renders the GitHub
+release notes from `CHANGELOG.md`, creates a draft GitHub release, publishes the four npm packages, and promotes
+the release only after all packages succeed.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crap-typescript-parent",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crap-typescript-parent",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -6700,10 +6700,10 @@
     },
     "packages/cli": {
       "name": "@barney-media/crap-typescript",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.2"
+        "@barney-media/crap-typescript-core": "^0.5.0"
       },
       "bin": {
         "crap-typescript": "dist/bin.js"
@@ -6714,7 +6714,7 @@
     },
     "packages/core": {
       "name": "@barney-media/crap-typescript-core",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@toon-format/toon": "~2.1.0",
@@ -6727,10 +6727,10 @@
     },
     "packages/jest": {
       "name": "@barney-media/crap-typescript-jest",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.2"
+        "@barney-media/crap-typescript-core": "^0.5.0"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -6741,10 +6741,10 @@
     },
     "packages/vitest": {
       "name": "@barney-media/crap-typescript-vitest",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@barney-media/crap-typescript-core": "^0.4.2"
+        "@barney-media/crap-typescript-core": "^0.5.0"
       },
       "engines": {
         "node": ">=22.13.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crap-typescript-parent",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "CRAP metrics for TypeScript",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "CLI for CRAP metric analysis in TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,6 +45,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.2"
+    "@barney-media/crap-typescript-core": "^0.5.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-core",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Core CRAP metric analyzer for TypeScript projects.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-jest",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Jest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -45,7 +45,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.2"
+    "@barney-media/crap-typescript-core": "^0.5.0"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barney-media/crap-typescript-vitest",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Vitest integration for crap-typescript.",
   "license": "Apache-2.0",
   "author": "Fabian Barney (https://github.com/fabian-barney)",
@@ -41,7 +41,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@barney-media/crap-typescript-core": "^0.4.2"
+    "@barney-media/crap-typescript-core": "^0.5.0"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"


### PR DESCRIPTION
Closes #205

## Implementation Summary

- Scope: prepare and harden the `v0.5.0` release path.
- Key changes: align all package and lockfile versions, finalize release notes,
  document the release flow, and create the GitHub Release draft before npm
  publication.
- Non-goals: new product behavior, additional registries, or runtime support
  policy changes.

## Review Focus

- Verify the five package versions and three internal dependency ranges stay
  aligned with the `v0.5.0` tag.
- Verify a failed npm publish leaves the GitHub Release as a draft and that a
  previously published release is not republished.
- The lockfile is repetitive metadata and can be skimmed after checking the
  workspace entries.

## Validation

- Tests executed: `npm ci`, `npm run build`, 237 unit tests with coverage,
  lint, cognitive gate, and CRAP gate all passed.
- Manual checks: release-version and release-notes checks passed; workspace
  pack dry-run produced four `0.5.0` artifacts; `git diff --check` passed.
- Residual risks: the tag-triggered GitHub workflow and npm Trusted Publishing
  permissions require final verification on GitHub.
